### PR TITLE
docs: Add custom API docs

### DIFF
--- a/docs/api/s3/index.md
+++ b/docs/api/s3/index.md
@@ -115,3 +115,14 @@ Note: IAM APIs are served at `https://fly.storage.tigris.dev:8009` for now.
 
 Check out the [language specific guides](../../sdks/s3/) on how to use the AWS
 S3 SDKs with Tigris.
+
+## Tigris Custom APIs.
+
+Besides AWS S3, IAM, and CloudFront APIs, Tigris also offers its own custom
+APIs:
+
+Custom S3 [Custom-S3 openapi yaml](/api/custom-s3.yaml)
+
+IAM [Custom-IAM openapi yaml](/api/custom-iam.yaml)
+
+IAM [Management openapi yaml](/api/management.yaml)

--- a/static/api/custom-iam.yaml
+++ b/static/api/custom-iam.yaml
@@ -1,0 +1,84 @@
+openapi: 3.0.0
+info:
+  title: Tigris Custom IAM APIs
+  version: 1.0.0
+  description: Tigris Custom IAM apis
+servers:
+  - url: "https://fly.iam.storage.tigris.dev"
+paths:
+  /?Action=CreateAccessKeyWithBucketsRole:
+    post:
+      parameters:
+        - in: query
+          name: Action
+          required: true
+          schema:
+            type: string
+            enum:
+              - CreateAccessKeyWithBucketsRole
+      summary:
+        Convenience method for generating access-keys with bucket level roles
+        attached.
+      operationId: CreateAccessKeyWithBucketsRole
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAccessKeyWithBucketsRoleRequest"
+      responses:
+        "200":
+          description: Constructed access key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateAccessKeyResponse"
+components:
+  schemas:
+    CreateAccessKeyWithBucketsRoleRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        buckets_role:
+          type: array
+          items:
+            $ref: "#/components/schemas/BucketsRole"
+    BucketsRole:
+      type: object
+      properties:
+        bucket:
+          type: string
+        role:
+          type: string
+    CreateAccessKeyResponse:
+      type: object
+      properties:
+        CommonResponse:
+          $ref: "#/components/schemas/CommonResponse"
+        CreateAccessKeyResult:
+          type: object
+          properties:
+            AccessKey:
+              $ref: "#/components/schemas/AccessKey"
+    AccessKey:
+      type: object
+      properties:
+        AccessKeyId:
+          type: string
+          sensitive: true
+        CreateDate:
+          type: string
+          format: date-time
+        SecretAccessKey:
+          type: string
+          sensitive: true
+        Status:
+          type: string
+          enum:
+            - Active
+            - Inactive
+        UserName:
+          type: string
+    CommonResponse:
+      type: object

--- a/static/api/custom-s3.yaml
+++ b/static/api/custom-s3.yaml
@@ -1,0 +1,255 @@
+openapi: 3.0.0
+info:
+  title: Tigris Object Store Custom APIs
+  version: 1.0.0
+  description: Tigris Object Store Custom APIs.
+servers:
+  - url: "https://fly.storage.tigris.dev"
+paths:
+  /?func=presign:
+    post:
+      parameters:
+        - in: query
+          name: func
+          required: true
+          schema:
+            type: string
+            enum:
+              - presign
+      summary: Convenience method for generating pre-signed URLs.
+      operationId: TigrisPreSignUrlGenerator
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TigrisPreSignUrlGeneratorRequest"
+      responses:
+        "200":
+          description: Constructed signed URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TigrisPreSignUrlGeneratorResponse"
+  /?explain=authz:
+    post:
+      parameters:
+        - in: query
+          name: explain
+          required: true
+          schema:
+            type: string
+            enum:
+              - authz
+        - in: query
+          name: IncludeReason
+          required: false
+          schema: {}
+          allowEmptyValue: true
+          description: When present, adds the reasoning for authz decision.
+      summary: Explain the authorization
+      operationId: ExplainAuthz
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExplainAuthzRequest"
+      responses:
+        "200":
+          description: Explanation of the authz decisions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExplainAuthzResponse"
+  /:
+    get:
+      parameters:
+        - in: query
+          name: IncludeVisibility
+          schema:
+            type: boolean
+          required: false
+          description: When set to true, adds the visibility detail to response.
+        - in: query
+          name: IncludeOwnerInfo
+          schema:
+            type: boolean
+          required: false
+          description: When set to true, adds the owner detail to response.
+        - in: query
+          name: IncludeRegionsInfo
+          schema:
+            type: boolean
+          required: false
+          description: When set to true, adds the regions detail to response.
+        - in: query
+          name: IncludeStats
+          schema:
+            type: boolean
+          required: false
+          description: When set to true, adds the stats for bucket to response.
+      summary: List buckets with options
+      operationId: ListBuckets
+      responses:
+        "200":
+          description: Lists the bucket with options.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Owner:
+                    type: object
+                    properties:
+                      ID:
+                        type: string
+                      DisplayName:
+                        type: string
+                    required:
+                      - ID
+                  Buckets:
+                    type: object
+                    properties:
+                      Bucket:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            Name:
+                              type: string
+                            CreationDate:
+                              type: string
+                              format: date-time
+                            Visibility:
+                              type: object
+                              properties:
+                                IsPublic:
+                                  type: boolean
+                              required:
+                                - IsPublic
+                            OwnerInfo:
+                              type: object
+                              properties:
+                                OwnerUserId:
+                                  type: string
+                                OwnerHumanUserId:
+                                  type: string
+                              required:
+                                - OwnerUserId
+                                - OwnerHumanUserId
+                            Regions:
+                              type: string
+                  Stats:
+                    type: object
+                    properties:
+                      ActiveBuckets:
+                        type: integer
+                      TotalStorageBytes:
+                        type: integer
+                      TotalObjects:
+                        type: integer
+  /status:
+    get:
+      summary: Check health status
+      operationId: getStatus
+      responses:
+        "200":
+          description: Status is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: healthy
+components:
+  schemas:
+    ExplainAuthzRequest:
+      type: object
+      properties:
+        queries:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExplainAuthzQuery"
+    ExplainAuthzQuery:
+      type: object
+      properties:
+        bucket:
+          type: string
+        object:
+          type: string
+        operation:
+          type: string
+      required:
+        - bucket
+        - object
+        - operation
+    ExplainAuthzResponse:
+      type: object
+      properties:
+        answers:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExplainAuthzAnswer"
+    ExplainAuthzAnswer:
+      type: object
+      properties:
+        query:
+          $ref: "#/components/schemas/ExplainAuthzQuery"
+        errorCode:
+          type: string
+        reason:
+          type: string
+    TigrisPreSignUrlGeneratorRequest:
+      type: object
+      properties:
+        bucket:
+          type: string
+        key:
+          type: string
+        key_id:
+          type: string
+        key_name:
+          type: string
+        expires_in:
+          type: integer
+          format: int32
+          description: Expiry time in seconds
+        type:
+          type: string
+          enum:
+            - GET
+            - PUT
+      required:
+        - bucket
+        - key
+        - key_id
+        - expires_in
+        - type
+    TigrisPreSignUrlGeneratorResponse:
+      type: object
+      properties:
+        bucket:
+          type: string
+        key:
+          type: string
+        type:
+          type: string
+          enum:
+            - GET
+            - PUT
+        url:
+          type: string
+        key_id:
+          type: string
+          description: optionally if the new key was constructed
+        key_secret:
+          type: string
+          description: optionally if the new key was constructed
+      required:
+        - bucket
+        - key
+        - type
+        - url

--- a/static/api/management.yaml
+++ b/static/api/management.yaml
@@ -1,0 +1,67 @@
+openapi: 3.0.0
+info:
+  title: Tigris Management APIs
+  version: 1.0.0
+  description: Tigris Management APIs
+servers:
+  - url: "https://fly.storage.tigris.dev:8086"
+paths:
+  /user-space/whoami:
+    get:
+      summary: Returns the information about the current user.
+      operationId: WhoAmI
+      responses:
+        "200":
+          description: Information about the current user.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WhoAmIResponse"
+  /user-space/get-org:
+    get:
+      summary: Returns the information about the current user's organization.
+      operationId: GetOrg
+      responses:
+        "200":
+          description: Information about the current user's organization.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Org"
+components:
+  schemas:
+    WhoAmIResponse:
+      type: object
+      properties:
+        UserId:
+          type: string
+        NamespaceId:
+          type: string
+    Org:
+      type: object
+      properties:
+        email:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        slug:
+          type: string
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/User"
+    User:
+      type: object
+      properties:
+        email:
+          type: string
+        agreed_to_tos:
+          type: boolean
+        userId:
+          type: string
+        user_name:
+          type: string
+        profile_picture_url:
+          type: string


### PR DESCRIPTION
Legacy format of API from S3 and our custom additions creates a form of API that is not supported by OpenAPI specification. The documentation tool we use can only accept the single API specification file. For these reasons the OpenAPI yamls are just hosted as static file and can be consumed by https://editor-next.swagger.io/