### PR TITLE
add multiple profiles for using aws alongside tigris

### DIFF
--- a/docs/sdks/s3/aws-cli.md
+++ b/docs/sdks/s3/aws-cli.md
@@ -4,6 +4,20 @@ This guide assumes that you have followed the steps in the
 [Getting Started](/docs/get-started/index.md) guide, and have the access keys
 available.
 
+## Service Endpoints
+
+Requests to Tigris must be directed to the appropriate service endpoint:
+
+- IAM requests must be directed to `https://fly.iam.storage.tigris.dev`
+- S3 requests must be directed to `https://fly.storage.tigris.dev`
+
+When using the AWS CLI, this service endpoint is set by default based on the
+region and is not configured by the user directly. AWS S3 recommends using
+per-region service endpoints, whereas Tigris provides a single global endpoint
+and manages all regional configurations for you. Tigris is S3-compatible, which
+means that you can use familiar S3 based tools like the AWS CLI, provided you
+change the service endpoint to point to Tigris.
+
 ## Configuring AWS CLI
 
 Once you have your access key, you can configure the AWS CLI with the following
@@ -11,8 +25,8 @@ command:
 
 ```bash
 aws configure
-AWS Access Key ID [None]: <access_key_id>
-AWS Secret Access Key [None]: <access_key_secret>
+AWS Access Key ID [None]: <tid_>
+AWS Secret Access Key [None]: <tsec_>
 Default region name [None]: auto
 Default output format [None]: json
 ```
@@ -31,9 +45,11 @@ You can also modify the `~/.aws/credentials` file directly, and add the endpoint
 URL to it so that you don't have to specify it every time:
 
 ```text
+nano ~/.aws/credentials
+
 [default]
-aws_access_key_id=<access_key_id>
-aws_secret_access_key=<access_key_secret>
+aws_access_key_id=<tid>
+aws_secret_access_key=<tsec_>
 endpoint_url=https://fly.storage.tigris.dev
 ```
 
@@ -43,6 +59,41 @@ Once this is done, you can use the AWS CLI as you normally would (without the
 ```bash
 aws s3api list-buckets
 aws s3api list-objects-v2 --bucket foo-bucket
+```
+
+## Using multiple AWS Profiles
+
+If you want to use Tigris alongside AWS, you'll need to differentiate your
+access keys. The most common way to do this is by adding another profile to
+`~/.aws/credentials`.
+
+```text
+nano ~/.aws/credentials
+
+[aws-compute]
+aws_access_key_id=<tid>
+aws_secret_access_key=<tsec_>
+
+[tigris]
+aws_access_key_id=<tid>
+aws_secret_access_key=<tsec_>
+endpoint_url=https://fly.storage.tigris.dev
+```
+
+You can verify the profiles are configured correctly:
+
+```text
+aws configure list-profiles
+# output:
+# aws-compute
+# tigris
+```
+
+You can switch between profiles per command by simply passing the name of the
+profile to the `profile` flag at the end of your command.
+
+```text
+aws s3 ls --profile <name of profile>
 ```
 
 ## Using presigned URLs

--- a/docs/sdks/s3/aws-python-sdk.md
+++ b/docs/sdks/s3/aws-python-sdk.md
@@ -39,6 +39,57 @@ response = svc.upload_file('bar.txt', 'foo-bucket', 'bar.txt')
 response = svc.download_file('foo-bucket', 'bar.txt', 'bar-downloaded.txt')
 ```
 
+## Using multiple AWS Profiles
+
+If you want to use Tigris alongside AWS, you'll need to differentiate your
+access keys. There are several options ranging from passing access keys as
+parameters when creating clients:
+
+```text
+import boto3
+
+client = boto3.client(
+    's3',
+    aws_access_key_id=ACCESS_KEY,
+    aws_secret_access_key=SECRET_KEY,
+    aws_session_token=SESSION_TOKEN,
+    endpoint_url='https://fly.storage.tigris.dev'
+)
+```
+
+Or you can add another profile to `~/.aws/credentials` directly:
+
+```text
+nano ~/.aws/credentials
+
+[aws-compute]
+aws_access_key_id=<access_key_id>
+aws_secret_access_key=<access_key_secret>
+
+[tigris]
+aws_access_key_id=<access_key_id>
+aws_secret_access_key=<access_key_secret>
+endpoint_url=https://fly.storage.tigris.dev
+```
+
+To switch profiles while using `boto3`, you can set the `profile` on the
+`session`:
+
+```text
+import boto3
+
+session = boto3.Session(profile_name='tigris')
+tigris_s3_client = session.client('s3')
+```
+
+To change the default `session` to use Tigris, you can configure boto3:
+
+```text
+import boto3
+
+boto3.setup_default_session(profile_name='tigris')
+```
+
 ## Using presigned URLs
 
 Presigned URLs can be used with the AWS Python (Boto3) SDK as follows:


### PR DESCRIPTION
Some folks may not know about aws profiles. We can potentially add more about role assumption since that's best practice, but for now this gives guidance on how to use AWS alongside Tigris and makes it less confusing to have multiple sets of access keys.