### PR TITLE
docs/sdks/s3/ruby: move examples to their own files

### DIFF
--- a/docs/sdks/s3/aws-ruby-sdk.mdx
+++ b/docs/sdks/s3/aws-ruby-sdk.mdx
@@ -1,0 +1,25 @@
+# AWS Ruby SDK
+
+import CodeBlock from "@theme/CodeBlock";
+
+This guide assumes that you have followed the steps in the
+[Getting Started](/docs/get-started/index.md) guide, and have the access keys
+available.
+
+You may continue to use the AWS Ruby SDK as you normally would, but with the
+endpoint set to `https://fly.storage.tigris.dev`.
+
+This example uses the [AWS Ruby SDK v3](https://github.com/aws/aws-sdk-ruby) and
+reads the default credentials file or the environment variables
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+
+import Gemfile from "!!raw-loader!../../../examples/ruby/Gemfile";
+
+<CodeBlock language="ruby">{Gemfile}</CodeBlock>
+
+Then you can use the SDK as you normally would, but with the endpoint set to
+`https://fly.storage.tigris.dev`.
+
+import gettingStarted from "!!raw-loader!../../../examples/ruby/getting_started.rb";
+
+<CodeBlock language="ruby">{gettingStarted}</CodeBlock>

--- a/examples/ruby/Gemfile
+++ b/examples/ruby/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem 'nokogiri', '~> 1.11'
+# highlight-start
+gem 'aws-sdk-s3', '~> 1'
+# highlight-end

--- a/examples/ruby/Gemfile.lock
+++ b/examples/ruby/Gemfile.lock
@@ -1,0 +1,40 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.3.0)
+    aws-partitions (1.1048.0)
+    aws-sdk-core (3.218.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.98.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.180.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.11.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.2.0)
+    jmespath (1.6.2)
+    mini_portile2 (2.8.8)
+    nokogiri (1.18.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.2-arm64-darwin)
+      racc (~> 1.4)
+    racc (1.8.1)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  aws-sdk-s3 (~> 1)
+  nokogiri (~> 1.11)
+
+BUNDLED WITH
+   2.6.2

--- a/examples/ruby/getting_started.rb
+++ b/examples/ruby/getting_started.rb
@@ -1,20 +1,6 @@
-# AWS Ruby SDK
+require "aws-sdk-s3"
 
-This guide assumes that you have followed the steps in the
-[Getting Started](/docs/get-started/index.md) guide, and have the access keys
-available.
-
-You may continue to use the AWS Ruby SDK as you normally would, but with the
-endpoint set to `https://fly.storage.tigris.dev`.
-
-This example uses the [AWS Ruby SDK v3](https://github.com/aws/aws-sdk-ruby) and
-reads the default credentials file or the environment variables
-`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-
-```ruby
-require "aws-sdk"
-
-bucket_name = "foo-bucket"
+bucket_name = "tigris-example"
 
 s3 = Aws::S3::Client.new(
     region: "auto",
@@ -30,7 +16,7 @@ resp.buckets.each do |bucket|
 end
 
 # List the first ten objects in the bucket
-resp = s3.list_objects(bucket: 'foo-bucket', max_keys: 10)
+resp = s3.list_objects(bucket: bucket_name, max_keys: 10)
 resp.contents.each do |object|
     puts "#{object.key} => #{object.etag}"
 end
@@ -41,11 +27,10 @@ begin
     s3.put_object(
         bucket: bucket_name,
         key: file_name,
-        body: File.read("bar.txt")
+        body: File.read("getting_started.rb")
     )
     puts "Uploaded #{file_name} to #{bucket_name}."
 rescue Exception => e
     puts "Failed to upload #{file_name} with error: #{e.message}"
     exit "Please fix error with file upload before continuing."
 end
-```


### PR DESCRIPTION
Closes TIG-3545