### PR TITLE
fix: Fixes the layout

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -51,12 +51,6 @@
   src: url(/fonts/FiraCode-VariableFont_wght.ttf);
 }
 
-@media (min-width: 997px) {
-  body .docItemCol_xLCN {
-    max-width: 100% !important;
-  }
-}
-
 pre,
 code {
   font-variant-ligatures: none;


### PR DESCRIPTION
The table of content layout was broken when there is a codeblock with longer code inside it. 