### PR TITLE
Update AWS Go SDK example to use correct bucket

### DIFF
--- a/examples/go/cmd/getting-started/main.go
+++ b/examples/go/cmd/getting-started/main.go
@@ -35,6 +35,7 @@ func main() {
 		o.BaseEndpoint = aws.String("https://t3.storage.dev")
 		o.Region = "auto"
 		o.UsePathStyle = false
+		o.DisableLogOutputChecksumValidationSkipped = true
 	})
 
 	// List buckets
@@ -49,7 +50,6 @@ func main() {
 	for _, b := range result.Buckets {
 		fmt.Printf("* %s created on %s\n",
 			aws.ToString(b.Name), aws.ToTime(b.CreationDate))
-		bucketName = aws.ToString(b.Name)
 	}
 
 	// Upload file
@@ -61,16 +61,17 @@ func main() {
 	if err != nil {
 		log.Printf("Couldn't open file to upload. Here's why: %v\n", err)
 		return
-	} else {
-		defer file.Close()
-		_, err = svc.PutObject(ctx, &s3.PutObjectInput{
-			Bucket: aws.String(bucketName),
-			Key:    aws.String("bar.txt"),
-			Body:   file,
-		})
-		if err != nil {
-			log.Printf("Couldn't upload file. Here's why: %v\n", err)
-		}
+	}
+
+	defer file.Close()
+	_, err = svc.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("bar.txt"),
+		Body:   file,
+	})
+	if err != nil {
+		log.Printf("Couldn't upload file. Here's why: %v\n", err)
+		return
 	}
 
 	fmt.Println("File uploaded.")
@@ -112,5 +113,7 @@ func main() {
 	})
 	if err != nil {
 		log.Printf("Couldn't download file. Here's why: %v", err)
+		return
 	}
+	fmt.Println("File downloaded.")
 }


### PR DESCRIPTION
This example program takes bucket name as a command line argument and then list all buckets, uploads an object and downloads the object. Previously, bucket name specified as a command line argument was ignored and instead object was uploaded to last bucket in list buckets response. Fixing that. Also:
* Setting `DisableLogOutputChecksumValidationSkipped` so that we don't get this WARNING log:
```
SDK 2025/05/14 17:59:43 WARN Response has no supported checksum. Not validating response payload.
```
* Removing unnecessary nesting for file uploading.
* Logging `File downloaded.`  statement when file is successfully downloaded. Previously, last log of successful example program run was: `Download file:`. That seemed incomplete.

