### PR TITLE
Rename mapped operations to controlled APIs in IAM actions reference table

### DIFF
--- a/docs/iam/policies/supported-actions.md
+++ b/docs/iam/policies/supported-actions.md
@@ -17,7 +17,8 @@ You can:
 
 ## 📋 Action Reference Table
 
-The table below lists supported IAM policy actions and what APIs they control (allow or deny).
+The table below lists supported IAM policy actions and what APIs they control
+(allow or deny).
 
 | IAM action                    | Controlled APIs                                                                | Description                                                                                                                                       |
 | ----------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Renaming "operations" to "APIs" for clarity.