### PR TITLE
Document retrieving snapshotting related headers from custom responses

### DIFF
--- a/docs/buckets/snapshots-and-forks.mdx
+++ b/docs/buckets/snapshots-and-forks.mdx
@@ -458,7 +458,7 @@ func hasSnapshottingEnabled(ctx context.Context, client *s3.Client, bucketName s
 		return false, err
 	}
 	rawResp := middleware.GetRawResponse(resp.ResultMetadata).(*http.Response)
-	return rawResp.Header.Get("X-Tigris-Enable-Snapshot") == true
+	return rawResp.Header.Get("X-Tigris-Enable-Snapshot") == "true", nil
 }
 ```
 
@@ -468,7 +468,7 @@ func hasSnapshottingEnabled(ctx context.Context, client *s3.Client, bucketName s
 Example using the AWS SDK for JavaScript v3:
 
 ```js
-import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { S3Client, HeadBucketCommand } from "@aws-sdk/client-s3";
 
 async function hasSnapshottingEnabled(s3Client, bucketName) {
   const response = await s3Client.send(


### PR DESCRIPTION
Adding details on how to retrieve the snapshot version from the CreateBucket response and how to retrieve snapshotting-related info from the HeadBucket response.

Note: The JS example of creating a snapshot is not being changed. It will be updated after the new functionality is added to the Tigris SDK.