### PR TITLE
fix: Object notifications using partner api

### DIFF
--- a/static/api/extensions/v1/api.yaml
+++ b/static/api/extensions/v1/api.yaml
@@ -679,7 +679,8 @@ components:
         enabled:
           type: boolean
           description:
-            Enable or disable notifications. When true, webhook must be provided.
+            Enable or disable notifications. When true, webhook must be
+            provided.
         webhook:
           type: string
           format: uri


### PR DESCRIPTION
---

## Summary by Gitar

- Adds **comprehensive object event notification configuration** to the Partner API, enabling webhook callbacks when objects are created, updated, or deleted in buckets
- Introduces two new OpenAPI schemas: `ObjectNotifications` (with fields for webhook URL, SQL filtering, region, and authentication) and `ObjectNotificationAuth` (supporting both Basic Auth and Bearer Token)
- Integrates notification configuration into three bucket management endpoints: `BucketOptions` (creation), `UpdateBucketRequest` (updates), and `BucketInfo` (retrieval responses)
- Includes detailed documentation with **partial update semantics**, JSON usage examples, and security notes about credential masking in API responses