### PR TITLE
chore: add sdk docs and examples

### DIFF
--- a/docs/sdks/tigris/client-uploads.mdx
+++ b/docs/sdks/tigris/client-uploads.mdx
@@ -36,12 +36,12 @@ import { upload } from "@tigrisdata/storage/client";
 | url                | Yes          | The URL to backend endpoint where Storage SDK is running on server.                                                                                 |
 | access             | No           | The access level for the object. Possible values are `public` and `private`.                                                                        |
 | addRandomSuffix    | No           | Whether to add a random suffix to the object name. Default is `false`.                                                                              |
+| concurrency        | No           | Maximum number of concurrent part uploads for multipart uploads. Default is `4`.                                                                    |
 | contentType        | No           | The content type of the object.                                                                                                                     |
 | contentDisposition | No           | The content disposition of the object. Possible values are `inline` and `attachment`. Default is `inline`. Use `attachment` for downloadable files. |
 | multipart          | No           | Pass `multipart: true` when uploading large objects. It will split the object into multiple parts and upload them in parallel.                      |
 | partSize           | No           | The size of the part to upload. Default is `5 * 1024 * 1024` (5 MiB).                                                                               |
 | onUploadProgress   | No           | Callback to track upload progress: `onUploadProgress({loaded: number, total: number, percentage: number})`.                                         |
-| config             | No           | A configuration object to override the [default configuration](/docs/sdks/tigris/using-sdk#authentication).                                         |
 
 In case of successful upload, the `data` property will be set to the upload and
 contains the following properties:

--- a/docs/sdks/tigris/examples.mdx
+++ b/docs/sdks/tigris/examples.mdx
@@ -225,3 +225,36 @@ export default function ClientUpload() {
 </TabItem>
 
 </Tabs>
+
+## React Package
+
+Alternatively, you can use the `Uploader` component from the `@tigrisdata/react`
+package to render a file uploader component that integrates with the Tigris
+Storage SDK.
+
+```tsx
+import { Uploader } from "@tigrisdata/react";
+import "@tigrisdata/react/styles.css"; // Optional: import default styles
+
+export default function ClientUpload() {
+  return (
+    <div className="bg-white shadow rounded-lg p-6 mb-6">
+      <h2 className="text-lg font-medium text-gray-900 mb-2">Client Uploads</h2>
+      <Uploader
+        className="mt-4 tigris-uploader"
+        accept="image/*"
+        multiple={true}
+        multipart={true}
+        concurrency={3}
+        url="/api/upload"
+        onUploadComplete={(file, response) => {
+          console.log("Uploaded:", response.url);
+        }}
+        onUploadError={(file, error) => {
+          console.error("Failed:", error.message);
+        }}
+      />
+    </div>
+  );
+}
+```


### PR DESCRIPTION
---

## Summary by Gitar

- **New parameter documentation:**
  - Added `concurrency` parameter to client upload options (controls concurrent part uploads, default: 4)
- **New React component example:**
  - `Uploader` component from `@tigrisdata/react` package with complete integration example
  - Includes event handlers (`onUploadComplete`, `onUploadError`) and multipart upload configuration
- **Documentation cleanup:**
  - Removed deprecated `config` parameter from client-uploads options table

---