### PR TITLE
Troubleshooting section for users not seeing buckets when logging into console

### DIFF
--- a/docs/account-management/accounts.md
+++ b/docs/account-management/accounts.md
@@ -33,11 +33,11 @@ Users can have one of three roles:
 
 :::warning Important: Accessing Fly-Provisioned Buckets
 
-If you created your Tigris buckets through Fly.io (using `fly storage create`), 
-you **must** log into the Tigris console by clicking the **Fly.io** button on the 
-[login page](https://console.tigris.dev/signin). 
+If you created your Tigris buckets through Fly.io (using `fly storage create`),
+you **must** log into the Tigris console by clicking the **Fly.io** button on
+the [login page](https://console.tigris.dev/signin).
 
-Logging in with Google, GitHub, or email will create a separate Tigris account 
+Logging in with Google, GitHub, or email will create a separate Tigris account
 that won't have access to your Fly-provisioned buckets.
 
 :::
@@ -79,15 +79,21 @@ access before leaving, you can recover access to the account by emailing
 
 ### I can't see my buckets in the Tigris console
 
-The most common reason is logging in with the wrong account type. Tigris has two separate account systems:
+The most common reason is logging in with the wrong account type. Tigris has two
+separate account systems:
 
-**Fly.io Accounts** - If you created buckets through Fly.io (using `fly storage create`):
-- Click the **Fly.io** button on the [login page](https://console.tigris.dev/signin)
+**Fly.io Accounts** - If you created buckets through Fly.io (using
+`fly storage create`):
+
+- Click the **Fly.io** button on the
+  [login page](https://console.tigris.dev/signin)
 
 **Native Tigris Accounts** - If you created your account directly at Tigris:
+
 - Use Google, GitHub, or email login
 
 **How to fix:**
+
 1. Log out of the Tigris console
 2. Go to [console.tigris.dev/signin](https://console.tigris.dev/signin)
 3. Click the **Fly.io** button if you use Fly.io
@@ -97,11 +103,15 @@ The most common reason is logging in with the wrong account type. Tigris has two
 
 If you can see some buckets but not others, or buckets appear empty:
 
-- **Check your organization:** Make sure you've selected the correct organization in the Tigris console (top-right dropdown)
-- **Verify using the correct Fly org:** If using Fly.io, ensure you're logged in with the Fly account that owns the buckets
-- **Check bucket permissions:** Verify you have the correct access permissions for the bucket
-- **Contact support:** Email [help@tigrisdata.com](mailto:help@tigrisdata.com) with:
-   - Your login email or Fly organization name
-   - The bucket names you're trying to access
-   - Which login method you used
-   - Screenshots if helpful
+- **Check your organization:** Make sure you've selected the correct
+  organization in the Tigris console (top-right dropdown)
+- **Verify using the correct Fly org:** If using Fly.io, ensure you're logged in
+  with the Fly account that owns the buckets
+- **Check bucket permissions:** Verify you have the correct access permissions
+  for the bucket
+- **Contact support:** Email [help@tigrisdata.com](mailto:help@tigrisdata.com)
+  with:
+  - Your login email or Fly organization name
+  - The bucket names you're trying to access
+  - Which login method you used
+  - Screenshots if helpful

--- a/docs/sdks/fly/index.md
+++ b/docs/sdks/fly/index.md
@@ -119,7 +119,9 @@ fly storage destroy bucket-name
 
 ## Accessing the Tigris Console
 
-While `flyctl` provides command-line management for your buckets, you can also use the Tigris web console for a visual interface to manage your buckets, upload objects, view analytics, and more.
+While `flyctl` provides command-line management for your buckets, you can also
+use the Tigris web console for a visual interface to manage your buckets, upload
+objects, view analytics, and more.
 
 ### Logging in to the Console
 
@@ -131,9 +133,11 @@ To access the Tigris console with your Fly-provisioned buckets:
 
 :::warning Important: Use the Fly.io Login
 
-You **must** click the **Fly.io** button on the login page to access your Fly-provisioned buckets. 
+You **must** click the **Fly.io** button on the login page to access your
+Fly-provisioned buckets.
 
-Do not use Google, GitHub, or email login, as those will create a separate native Tigris account that won't have access to your Fly buckets.
+Do not use Google, GitHub, or email login, as those will create a separate
+native Tigris account that won't have access to your Fly buckets.
 
 :::
 
@@ -146,4 +150,6 @@ Do not use Google, GitHub, or email login, as those will create a separate nativ
 - Manage access keys and permissions
 - Configure bucket notifications and snapshots
 
-For more information about managing your account and understanding the difference between Fly and native Tigris accounts, see the [Accounts documentation](../../account-management/accounts/).
+For more information about managing your account and understanding the
+difference between Fly and native Tigris accounts, see the
+[Accounts documentation](../../account-management/accounts/).


### PR DESCRIPTION
- **added troubleshooting section when users don't see any buckets**

---

## Summary by Gitar

- **New troubleshooting documentation:**
  - Added "Troubleshooting" section to `docs/account-management/accounts.md` with solutions for users unable to see buckets in the Tigris console
  - Covers two scenarios: incorrect login method (Fly.io vs native Tigris) and missing/empty buckets
- **Console access guidance:**
  - Added "Accessing the Tigris Console" section to `docs/sdks/fly/index.md` explaining how Fly.io users can access the web console
  - Includes step-by-step login instructions and list of console features
- **Warning callouts:**
  - Added prominent warnings in both files emphasizing the need to use Fly.io button login for Fly-provisioned buckets

<sub>This will update automatically on new commits.</sub>

---