### PR TITLE
docs: move request type descriptions after data transfer

### DIFF
--- a/docs/pricing/index.md
+++ b/docs/pricing/index.md
@@ -43,21 +43,6 @@ Every account includes a generous free tier each month:
 
 All storage prices are per GB per month.
 
-**Class A** requests modify state: `CreateBucket`, `CreateMultipartUpload`,
-`CopyObject`, `ListObjects`, `ListObjectsV2`, `ListMultipartUploads`,
-`ListBuckets`, `ListParts`, `PutBucketCors`, `PutBucketLifecycleConfiguration`,
-`PutObjectTagging`, `PutObjectAcl`, `PutObjectRetention`, `PutObjectLegalHold`,
-`PutObjectLockConfiguration`, `PutBucketAcl`, `PutBucketPolicy`,
-`PutBucketTagging`, `PutBucketAccelerateConfiguration`,
-`PutBucketOwnershipControls`, `PutObject`.
-
-**Class B** requests are reads: `GetBucketAccelerateConfiguration`,
-`GetBucketAcl`, `GetBucketCors`, `GetBucketLifecycleConfiguration`,
-`GetBucketLocation`, `GetBucketOwnershipControls`, `GetBucketPolicy`,
-`GetBucketPolicyStatus`, `GetBucketRequestPayment`, `GetBucketTagging`,
-`GetBucketVersioning`, `GetObject`, `GetObjectAcl`, `GetObjectTagging`,
-`HeadBucket`, `HeadObject`.
-
 ## Multi-region pricing
 
 |                        | Standard     | Infrequent Access | Archive      | Archive Instant Retrieval |
@@ -98,6 +83,23 @@ Tigris charges zero egress fees. No charges for:
 - Regional transfers
 - Inter-region transfers
 - Internet egress
+
+## Request types
+
+**Class A** requests modify state: `CreateBucket`, `CreateMultipartUpload`,
+`CopyObject`, `ListObjects`, `ListObjectsV2`, `ListMultipartUploads`,
+`ListBuckets`, `ListParts`, `PutBucketCors`, `PutBucketLifecycleConfiguration`,
+`PutObjectTagging`, `PutObjectAcl`, `PutObjectRetention`, `PutObjectLegalHold`,
+`PutObjectLockConfiguration`, `PutBucketAcl`, `PutBucketPolicy`,
+`PutBucketTagging`, `PutBucketAccelerateConfiguration`,
+`PutBucketOwnershipControls`, `PutObject`.
+
+**Class B** requests are reads: `GetBucketAccelerateConfiguration`,
+`GetBucketAcl`, `GetBucketCors`, `GetBucketLifecycleConfiguration`,
+`GetBucketLocation`, `GetBucketOwnershipControls`, `GetBucketPolicy`,
+`GetBucketPolicyStatus`, `GetBucketRequestPayment`, `GetBucketTagging`,
+`GetBucketVersioning`, `GetObject`, `GetObjectAcl`, `GetObjectTagging`,
+`HeadBucket`, `HeadObject`.
 
 ## Enterprise
 


### PR DESCRIPTION
## Summary
- Moves Class A and Class B request descriptions below the "Data transfer" section on the pricing overview page
- Adds a "Request types" heading for the moved content

## Test plan
- [ ] Verify pricing page renders correctly with `npm start`
- [ ] Confirm request type descriptions appear after data transfer section


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that reorders content and adds a heading, with no product or billing logic changes.
> 
> **Overview**
> Updates `docs/pricing/index.md` to **move the Class A/Class B request type definitions** from directly under the pricing tables to a new **`## Request types`** section placed after **`## Data transfer`**, improving page flow without changing any pricing values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 129d018cd72e100e981becde71116261b622b2e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->