### PR TITLE
docs: add elixir, php, and ruby language guides

### DIFF
--- a/docs/quickstarts/elixir.mdx
+++ b/docs/quickstarts/elixir.mdx
@@ -1,0 +1,129 @@
+---
+id: elixir
+title: "Elixir"
+---
+
+# Elixir
+
+Use Tigris with Elixir through the [ExAWS](https://hexdocs.pm/ex_aws/ExAws.html)
+library. ExAWS provides an S3 client that works with Tigris by changing the
+endpoint configuration.
+
+For the full SDK reference, see the
+[ExAWS Elixir SDK guide](/docs/sdks/s3/aws-elixir-sdk/).
+
+## Prerequisites
+
+- Elixir 1.14+
+- A Tigris account — create one at [storage.new](https://storage.new)
+- An access key from
+  [console.storage.dev/createaccesskey](https://console.storage.dev/createaccesskey)
+
+## Install
+
+Add the dependencies to your `mix.exs` file:
+
+```elixir
+defp deps do
+  [
+    {:ex_aws, "~> 2.0"},
+    {:ex_aws_s3, "~> 2.0"},
+    {:poison, "~> 3.0"},
+    {:hackney, "~> 1.9"},
+    {:sweet_xml, "~> 0.6.6"},
+    {:jason, "~> 1.1"},
+  ]
+end
+```
+
+Then fetch dependencies:
+
+```bash
+mix deps.get
+```
+
+## Configure credentials
+
+Set your Tigris credentials as environment variables:
+
+```bash
+export AWS_ACCESS_KEY_ID="tid_your_access_key"
+export AWS_SECRET_ACCESS_KEY="tsec_your_secret_key"
+```
+
+Then configure ExAWS in your `config/config.exs`:
+
+```elixir
+import Config
+
+config :ex_aws,
+  debug_requests: true,
+  json_codec: Jason,
+  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
+  secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role]
+
+config :ex_aws, :s3,
+  scheme: "https://",
+  host: "t3.storage.dev",
+  region: "auto"
+```
+
+## Basic operations
+
+### List buckets
+
+```elixir
+{:ok, %{body: %{buckets: buckets}}} = ExAws.S3.list_buckets() |> ExAws.request()
+
+for bucket <- buckets do
+  IO.puts(bucket.name)
+end
+```
+
+### Upload an object
+
+```elixir
+"Hello, World!"
+|> ExAws.S3.put_object("my-bucket", "hello.txt")
+|> ExAws.request!()
+```
+
+### Download an object
+
+```elixir
+{:ok, %{body: body}} =
+  ExAws.S3.get_object("my-bucket", "hello.txt")
+  |> ExAws.request()
+
+IO.puts(body)
+```
+
+### List objects
+
+```elixir
+{:ok, %{body: %{contents: objects}}} =
+  ExAws.S3.list_objects("my-bucket")
+  |> ExAws.request()
+
+for object <- objects do
+  IO.puts("  #{object.key}  (#{object.size} bytes)")
+end
+```
+
+### Generate a presigned URL
+
+```elixir
+{:ok, presigned_url} =
+  ExAws.S3.presigned_url(ExAws.Config.new(:s3), :get, "my-bucket", "hello.txt",
+    expires_in: 3600
+  )
+
+IO.puts(presigned_url)
+```
+
+## Next steps
+
+- [ExAWS Elixir SDK reference](/docs/sdks/s3/aws-elixir-sdk/) — presigned URLs,
+  custom domains, and full configuration details
+- [Snapshots and forks](/docs/buckets/snapshots-and-forks/) — Tigris snapshot
+  and fork concepts

--- a/docs/quickstarts/elixir.mdx
+++ b/docs/quickstarts/elixir.mdx
@@ -57,7 +57,7 @@ Then configure ExAWS in your `config/config.exs`:
 import Config
 
 config :ex_aws,
-  debug_requests: true,
+  debug_requests: false,
   json_codec: Jason,
   access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
   secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role]
@@ -83,8 +83,7 @@ end
 ### Upload an object
 
 ```elixir
-"Hello, World!"
-|> ExAws.S3.put_object("my-bucket", "hello.txt")
+ExAws.S3.put_object("my-bucket", "hello.txt", "Hello, World!")
 |> ExAws.request!()
 ```
 

--- a/docs/quickstarts/php.mdx
+++ b/docs/quickstarts/php.mdx
@@ -1,0 +1,118 @@
+---
+id: php
+title: "PHP"
+---
+
+# PHP
+
+Use Tigris with PHP through the
+[AWS SDK for PHP](https://aws.amazon.com/sdk-for-php/). The SDK works with
+Tigris by changing the endpoint configuration.
+
+For the full SDK reference, see the
+[AWS PHP SDK guide](/docs/sdks/s3/aws-php-sdk/).
+
+## Prerequisites
+
+- PHP 8.1+
+- Composer
+- A Tigris account — create one at [storage.new](https://storage.new)
+- An access key from
+  [console.storage.dev/createaccesskey](https://console.storage.dev/createaccesskey)
+
+## Install
+
+```bash
+composer require aws/aws-sdk-php
+```
+
+## Configure credentials
+
+Set your Tigris credentials as environment variables:
+
+```bash
+export AWS_ACCESS_KEY_ID="tid_your_access_key"
+export AWS_SECRET_ACCESS_KEY="tsec_your_secret_key"
+```
+
+## Create a client
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+use Aws\S3\S3Client;
+
+$s3 = new S3Client([
+    'region' => 'auto',
+    'endpoint' => 'https://t3.storage.dev',
+    'version' => 'latest',
+]);
+```
+
+The client reads credentials from the `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` environment variables automatically.
+
+## Basic operations
+
+### List buckets
+
+```php
+$result = $s3->listBuckets();
+
+foreach ($result['Buckets'] as $bucket) {
+    echo $bucket['Name'] . "\n";
+}
+```
+
+### Upload an object
+
+```php
+$s3->putObject([
+    'Bucket' => 'my-bucket',
+    'Key' => 'hello.txt',
+    'Body' => 'Hello, World!',
+]);
+```
+
+### Download an object
+
+```php
+$result = $s3->getObject([
+    'Bucket' => 'my-bucket',
+    'Key' => 'hello.txt',
+]);
+
+echo $result['Body'] . "\n";
+```
+
+### List objects
+
+```php
+$result = $s3->listObjectsV2([
+    'Bucket' => 'my-bucket',
+]);
+
+foreach ($result['Contents'] as $object) {
+    echo "  {$object['Key']}  ({$object['Size']} bytes)\n";
+}
+```
+
+### Generate a presigned URL
+
+```php
+$command = $s3->getCommand('GetObject', [
+    'Bucket' => 'my-bucket',
+    'Key' => 'hello.txt',
+]);
+
+$request = $s3->createPresignedRequest($command, '+60 minutes');
+echo (string) $request->getUri() . "\n";
+```
+
+## Next steps
+
+- [AWS PHP SDK reference](/docs/sdks/s3/aws-php-sdk/) — presigned URLs, custom
+  domains, and full configuration details
+- [Snapshots and forks](/docs/buckets/snapshots-and-forks/) — Tigris snapshot
+  and fork concepts

--- a/docs/quickstarts/php.mdx
+++ b/docs/quickstarts/php.mdx
@@ -93,7 +93,7 @@ $result = $s3->listObjectsV2([
     'Bucket' => 'my-bucket',
 ]);
 
-foreach ($result['Contents'] as $object) {
+foreach ($result['Contents'] ?? [] as $object) {
     echo "  {$object['Key']}  ({$object['Size']} bytes)\n";
 }
 ```

--- a/docs/quickstarts/ruby.mdx
+++ b/docs/quickstarts/ruby.mdx
@@ -1,0 +1,129 @@
+---
+id: ruby
+title: "Ruby"
+---
+
+# Ruby
+
+Use Tigris with Ruby through the
+[AWS SDK for Ruby](https://aws.amazon.com/sdk-for-ruby/). The SDK works with
+Tigris by changing the endpoint configuration.
+
+For the full SDK reference, see the
+[AWS Ruby SDK guide](/docs/sdks/s3/aws-ruby-sdk/).
+
+## Prerequisites
+
+- Ruby 3.0+
+- A Tigris account — create one at [storage.new](https://storage.new)
+- An access key from
+  [console.storage.dev/createaccesskey](https://console.storage.dev/createaccesskey)
+
+## Install
+
+Add the AWS SDK to your `Gemfile`:
+
+```ruby
+gem "aws-sdk-s3"
+```
+
+Then install:
+
+```bash
+bundle install
+```
+
+Or install directly:
+
+```bash
+gem install aws-sdk-s3
+```
+
+## Configure credentials
+
+Set your Tigris credentials as environment variables:
+
+```bash
+export AWS_ACCESS_KEY_ID="tid_your_access_key"
+export AWS_SECRET_ACCESS_KEY="tsec_your_secret_key"
+```
+
+## Create a client
+
+```ruby
+require "aws-sdk-s3"
+
+s3 = Aws::S3::Client.new(
+  region: "auto",
+  endpoint: "https://t3.storage.dev",
+  force_path_style: false,
+)
+```
+
+The client reads credentials from the `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` environment variables automatically.
+
+## Basic operations
+
+### List buckets
+
+```ruby
+resp = s3.list_buckets
+
+resp.buckets.each do |bucket|
+  puts bucket.name
+end
+```
+
+### Upload an object
+
+```ruby
+s3.put_object(
+  bucket: "my-bucket",
+  key: "hello.txt",
+  body: "Hello, World!",
+)
+```
+
+### Download an object
+
+```ruby
+resp = s3.get_object(
+  bucket: "my-bucket",
+  key: "hello.txt",
+)
+
+puts resp.body.read
+```
+
+### List objects
+
+```ruby
+resp = s3.list_objects_v2(bucket: "my-bucket")
+
+resp.contents.each do |object|
+  puts "  #{object.key}  (#{object.size} bytes)"
+end
+```
+
+### Generate a presigned URL
+
+```ruby
+signer = Aws::S3::Presigner.new(client: s3)
+
+url = signer.presigned_url(
+  :get_object,
+  bucket: "my-bucket",
+  key: "hello.txt",
+  expires_in: 3600,
+)
+
+puts url
+```
+
+## Next steps
+
+- [AWS Ruby SDK reference](/docs/sdks/s3/aws-ruby-sdk/) — presigned URLs, custom
+  domains, and full configuration details
+- [Snapshots and forks](/docs/buckets/snapshots-and-forks/) — Tigris snapshot
+  and fork concepts

--- a/sidebars.js
+++ b/sidebars.js
@@ -293,6 +293,21 @@ const sidebars = {
             },
             {
               type: "doc",
+              label: "Elixir",
+              id: "quickstarts/elixir",
+            },
+            {
+              type: "doc",
+              label: "PHP",
+              id: "quickstarts/php",
+            },
+            {
+              type: "doc",
+              label: "Ruby",
+              id: "quickstarts/ruby",
+            },
+            {
+              type: "doc",
               label: "Kubernetes",
               id: "quickstarts/kubernetes",
             },

--- a/src/components/StackGrid/index.jsx
+++ b/src/components/StackGrid/index.jsx
@@ -46,6 +46,13 @@ export default function StackGrid() {
           to="/quickstarts/node/"
         />
         <StackTile
+          icon="img/icons/elixir"
+          title="Elixir"
+          to="/quickstarts/elixir/"
+        />
+        <StackTile icon="img/icons/php" title="PHP" to="/quickstarts/php/" />
+        <StackTile icon="img/icons/ruby" title="Ruby" to="/quickstarts/ruby/" />
+        <StackTile
           icon="img/icons/kubernetes"
           title="Kubernetes"
           to="/quickstarts/kubernetes/"


### PR DESCRIPTION
## Summary
- Add quickstart guides for Elixir (ExAWS), PHP (AWS SDK for PHP), and Ruby (AWS SDK for Ruby) under Guides > Languages & Frameworks
- Add tiles for all three languages to the docs homepage StackGrid component
- Each guide covers prerequisites, installation, credential setup, client creation, basic operations (list buckets, upload, download, list objects, presigned URLs), and links to the full SDK reference

## Test plan
- [ ] Verify the three new pages render correctly at `/quickstarts/elixir/`, `/quickstarts/php/`, `/quickstarts/ruby/`
- [ ] Verify tiles appear on the docs homepage between Node and Kubernetes
- [ ] Verify sidebar shows Elixir, PHP, and Ruby under Guides > Languages & Frameworks
- [ ] Verify dark/light mode icon switching works for all three tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new documentation pages and navigation/landing-page links without changing runtime or backend behavior.
> 
> **Overview**
> Adds new language quickstarts for `Elixir`, `PHP`, and `Ruby`, showing how to use Tigris via S3-compatible SDKs (install, credential setup, basic bucket/object operations, and presigned URLs).
> 
> Updates docs navigation by registering these pages under **Guides → Languages & Frameworks** in `sidebars.js`, and adds corresponding tiles/links on the homepage stack grid in `src/components/StackGrid/index.jsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cbea3068c55ec89201582b238c2ccd594918997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->