### PR TITLE
ci: use namespace runner for test workflow

### DIFF
--- a/.github/workflows/language-specific.yaml
+++ b/.github/workflows/language-specific.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   dotnet:
     name: ".Net"
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
@@ -25,7 +25,7 @@ jobs:
           AWS_REGION: auto
   elixir:
     name: Elixir
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
@@ -41,7 +41,7 @@ jobs:
           AWS_REGION: auto
   go:
     name: Go
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -58,7 +58,7 @@ jobs:
           AWS_REGION: auto
   javascript:
     name: "JavaScript"
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -75,7 +75,7 @@ jobs:
           AWS_ENDPOINT_URL_S3: https://t3.storage.dev
   python:
     name: "Python"
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -91,7 +91,7 @@ jobs:
           AWS_REGION: auto
   ruby:
     name: "Ruby"
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-2404
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,11 +12,12 @@ jobs:
     runs-on: namespace-profile-ubuntu-2404
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: npm
 
       - name: Check types + linting + build
         run: |


### PR DESCRIPTION
## Summary
- Switch test workflow runner from `ubuntu-latest` to `namespace-profile-ubuntu-2404` for consistent CI environment

## Test plan
- [ ] Verify the test workflow runs successfully on the new runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only changes; main risk is workflow failures due to runner/environment differences or action version bumps.
> 
> **Overview**
> Switches the `test` and `language-specific` GitHub Actions workflows from `ubuntu-latest` to `namespace-profile-ubuntu-2404` for a consistent CI runtime.
> 
> Modernizes the `test` workflow by upgrading `actions/checkout` and `actions/setup-node` to `@v4` and enabling npm caching via `cache: npm`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff32bc20fe0258f1b5961b9c850567f8cc67cb35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->