### PR TITLE
free tier for partners

### DIFF
--- a/docs/partner-integrations/index.mdx
+++ b/docs/partner-integrations/index.mdx
@@ -73,8 +73,46 @@ deactivating the organization and its associated access keys.
 
 ## Billing
 
-You can run your own billing logic. Tigris provides billing totals given a date
-range with granularity to the day per organization.
+Tigris uses [usage-based pricing](https://www.tigrisdata.com/pricing/) for
+partners, same rates as the standard platform. All charges are in USD on a
+calendar month cycle. There are no egress fees.
+
+### Free tier
+
+Every provider account includes a free tier:
+
+| Resource                           | Free allowance |
+| ---------------------------------- | -------------- |
+| Storage                            | 5 GB           |
+| Class A requests (PUT, POST, LIST) | 10,000         |
+| Class B requests (GET, HEAD)       | 100,000        |
+
+The free tier is applied to your consolidated usage across all organizations
+under your provider account. You receive a single consolidated bill that totals
+the usage across every organization, and the free allowance is subtracted from
+that total. Usage beyond the free tier is charged at standard rates.
+
+### Invoices and payment
+
+Invoices are generated at the end of each calendar month and sent to your
+provider billing email. Each invoice includes a breakdown of usage and charges
+for the billing period. You can make payment through the link in the invoice
+email.
+
+### Billing API
+
+You can fetch invoices and usage data programmatically at any time through the
+[Usage and Billing](/docs/partner-integrations/api/billing/) API endpoints:
+
+- [Get Account Invoice](/docs/partner-integrations/api/tigris-get-account-invoice)
+  for your consolidated provider invoice for a given month.
+- [Get Invoice](/docs/partner-integrations/api/tigris-get-invoice) for a
+  per-organization invoice for a given month.
+- [Get Usage](/docs/partner-integrations/api/tigris-get-usage) for detailed
+  usage metrics over a date range, with daily granularity per organization.
+
+Use these to build your own billing logic, cost attribution, or customer-facing
+usage dashboards.
 
 ## Partnerships
 

--- a/docs/partner-integrations/index.mdx
+++ b/docs/partner-integrations/index.mdx
@@ -75,11 +75,13 @@ deactivating the organization and its associated access keys.
 
 Tigris uses [usage-based pricing](https://www.tigrisdata.com/pricing/) for
 partners, same rates as the standard platform. All charges are in USD on a
-calendar month cycle. There are no egress fees.
+calendar month cycle. There are no egress fees. Customized pricing options are
+available for high-volume accounts.
 
 ### Free tier
 
-Every provider account includes a free tier:
+Every partner has access to a free tier, applied to consolidated usage across
+all organizations:
 
 | Resource                           | Free allowance |
 | ---------------------------------- | -------------- |
@@ -87,10 +89,8 @@ Every provider account includes a free tier:
 | Class A requests (PUT, POST, LIST) | 10,000         |
 | Class B requests (GET, HEAD)       | 100,000        |
 
-The free tier is applied to your consolidated usage across all organizations
-under your provider account. You receive a single consolidated bill that totals
-the usage across every organization, and the free allowance is subtracted from
-that total. Usage beyond the free tier is charged at standard rates.
+These allowances reset each billing cycle. Your consolidated bill totals usage
+across every organization, and the free allowance is subtracted from that total.
 
 ### Invoices and payment
 

--- a/docs/partner-integrations/index.mdx
+++ b/docs/partner-integrations/index.mdx
@@ -102,7 +102,7 @@ email.
 ### Billing API
 
 You can fetch invoices and usage data programmatically at any time through the
-[Usage and Billing](/docs/partner-integrations/api/billing/) API endpoints:
+Partner Integrations API:
 
 - [Get Account Invoice](/docs/partner-integrations/api/tigris-get-account-invoice)
   for your consolidated provider invoice for a given month.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only update that changes partner billing guidance and adds free-tier details; low risk aside from potential user confusion if the described billing terms are inaccurate.
> 
> **Overview**
> Updates the Partner Integrations docs billing section to describe **usage-based partner pricing** (USD monthly cycle, no egress fees, high-volume custom pricing) instead of the prior brief note.
> 
> Adds a **partner free tier** table (5GB storage, 10k Class A, 100k Class B requests), explains consolidated allowance application/reset, and documents invoice delivery/payment plus links to billing-related API endpoints for invoices and usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b102099a2a1c7cc09c15ba8d33f998009394388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->