### PR TITLE
docs: clarify agent shell authentication section

### DIFF
--- a/docs/ai/agent-shell/index.mdx
+++ b/docs/ai/agent-shell/index.mdx
@@ -70,15 +70,15 @@ This gives you:
 
 ## Authentication
 
-You can authenticate with environment variables or by passing config directly.
+Pass your Tigris credentials when constructing `TigrisShell`. The examples on
+this page load them from the following environment variables:
 
-```ts
-const shell = new TigrisShell({
-  bucket: process.env.TIGRIS_STORAGE_BUCKET,
-  accessKeyId: process.env.TIGRIS_STORAGE_ACCESS_KEY_ID,
-  secretAccessKey: process.env.TIGRIS_STORAGE_SECRET_ACCESS_KEY,
-});
-```
+- `TIGRIS_STORAGE_BUCKET` — target bucket name
+- `TIGRIS_STORAGE_ACCESS_KEY_ID` — access key ID
+- `TIGRIS_STORAGE_SECRET_ACCESS_KEY` — secret access key
+
+You can also pass literal strings or values from any other source — any
+`TigrisConfig` object works.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
Addresses Greptile review feedback on #425:

- Replace the misleading "or by passing config directly" intro sentence — the only example used `process.env`, so the phrasing didn't match what was shown
- Drop the code block that duplicated the one in Basic Usage
- List the env vars (`TIGRIS_STORAGE_BUCKET`, `TIGRIS_STORAGE_ACCESS_KEY_ID`, `TIGRIS_STORAGE_SECRET_ACCESS_KEY`) so readers know what to set

The third Greptile comment about a missing `endpoint` option is skipped — the library is Tigris-specific and endpoint config was intentionally removed from `TigrisConfig` (per the PR description).

## Test plan
- [ ] `npm run dev` and verify the Agent Shell → Authentication section renders correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that don’t affect runtime behavior; risk is limited to potential wording/formatting regressions.
> 
> **Overview**
> Updates the `Agent Shell` docs to clarify authentication setup: the section now states that credentials are passed via `TigrisShell` config, explicitly lists the expected `TIGRIS_STORAGE_*` environment variables, and notes that any `TigrisConfig` source (including literal strings) is valid.
> 
> Removes the duplicated authentication code block from this section to avoid repeating the `Basic Usage` example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c12b5405c35cb37291bb6800dc08d738d693ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->