### PR TITLE
fix: enable Accept: text/markdown content negotiation

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -29,7 +29,20 @@
       ]
     },
     {
-      "source": "/docs/:path((?!.*\\.(?:js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|json|xml|txt|md|map)$).*)",
+      "source": "/docs/",
+      "headers": [
+        {
+          "key": "Link",
+          "value": "</docs/llms.txt>; rel=\"alternate\"; type=\"text/plain\""
+        },
+        {
+          "key": "Vary",
+          "value": "Accept"
+        }
+      ]
+    },
+    {
+      "source": "/docs/:path+/",
       "headers": [
         {
           "key": "Link",
@@ -43,54 +56,6 @@
     }
   ],
   "redirects": [
-    {
-      "source": "/docs/",
-      "has": [
-        {
-          "type": "header",
-          "key": "accept",
-          "value": ".*text/markdown.*"
-        }
-      ],
-      "destination": "/docs/index.md",
-      "statusCode": 307
-    },
-    {
-      "source": "/docs/:path+/",
-      "has": [
-        {
-          "type": "header",
-          "key": "accept",
-          "value": ".*text/markdown.*"
-        }
-      ],
-      "destination": "/docs/:path.md",
-      "statusCode": 307
-    },
-    {
-      "source": "/docs/",
-      "has": [
-        {
-          "type": "header",
-          "key": "user-agent",
-          "value": ".*(ClaudeBot|ChatGPT-User|GPTBot|Google-Extended|PerplexityBot|Cohere-AI|OAI-SearchBot|YouBot|AI2Bot|Applebot-Extended|Meta-ExternalAgent|Meta-ExternalFetcher|Firecrawl|JinaBot).*"
-        }
-      ],
-      "destination": "/docs/index.md",
-      "statusCode": 307
-    },
-    {
-      "source": "/docs/:path+/",
-      "has": [
-        {
-          "type": "header",
-          "key": "user-agent",
-          "value": ".*(ClaudeBot|ChatGPT-User|GPTBot|Google-Extended|PerplexityBot|Cohere-AI|OAI-SearchBot|YouBot|AI2Bot|Applebot-Extended|Meta-ExternalAgent|Meta-ExternalFetcher|Firecrawl|JinaBot).*"
-        }
-      ],
-      "destination": "/docs/:path.md",
-      "statusCode": 307
-    },
     {
       "source": "/docs/caching/",
       "destination": "/docs/objects/caching/",
@@ -135,6 +100,54 @@
       "source": "/docs/get-started/",
       "destination": "/docs/",
       "permanent": true
+    },
+    {
+      "source": "/docs/",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/docs/index.md",
+      "statusCode": 307
+    },
+    {
+      "source": "/docs/:path+/",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/docs/:path.md",
+      "statusCode": 307
+    },
+    {
+      "source": "/docs/",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*(ClaudeBot|ChatGPT-User|GPTBot|Google-Extended|PerplexityBot|Cohere-AI|OAI-SearchBot|YouBot|AI2Bot|Applebot-Extended|Meta-ExternalAgent|Meta-ExternalFetcher|Firecrawl|JinaBot).*"
+        }
+      ],
+      "destination": "/docs/index.md",
+      "statusCode": 307
+    },
+    {
+      "source": "/docs/:path+/",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*(ClaudeBot|ChatGPT-User|GPTBot|Google-Extended|PerplexityBot|Cohere-AI|OAI-SearchBot|YouBot|AI2Bot|Applebot-Extended|Meta-ExternalAgent|Meta-ExternalFetcher|Firecrawl|JinaBot).*"
+        }
+      ],
+      "destination": "/docs/:path.md",
+      "statusCode": 307
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -27,9 +27,70 @@
           "value": "text/markdown; charset=utf-8"
         }
       ]
+    },
+    {
+      "source": "/docs/:path((?!.*\\.(?:js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|json|xml|txt|md|map)$).*)",
+      "headers": [
+        {
+          "key": "Link",
+          "value": "</docs/llms.txt>; rel=\"alternate\"; type=\"text/plain\""
+        },
+        {
+          "key": "Vary",
+          "value": "Accept"
+        }
+      ]
     }
   ],
   "redirects": [
+    {
+      "source": "/docs/",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/docs/index.md",
+      "statusCode": 307
+    },
+    {
+      "source": "/docs/:path+/",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/docs/:path.md",
+      "statusCode": 307
+    },
+    {
+      "source": "/docs/",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*(ClaudeBot|ChatGPT-User|GPTBot|Google-Extended|PerplexityBot|Cohere-AI|OAI-SearchBot|YouBot|AI2Bot|Applebot-Extended|Meta-ExternalAgent|Meta-ExternalFetcher|Firecrawl|JinaBot).*"
+        }
+      ],
+      "destination": "/docs/index.md",
+      "statusCode": 307
+    },
+    {
+      "source": "/docs/:path+/",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*(ClaudeBot|ChatGPT-User|GPTBot|Google-Extended|PerplexityBot|Cohere-AI|OAI-SearchBot|YouBot|AI2Bot|Applebot-Extended|Meta-ExternalAgent|Meta-ExternalFetcher|Firecrawl|JinaBot).*"
+        }
+      ],
+      "destination": "/docs/:path.md",
+      "statusCode": 307
+    },
     {
       "source": "/docs/caching/",
       "destination": "/docs/objects/caching/",


### PR DESCRIPTION
## Summary

- The Edge Middleware (`middleware.mjs`) isn't being executed on Vercel's Docusaurus static site adapter — confirmed by missing `Link` and `Vary` headers on all responses
- Adds conditional `redirects` in `vercel.json` with `has` conditions, which Vercel processes at the routing layer before static file serving
- Requests with `Accept: text/markdown` or known AI bot User-Agents get 307-redirected to the corresponding `.md` file (generated by the llms-txt plugin)
- Adds `Link` and `Vary: Accept` headers on doc HTML pages for llms.txt discovery and correct CDN caching

## Test plan

- [ ] Deploy preview and verify: `curl -sI -H "Accept: text/markdown" <preview-url>/docs/use-cases/agent-coordination/` returns a 307 to `.md`
- [ ] Verify normal browser requests still get HTML
- [ ] Verify `.md` file is served with `Content-Type: text/markdown`
- [ ] Verify `Link` and `Vary` headers appear on HTML doc responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)