### PR TITLE
fix: restore Access Control entry in partner sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -721,6 +721,11 @@ const sidebars = {
           id: "partner-integrations/architecture",
         },
         {
+          type: "doc",
+          label: "Access Control",
+          id: "partner-integrations/access-control",
+        },
+        {
           type: "category",
           label: "API reference",
           link: {


### PR DESCRIPTION
## Summary

- The [Access Control page](https://www.tigrisdata.com/docs/partner-integrations/access-control/) has been live since PR #395 but has no entry in the left sidebar, so it's only reachable via direct link.
- Root cause: PR #393's navigation restructure merged a few hours after #395 with a branch cut before #395 landed, silently overwriting the sidebar and dropping this entry (and the TAG entries). PR #397 restored TAG but missed Access Control.
- Restores the entry in its original position under "Partner Integration Program", right after "Multi-Tenant Architecture".

## Test plan

- [ ] `npm run dev` — confirm "Access Control" appears in the sidebar under Partner Integration Program
- [ ] Click through to `/docs/partner-integrations/access-control/` and verify the sidebar highlights the active entry
- [ ] `npm run build` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single navigation config change with no runtime logic or data/security impact; risk is limited to potential doc link/id mismatch.
> 
> **Overview**
> Restores the `Access Control` documentation entry (`partner-integrations/access-control`) to the **Partner Integration Program** sidebar, placing it after `Multi-Tenant Architecture` so the page is reachable and properly highlighted via navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a6ccb10e6953b15c73fe451eedbdb15ce2e9711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->