### PR TITLE
docs: add Agent Experimentation use case

### DIFF
--- a/docs/use-cases/agent-experimentation.mdx
+++ b/docs/use-cases/agent-experimentation.mdx
@@ -63,9 +63,9 @@ Writes in one fork don't show up in any other.
 <details>
 <summary>Copy-on-write storage sharing</summary>
 
-Forks share the baseline data through copy-on-write. You only pay for bytes
-each experiment actually writes. If your experiments add scores or labels on top
-of the original data, overhead is small. If they rewrite most of the data (like
+Forks share the baseline data through copy-on-write. You only pay for bytes each
+experiment actually writes. If your experiments add scores or labels on top of
+the original data, overhead is small. If they rewrite most of the data (like
 re-embedding an entire corpus), each fork uses more storage.
 
 </details>

--- a/docs/use-cases/agent-experimentation.mdx
+++ b/docs/use-cases/agent-experimentation.mdx
@@ -1,0 +1,209 @@
+---
+id: agent-experimentation
+title: "Agent Experimentation"
+---
+
+import AgentExperimentationDiagram from "@site/src/components/diagrams/AgentExperimentationDiagram";
+import DiagramLightbox from "@site/src/components/diagrams/DiagramLightbox";
+
+# Agent Experimentation
+
+## Try multiple approaches and keep the best
+
+_Fork the data, let each agent try a different approach, compare outcomes,
+promote the winner._
+
+<div className="use-case-hero">
+  <div className="use-case-hero__text">
+
+You want to try three different embedding models, or two chunking strategies, or
+a new prompt template against the old one. Each variant needs to run against the
+same data without stepping on the others. Copying the dataset per experiment is
+slow and multiplies your storage bill.
+
+[Tigris bucket forks](/docs/buckets/snapshots-and-forks/) give each variant its
+own writable copy of the data with no upfront cost. A fork is a copy-on-write
+clone: instant to create, zero storage until something new gets written. Unlike
+[sandboxes](/docs/use-cases/agent-sandboxes/), which focus on giving agents
+isolated environments, the experimentation pattern adds a comparison step at the
+end: run the same task multiple ways, score the outputs, keep the winner.
+
+[Snapshots and forks →](/docs/buckets/snapshots-and-forks/)
+
+  </div>
+  <div className="use-case-hero__diagram">
+    <DiagramLightbox>
+      <div className="mermaid-frame">
+        <AgentExperimentationDiagram />
+      </div>
+    </DiagramLightbox>
+  </div>
+</div>
+
+### Benefits
+
+<details>
+<summary>Non-destructive writes via fork isolation</summary>
+
+Each experiment runs inside its own fork. If an agent corrupts the data or
+produces garbage, the original dataset is untouched. Delete the fork and start
+over.
+
+</details>
+
+<details>
+<summary>Per-experiment S3 namespace</summary>
+
+Multiple agents can work on the same data at the same time. Each fork is its own
+S3 namespace, so there's no locking and no path-prefix conventions to manage.
+Writes in one fork don't show up in any other.
+
+</details>
+
+<details>
+<summary>Copy-on-write storage sharing</summary>
+
+Forks share the baseline data through copy-on-write. You only pay for bytes
+each experiment actually writes. If your experiments add scores or labels on top
+of the original data, overhead is small. If they rewrite most of the data (like
+re-embedding an entire corpus), each fork uses more storage.
+
+</details>
+
+<details>
+<summary>Snapshot-pinned baselines</summary>
+
+Snapshot the dataset before you start. Every fork branches from the same
+snapshot, so results are directly comparable. Weeks later, re-run any experiment
+by forking from the same snapshot version.
+
+```bash
+tigris snapshots take my-dataset baseline-v1
+```
+
+</details>
+
+<details>
+<summary>Collision-free output paths</summary>
+
+Each fork is its own S3 namespace. Every agent can write to
+`results/scores.json` without colliding. Collecting results across experiments
+is a loop over bucket names, not a query against a shared database.
+
+</details>
+
+### Patterns
+
+#### Prompt and model evaluation
+
+Test the same task across different models or prompt templates. Fork the test
+set, let each agent run its variant, and compare output quality. Each agent
+reads inputs from its fork and writes scores to a known path.
+
+```bash
+# Pin the test set
+tigris snapshots take eval-set "pre-eval"
+
+# One fork per variant
+tigris forks create eval-set eval-gpt4o
+tigris forks create eval-set eval-claude
+tigris forks create eval-set eval-llama
+
+# Each agent reads s3://eval-{model}/inputs/ and writes to
+# s3://eval-{model}/results/scores.json
+```
+
+#### Data preparation and enrichment
+
+Agents that clean, label, or transform datasets can try different approaches in
+parallel and keep the output that scores highest. The original raw data is
+shared across forks; each agent writes its transformed output on top.
+
+```bash
+tigris forks create raw-dataset cleaned-aggressive
+tigris forks create raw-dataset cleaned-conservative
+tigris forks create raw-dataset cleaned-llm-assisted
+
+# Each agent reads the original files (shared via copy-on-write)
+# and writes transformed output to s3://{fork}/processed/
+```
+
+#### RAG pipeline tuning
+
+Try different retrieval configurations against the same knowledge base. Each
+fork starts with the same source documents; each agent builds its own index
+inside the fork. Since re-indexing rewrites most of the data, the storage
+savings come from sharing the source documents, not the indices.
+
+```bash
+tigris forks create knowledge-base rag-chunk-256
+tigris forks create knowledge-base rag-chunk-512
+tigris forks create knowledge-base rag-with-reranker
+
+# Each agent reads s3://{fork}/documents/ (shared, zero-copy)
+# and writes its index to s3://{fork}/index/ (new per fork)
+```
+
+#### Rollout safety
+
+Before deploying a new agent version, fork production data and let the new
+version process it. Compare its output against the current version's results
+without touching live data.
+
+```bash
+# Snapshot current production state
+tigris snapshots take prod-data "pre-rollout-$(date +%s)"
+
+# Fork for the new version to run against
+tigris forks create prod-data rollout-candidate
+
+# New agent version reads from and writes to the fork
+# Diff s3://rollout-candidate/results/ against s3://prod-data/results/
+```
+
+#### Compare, promote, and clean up
+
+After all agents finish, collect results, keep the winner, and delete the rest.
+
+**1. Pull results from each fork.** Since every fork is an S3 bucket and agents
+write to the same relative path, collecting outputs is a loop over bucket names.
+
+```bash
+export AWS_ENDPOINT_URL="https://t3.storage.dev"
+
+for fork in eval-gpt4o eval-claude eval-llama; do
+  aws s3 cp "s3://${fork}/results/scores.json" "./results/${fork}.json"
+done
+```
+
+**2. Snapshot the winner.** This creates an immutable record of the experiment
+state that you can fork from later if you want to build on the result.
+
+```bash
+tigris snapshots take eval-claude "promoted-$(date +%s)"
+```
+
+**3. Delete the losing forks.** Only each fork's unique writes are reclaimed.
+The shared baseline is unaffected.
+
+```bash
+tigris rm -f eval-gpt4o
+tigris rm -f eval-llama
+```
+
+#### Iterative refinement
+
+An agent can fork its own fork to try a variation without losing intermediate
+state. If the variation doesn't work, delete it and try again from the same
+parent.
+
+```bash
+# Agent B has good results; try a refinement
+tigris forks create rag-chunk-512 rag-chunk-512-v2
+
+# If the refinement works, promote it
+tigris snapshots take rag-chunk-512-v2 "promoted"
+
+# If it doesn't, throw it away; the parent fork is unchanged
+tigris rm -f rag-chunk-512-v2
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -213,6 +213,11 @@ const sidebars = {
               label: "Agent Sandboxes",
               id: "use-cases/agent-sandboxes",
             },
+            {
+              type: "doc",
+              label: "Agent Experimentation",
+              id: "use-cases/agent-experimentation",
+            },
           ],
         },
         {

--- a/src/components/diagrams/AgentExperimentationDiagram.tsx
+++ b/src/components/diagrams/AgentExperimentationDiagram.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import ExcalidrawDiagram from "./ExcalidrawDiagram";
+import elements from "./data/agent-experimentation.json";
+
+export default function AgentExperimentationDiagram() {
+  return <ExcalidrawDiagram elements={elements} />;
+}

--- a/src/components/diagrams/data/agent-experimentation.json
+++ b/src/components/diagrams/data/agent-experimentation.json
@@ -55,7 +55,10 @@
     "strokeWidth": 1.5,
     "endArrowhead": "arrow",
     "startArrowhead": null,
-    "points": [[0, 0], [100, 0]]
+    "points": [
+      [0, 0],
+      [100, 0]
+    ]
   },
   {
     "type": "text",
@@ -104,7 +107,10 @@
     "strokeStyle": "dashed",
     "endArrowhead": "arrow",
     "startArrowhead": null,
-    "points": [[0, 0], [-280, 80]]
+    "points": [
+      [0, 0],
+      [-280, 80]
+    ]
   },
   {
     "type": "arrow",
@@ -118,7 +124,10 @@
     "strokeStyle": "dashed",
     "endArrowhead": "arrow",
     "startArrowhead": null,
-    "points": [[0, 0], [0, 80]]
+    "points": [
+      [0, 0],
+      [0, 80]
+    ]
   },
   {
     "type": "arrow",
@@ -132,7 +141,10 @@
     "strokeStyle": "dashed",
     "endArrowhead": "arrow",
     "startArrowhead": null,
-    "points": [[0, 0], [280, 80]]
+    "points": [
+      [0, 0],
+      [280, 80]
+    ]
   },
 
   {
@@ -259,7 +271,10 @@
     "strokeWidth": 1.5,
     "endArrowhead": "arrow",
     "startArrowhead": null,
-    "points": [[0, 0], [0, 50]]
+    "points": [
+      [0, 0],
+      [0, 50]
+    ]
   },
   {
     "type": "arrow",
@@ -272,7 +287,10 @@
     "strokeWidth": 1.5,
     "endArrowhead": "arrow",
     "startArrowhead": null,
-    "points": [[0, 0], [0, 50]]
+    "points": [
+      [0, 0],
+      [0, 50]
+    ]
   },
   {
     "type": "arrow",
@@ -285,7 +303,10 @@
     "strokeWidth": 1.5,
     "endArrowhead": "arrow",
     "startArrowhead": null,
-    "points": [[0, 0], [0, 50]]
+    "points": [
+      [0, 0],
+      [0, 50]
+    ]
   },
 
   {
@@ -372,7 +393,10 @@
     "strokeStyle": "dashed",
     "endArrowhead": "arrow",
     "startArrowhead": null,
-    "points": [[0, 0], [280, 70]]
+    "points": [
+      [0, 0],
+      [280, 70]
+    ]
   },
   {
     "type": "arrow",
@@ -386,7 +410,10 @@
     "strokeStyle": "dashed",
     "endArrowhead": "arrow",
     "startArrowhead": null,
-    "points": [[0, 0], [0, 70]]
+    "points": [
+      [0, 0],
+      [0, 70]
+    ]
   },
   {
     "type": "arrow",
@@ -400,7 +427,10 @@
     "strokeStyle": "dashed",
     "endArrowhead": "arrow",
     "startArrowhead": null,
-    "points": [[0, 0], [-280, 70]]
+    "points": [
+      [0, 0],
+      [-280, 70]
+    ]
   },
 
   {

--- a/src/components/diagrams/data/agent-experimentation.json
+++ b/src/components/diagrams/data/agent-experimentation.json
@@ -1,0 +1,450 @@
+[
+  {
+    "type": "text",
+    "id": "title",
+    "x": 370,
+    "y": 0,
+    "text": "Experiment Swimlanes",
+    "fontSize": 18,
+    "fontFamily": 1,
+    "strokeColor": "#62FEB5"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "baseline",
+    "x": 80,
+    "y": 40,
+    "width": 200,
+    "height": 55,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "baseline-lbl",
+    "x": 110,
+    "y": 48,
+    "text": "Baseline Bucket",
+    "fontSize": 15,
+    "fontFamily": 1,
+    "strokeColor": "#62FEB5"
+  },
+  {
+    "type": "text",
+    "id": "baseline-sub",
+    "x": 110,
+    "y": 72,
+    "text": "shared dataset",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "arrow",
+    "id": "a-base-snap",
+    "x": 280,
+    "y": 67,
+    "width": 100,
+    "height": 0,
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [[0, 0], [100, 0]]
+  },
+  {
+    "type": "text",
+    "id": "snap-arrow-lbl",
+    "x": 295,
+    "y": 45,
+    "text": "snapshot",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "snapshot",
+    "x": 380,
+    "y": 40,
+    "width": 160,
+    "height": 55,
+    "backgroundColor": "#0e1920",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1.5
+  },
+  {
+    "type": "text",
+    "id": "snapshot-lbl",
+    "x": 410,
+    "y": 55,
+    "text": "Snapshot v1",
+    "fontSize": 15,
+    "fontFamily": 1,
+    "strokeColor": "#62FEB5"
+  },
+
+  {
+    "type": "arrow",
+    "id": "a-snap-fork-a",
+    "x": 460,
+    "y": 95,
+    "width": -280,
+    "height": 80,
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 2,
+    "strokeStyle": "dashed",
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [[0, 0], [-280, 80]]
+  },
+  {
+    "type": "arrow",
+    "id": "a-snap-fork-b",
+    "x": 460,
+    "y": 95,
+    "width": 0,
+    "height": 80,
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 2,
+    "strokeStyle": "dashed",
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [[0, 0], [0, 80]]
+  },
+  {
+    "type": "arrow",
+    "id": "a-snap-fork-c",
+    "x": 460,
+    "y": 95,
+    "width": 280,
+    "height": 80,
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 2,
+    "strokeStyle": "dashed",
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [[0, 0], [280, 80]]
+  },
+
+  {
+    "type": "text",
+    "id": "fork-lbl",
+    "x": 830,
+    "y": 120,
+    "text": "zero-copy fork",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#CF8E5B"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "fork-a",
+    "x": 80,
+    "y": 175,
+    "width": 200,
+    "height": 55,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "fork-a-lbl",
+    "x": 115,
+    "y": 183,
+    "text": "Fork A",
+    "fontSize": 14,
+    "fontFamily": 1,
+    "strokeColor": "#CF8E5B"
+  },
+  {
+    "type": "text",
+    "id": "fork-a-sub",
+    "x": 115,
+    "y": 205,
+    "text": "strategy A",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "fork-b",
+    "x": 360,
+    "y": 175,
+    "width": 200,
+    "height": 55,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "fork-b-lbl",
+    "x": 395,
+    "y": 183,
+    "text": "Fork B",
+    "fontSize": 14,
+    "fontFamily": 1,
+    "strokeColor": "#CF8E5B"
+  },
+  {
+    "type": "text",
+    "id": "fork-b-sub",
+    "x": 395,
+    "y": 205,
+    "text": "strategy B",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "fork-c",
+    "x": 640,
+    "y": 175,
+    "width": 200,
+    "height": 55,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "fork-c-lbl",
+    "x": 675,
+    "y": 183,
+    "text": "Fork C",
+    "fontSize": 14,
+    "fontFamily": 1,
+    "strokeColor": "#CF8E5B"
+  },
+  {
+    "type": "text",
+    "id": "fork-c-sub",
+    "x": 675,
+    "y": 205,
+    "text": "strategy C",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "arrow",
+    "id": "a-fa-results-a",
+    "x": 180,
+    "y": 230,
+    "width": 0,
+    "height": 50,
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [[0, 0], [0, 50]]
+  },
+  {
+    "type": "arrow",
+    "id": "a-fb-results-b",
+    "x": 460,
+    "y": 230,
+    "width": 0,
+    "height": 50,
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [[0, 0], [0, 50]]
+  },
+  {
+    "type": "arrow",
+    "id": "a-fc-results-c",
+    "x": 740,
+    "y": 230,
+    "width": 0,
+    "height": 50,
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [[0, 0], [0, 50]]
+  },
+
+  {
+    "type": "rectangle",
+    "id": "results-a",
+    "x": 100,
+    "y": 280,
+    "width": 160,
+    "height": 45,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5
+  },
+  {
+    "type": "text",
+    "id": "results-a-lbl",
+    "x": 130,
+    "y": 290,
+    "text": "results/",
+    "fontSize": 14,
+    "fontFamily": 1,
+    "strokeColor": "#5BA4CF"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "results-b",
+    "x": 380,
+    "y": 280,
+    "width": 160,
+    "height": 45,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5
+  },
+  {
+    "type": "text",
+    "id": "results-b-lbl",
+    "x": 410,
+    "y": 290,
+    "text": "results/",
+    "fontSize": 14,
+    "fontFamily": 1,
+    "strokeColor": "#5BA4CF"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "results-c",
+    "x": 660,
+    "y": 280,
+    "width": 160,
+    "height": 45,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5
+  },
+  {
+    "type": "text",
+    "id": "results-c-lbl",
+    "x": 690,
+    "y": 290,
+    "text": "results/",
+    "fontSize": 14,
+    "fontFamily": 1,
+    "strokeColor": "#5BA4CF"
+  },
+
+  {
+    "type": "arrow",
+    "id": "a-ra-compare",
+    "x": 180,
+    "y": 325,
+    "width": 280,
+    "height": 70,
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5,
+    "strokeStyle": "dashed",
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [[0, 0], [280, 70]]
+  },
+  {
+    "type": "arrow",
+    "id": "a-rb-compare",
+    "x": 460,
+    "y": 325,
+    "width": 0,
+    "height": 70,
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5,
+    "strokeStyle": "dashed",
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [[0, 0], [0, 70]]
+  },
+  {
+    "type": "arrow",
+    "id": "a-rc-compare",
+    "x": 740,
+    "y": 325,
+    "width": -280,
+    "height": 70,
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5,
+    "strokeStyle": "dashed",
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [[0, 0], [-280, 70]]
+  },
+
+  {
+    "type": "rectangle",
+    "id": "compare",
+    "x": 340,
+    "y": 395,
+    "width": 240,
+    "height": 55,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "compare-lbl",
+    "x": 385,
+    "y": 405,
+    "text": "Compare + Pick",
+    "fontSize": 16,
+    "fontFamily": 1,
+    "strokeColor": "#62FEB5"
+  },
+  {
+    "type": "text",
+    "id": "compare-sub",
+    "x": 385,
+    "y": 428,
+    "text": "promote winner",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "text",
+    "id": "note",
+    "x": 200,
+    "y": 475,
+    "text": "Each fork shares the baseline — you only store new writes per experiment",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  }
+]


### PR DESCRIPTION
Adds a fourth use case page under Agent Storage: experimentation with bucket
forks as isolated swimlanes.

## What's in it

- Use case page at `docs/use-cases/agent-experimentation.mdx` covering five
  patterns: prompt/model evaluation, data preparation, RAG pipeline tuning,
  rollout safety, and iterative refinement
- Excalidraw diagram showing the fork → experiment → compare → promote flow
- Sidebar entry under Agent Storage alongside Coordination, Managed Storage,
  and Sandboxes

## How it differs from Agent Sandboxes

Sandboxes give agents isolated environments to work in. Experimentation adds a
comparison and promotion step: run the same task multiple ways, score the
outputs, keep the winner. The page makes this distinction explicit and links to
the sandboxes page.