### PR TITLE
docs: add Agent Recovery use case

### DIFF
--- a/docs/use-cases/agent-recovery.mdx
+++ b/docs/use-cases/agent-recovery.mdx
@@ -140,8 +140,9 @@ tigris snapshots list agent-state
 
 # Read the thread state at a specific point in time
 # Any nanosecond timestamp works, not just named snapshots
-curl -H "X-Tigris-Snapshot-Version: 1751631910196672425" \
-  "https://t3.storage.dev/agent-state/threads/thread-42/thread.json"
+tigris objects get agent-state threads/thread-42/thread.json \
+  --snapshot 1751631910196672425 \
+  --output thread-at-that-moment.json
 ```
 
 #### Selective recovery via fork
@@ -156,7 +157,6 @@ tigris forks create agent-state clean-state
 
 # The fork has all threads at the known-good point
 # Copy unaffected threads forward from the current bucket if needed
-export AWS_ENDPOINT_URL="https://t3.storage.dev"
-aws s3 sync "s3://agent-state/threads/thread-99/" \
-  "s3://clean-state/threads/thread-99/"
+tigris cp t3://agent-state/threads/thread-99/ \
+  t3://clean-state/threads/thread-99/ -r
 ```

--- a/docs/use-cases/agent-recovery.mdx
+++ b/docs/use-cases/agent-recovery.mdx
@@ -23,9 +23,9 @@ conversation. When that happens, you need to rewind — not restart.
 any point via the append-only version log. When something goes wrong, fork from
 the last known-good snapshot and resume from there. The fork is instant and
 copy-on-write — no data is copied, and the original bucket is preserved for
-debugging. Unlike [experimentation](/docs/use-cases/agent-experimentation/),
-which compares multiple approaches side by side, recovery is about reverting a
-single agent to a previous state and continuing forward.
+debugging. Unlike experimentation, which compares multiple approaches side by
+side, recovery is about reverting a single agent to a previous state and
+continuing forward.
 
 [Snapshots and forks →](/docs/buckets/snapshots-and-forks/)
 

--- a/docs/use-cases/agent-recovery.mdx
+++ b/docs/use-cases/agent-recovery.mdx
@@ -1,0 +1,162 @@
+---
+id: agent-recovery
+title: "Agent Recovery"
+---
+
+import AgentRecoveryDiagram from "@site/src/components/diagrams/AgentRecoveryDiagram";
+import DiagramLightbox from "@site/src/components/diagrams/DiagramLightbox";
+
+# Agent Recovery
+
+## Roll back agent state to a known-good point
+
+_Snapshot before risky changes. Fork to recover. Inspect any moment in time._
+
+<div className="use-case-hero">
+  <div className="use-case-hero__text">
+
+Agents in production break. A prompt update causes hallucinations, a tool change
+corrupts downstream state, or an agent drifts from its guardrails over a long
+conversation. When that happens, you need to rewind — not restart.
+
+[Tigris snapshots](/docs/buckets/snapshots-and-forks/) capture agent state at
+any point via the append-only version log. When something goes wrong, fork from
+the last known-good snapshot and resume from there. The fork is instant and
+copy-on-write — no data is copied, and the original bucket is preserved for
+debugging. Unlike [experimentation](/docs/use-cases/agent-experimentation/),
+which compares multiple approaches side by side, recovery is about reverting a
+single agent to a previous state and continuing forward.
+
+[Snapshots and forks →](/docs/buckets/snapshots-and-forks/)
+
+  </div>
+  <div className="use-case-hero__diagram">
+    <DiagramLightbox>
+      <div className="mermaid-frame">
+        <AgentRecoveryDiagram />
+      </div>
+    </DiagramLightbox>
+  </div>
+</div>
+
+### Benefits
+
+<details>
+<summary>Instant rollback via copy-on-write fork</summary>
+
+Forking from a snapshot is an O(1) metadata operation. A 50 GB state bucket
+forks in the same time as a 50 KB one. The agent can resume from the forked
+bucket immediately while the corrupted original stays intact for post-mortem
+analysis.
+
+</details>
+
+<details>
+<summary>Append-only version history</summary>
+
+Every S3 PUT to a snapshot-enabled bucket creates a new version in the
+append-only log. You can read the state of any object at any past nanosecond
+timestamp — no need to take explicit snapshots before every change. Named
+snapshots mark significant checkpoints (pre-deploy, pre-migration) for fast
+lookup.
+
+</details>
+
+<details>
+<summary>Original state preserved for debugging</summary>
+
+The corrupted bucket is never modified during recovery. Fork and resume in the
+new bucket; inspect the old one at your own pace. When the investigation is
+done, delete it or keep it as a record.
+
+</details>
+
+<details>
+<summary>Per-object granularity</summary>
+
+Agent state stored as individual S3 objects (one object per message, per tool
+call, per config change) gives you message-level granularity in the version
+history. You can inspect or roll back a single conversation thread without
+affecting the rest of the state.
+
+</details>
+
+<details>
+<summary>Zero-cost until you write</summary>
+
+Recovery forks share all data with the source snapshot through copy-on-write.
+The fork only consumes storage for objects the recovered agent writes going
+forward. If the agent resumes a conversation and adds 10 messages to a bucket
+with 100,000 objects, you store 10 new objects.
+
+</details>
+
+### Patterns
+
+#### Automated rollback on bad deploy
+
+Snapshot the state bucket before deploying a new prompt version or model update.
+If the new version produces bad output, fork from the pre-deploy snapshot and
+point the agent at the fork.
+
+```bash
+# Snapshot before deploying
+tigris snapshots take agent-state "pre-deploy-v2.3"
+
+# Deploy new prompt version...
+# Monitor for regressions...
+
+# Something goes wrong — fork from the snapshot
+tigris forks create agent-state recovery-v2.3
+
+# Point the agent at the fork bucket and resume
+```
+
+#### Multi-agent replay
+
+When agent B depends on agent A's output and agent A produces bad state, you
+don't need to re-run the entire pipeline. Fork agent A's bucket from a
+known-good snapshot and replay agent B against it.
+
+```bash
+# Agent A's state went bad after a tool change
+# Fork from the last good snapshot
+tigris forks create agent-a-state replay-from-good
+
+# Re-run agent B against the forked bucket
+# Agent B reads from s3://replay-from-good/ instead of s3://agent-a-state/
+```
+
+#### Time-travel audit
+
+Read any object at any past point in time without taking explicit snapshots
+first. The append-only log retains every write. Pass a nanosecond timestamp via
+the `X-Tigris-Snapshot-Version` header to answer "what did the agent know at
+time T?" during incident review.
+
+```bash
+# List named snapshots to find the right timestamp
+tigris snapshots list agent-state
+
+# Read the thread state at a specific point in time
+# Any nanosecond timestamp works, not just named snapshots
+curl -H "X-Tigris-Snapshot-Version: 1751631910196672425" \
+  "https://t3.storage.dev/agent-state/threads/thread-42/thread.json"
+```
+
+#### Selective recovery via fork
+
+Fork from a pre-incident snapshot to get a clean copy of all state. The fork
+contains every thread at the known-good point. Copy forward any threads from the
+current bucket that weren't affected by the incident.
+
+```bash
+# Fork from the pre-deploy snapshot
+tigris forks create agent-state clean-state
+
+# The fork has all threads at the known-good point
+# Copy unaffected threads forward from the current bucket if needed
+export AWS_ENDPOINT_URL="https://t3.storage.dev"
+aws s3 sync "s3://agent-state/threads/thread-99/" \
+  "s3://clean-state/threads/thread-99/"
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -213,6 +213,12 @@ const sidebars = {
               label: "Agent Sandboxes",
               id: "use-cases/agent-sandboxes",
             },
+
+            {
+              type: "doc",
+              label: "Agent Recovery",
+              id: "use-cases/agent-recovery",
+            },
           ],
         },
         {

--- a/src/components/diagrams/AgentRecoveryDiagram.tsx
+++ b/src/components/diagrams/AgentRecoveryDiagram.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import ExcalidrawDiagram from "./ExcalidrawDiagram";
+import elements from "./data/agent-recovery.json";
+
+export default function AgentRecoveryDiagram() {
+  return <ExcalidrawDiagram elements={elements} />;
+}

--- a/src/components/diagrams/data/agent-recovery.json
+++ b/src/components/diagrams/data/agent-recovery.json
@@ -1,0 +1,293 @@
+[
+  {
+    "type": "text",
+    "id": "title",
+    "x": 320,
+    "y": 0,
+    "text": "Agent Recovery",
+    "fontSize": 18,
+    "fontFamily": 1,
+    "strokeColor": "#62FEB5"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "agent-state",
+    "x": 300,
+    "y": 45,
+    "width": 220,
+    "height": 55,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "agent-state-lbl",
+    "x": 335,
+    "y": 53,
+    "text": "Agent State Bucket",
+    "fontSize": 15,
+    "fontFamily": 1,
+    "strokeColor": "#62FEB5"
+  },
+  {
+    "type": "text",
+    "id": "agent-state-sub",
+    "x": 335,
+    "y": 77,
+    "text": "messages, tools, config",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "arrow",
+    "id": "a-state-snap",
+    "x": 410,
+    "y": 100,
+    "width": 0,
+    "height": 70,
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [
+      [0, 0],
+      [0, 70]
+    ]
+  },
+  {
+    "type": "text",
+    "id": "snap-lbl",
+    "x": 425,
+    "y": 120,
+    "text": "snapshot",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "checkpoint",
+    "x": 300,
+    "y": 170,
+    "width": 220,
+    "height": 55,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1.5
+  },
+  {
+    "type": "text",
+    "id": "checkpoint-lbl",
+    "x": 345,
+    "y": 178,
+    "text": "Checkpoint",
+    "fontSize": 15,
+    "fontFamily": 1,
+    "strokeColor": "#62FEB5"
+  },
+  {
+    "type": "text",
+    "id": "checkpoint-sub",
+    "x": 345,
+    "y": 202,
+    "text": "known-good state",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "arrow",
+    "id": "a-snap-bad",
+    "x": 410,
+    "y": 225,
+    "width": 0,
+    "height": 70,
+    "strokeColor": "#CF5B5B",
+    "strokeWidth": 1.5,
+    "strokeStyle": "dashed",
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [
+      [0, 0],
+      [0, 70]
+    ]
+  },
+  {
+    "type": "text",
+    "id": "bad-lbl",
+    "x": 425,
+    "y": 248,
+    "text": "bad deploy",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#CF5B5B"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "corrupted",
+    "x": 300,
+    "y": 295,
+    "width": 220,
+    "height": 55,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#CF5B5B",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "corrupted-lbl",
+    "x": 340,
+    "y": 303,
+    "text": "Corrupted State",
+    "fontSize": 15,
+    "fontFamily": 1,
+    "strokeColor": "#CF5B5B"
+  },
+  {
+    "type": "text",
+    "id": "corrupted-sub",
+    "x": 340,
+    "y": 327,
+    "text": "kept for debugging",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "arrow",
+    "id": "a-checkpoint-fork",
+    "x": 300,
+    "y": 197,
+    "width": -180,
+    "height": 200,
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 2,
+    "strokeStyle": "dashed",
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [
+      [0, 0],
+      [-180, 0],
+      [-180, 200]
+    ]
+  },
+  {
+    "type": "text",
+    "id": "fork-lbl",
+    "x": 50,
+    "y": 270,
+    "text": "zero-copy fork",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#CF8E5B"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "recovery-fork",
+    "x": 20,
+    "y": 397,
+    "width": 200,
+    "height": 55,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "fork-box-lbl",
+    "x": 55,
+    "y": 405,
+    "text": "Recovery Fork",
+    "fontSize": 15,
+    "fontFamily": 1,
+    "strokeColor": "#CF8E5B"
+  },
+  {
+    "type": "text",
+    "id": "fork-box-sub",
+    "x": 55,
+    "y": 429,
+    "text": "same data, new writes",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "arrow",
+    "id": "a-fork-resume",
+    "x": 220,
+    "y": 424,
+    "width": 160,
+    "height": 0,
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "startArrowhead": null,
+    "points": [
+      [0, 0],
+      [160, 0]
+    ]
+  },
+  {
+    "type": "text",
+    "id": "resume-lbl",
+    "x": 255,
+    "y": 400,
+    "text": "resume",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "resumed",
+    "x": 380,
+    "y": 397,
+    "width": 220,
+    "height": 55,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "resumed-lbl",
+    "x": 420,
+    "y": 405,
+    "text": "Agent Resumes",
+    "fontSize": 15,
+    "fontFamily": 1,
+    "strokeColor": "#5BA4CF"
+  },
+  {
+    "type": "text",
+    "id": "resumed-sub",
+    "x": 420,
+    "y": 429,
+    "text": "guardrails active",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  }
+]


### PR DESCRIPTION
Adds two new use case pages under Agent Storage: experimentation with bucket forks as isolated swimlanes, and recovery via snapshot-and-fork rollback.

What's in it

* Use case page at `docs/use-cases/agent-experimentation.mdx` covering five patterns: prompt/model evaluation, data preparation, RAG pipeline tuning, rollout safety, and iterative refinement
* Use case page at `docs/use-cases/agent-recovery.mdx` covering three patterns: automated rollback on bad deploy, multi-agent replay, and time-travel audit via `X-Tigris-Snapshot-Version`
* Excalidraw diagram for experimentation showing the fork → experiment → compare → promote flow
* Excalidraw diagram for recovery showing the snapshot → corruption → fork → resume flow
* Sidebar entries under Agent Storage alongside Coordination, Managed Storage, and Sandboxes