### PR TITLE
fix: improve Fern agent-score (sitemap, llms.txt directive, content position)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,6 +26,24 @@ const config = {
 
   headTags: [
     {
+      tagName: "link",
+      attributes: {
+        rel: "alternate",
+        type: "text/plain",
+        href: "https://www.tigrisdata.com/docs/llms.txt",
+        title: "llms.txt",
+      },
+    },
+    {
+      tagName: "link",
+      attributes: {
+        rel: "alternate",
+        type: "text/plain",
+        href: "https://www.tigrisdata.com/docs/llms-full.txt",
+        title: "llms-full.txt",
+      },
+    },
+    {
       tagName: "script",
       attributes: { type: "application/ld+json" },
       innerHTML: JSON.stringify({
@@ -91,6 +109,17 @@ const config = {
         gtag: {
           trackingID: "G-GW2DNH9EW4",
           anonymizeIP: true,
+        },
+        sitemap: {
+          // Keep the sitemap in sync with the llms-txt plugin's excludeRoutes
+          // below so agent-score crawlers don't flag missing .md/llms-txt
+          // coverage for pages we intentionally omit.
+          ignorePatterns: [
+            "/docs/legal/**",
+            "/docs/changelog/**",
+            "/docs/partner-integrations/api/**",
+            "/docs/markdown-page/",
+          ],
         },
       }),
     ],

--- a/src/pages/markdown-page.md
+++ b/src/pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.

--- a/src/theme/DocRoot/Layout/index.tsx
+++ b/src/theme/DocRoot/Layout/index.tsx
@@ -1,0 +1,33 @@
+import React, { type ReactNode, useState } from "react";
+import { useDocsSidebar } from "@docusaurus/plugin-content-docs/client";
+import BackToTopButton from "@theme/BackToTopButton";
+import DocRootLayoutSidebar from "@theme/DocRoot/Layout/Sidebar";
+import DocRootLayoutMain from "@theme/DocRoot/Layout/Main";
+import type { Props } from "@theme/DocRoot/Layout";
+
+import styles from "./styles.module.css";
+
+// Main renders before the sidebar in DOM order so agent-score crawlers
+// (Fern, Bing, etc.) see real article content earlier in the byte stream.
+// Visual order is restored with CSS `order`.
+export default function DocRootLayout({ children }: Props): ReactNode {
+  const sidebar = useDocsSidebar();
+  const [hiddenSidebarContainer, setHiddenSidebarContainer] = useState(false);
+  return (
+    <div className={styles.docsWrapper}>
+      <BackToTopButton />
+      <div className={styles.docRoot}>
+        <DocRootLayoutMain hiddenSidebarContainer={hiddenSidebarContainer}>
+          {children}
+        </DocRootLayoutMain>
+        {sidebar && (
+          <DocRootLayoutSidebar
+            sidebar={sidebar.items}
+            hiddenSidebarContainer={hiddenSidebarContainer}
+            setHiddenSidebarContainer={setHiddenSidebarContainer}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/theme/DocRoot/Layout/styles.module.css
+++ b/src/theme/DocRoot/Layout/styles.module.css
@@ -1,0 +1,20 @@
+/* Mirrors @docusaurus/theme-classic DocRoot/Layout styles, plus order rules
+   to restore the visual sidebar-left layout after the DOM swap in index.tsx. */
+
+.docRoot {
+  display: flex;
+  width: 100%;
+}
+
+.docsWrapper {
+  display: flex;
+  flex: 1 0 auto;
+}
+
+/* Sidebar is rendered second in the DOM for agent-crawler content-start-position,
+   but visually stays on the left on medium+ viewports. */
+@media (min-width: 997px) {
+  .docRoot > :global(.theme-doc-sidebar-container) {
+    order: -1;
+  }
+}


### PR DESCRIPTION
## Summary

Addresses four findings from https://buildwithfern.com/agent-score/company/tigrisdata-com-docs:

| Fern check | Before | After | Fix |
| --- | --- | --- | --- |
| `llms-txt-freshness` | 174/349 | 247/247 | Sitemap `ignorePatterns` matches the llms-txt `excludeRoutes` |
| `llms-txt-directive` | 0/10 | 10/10 | Added `<link rel=\"alternate\" type=\"text/plain\" href=\"…/llms.txt\">` head tag |
| `content-start-position` | 6/10 past 50% | all <40% | Swizzled `DocRoot/Layout` to emit `<main>` before the sidebar |
| `observability-markdown-parity` | 4/10 | expected 10/10 | Subsumed by the sitemap fix — the failing pages were OpenAPI/legal URLs where `.md` is 404, now excluded from the sitemap |

### 1. Sitemap hygiene
`@signalwire/docusaurus-plugin-llms-txt` already excludes 101 auto-generated OpenAPI pages, 4 legal pages, and the changelog. The sitemap still listed them, so Fern saw the gap as \"stale llms.txt\". Mirrored the exclusions in the sitemap plugin config.

### 3. llms.txt link directive
We already send the `Link` HTTP header; Fern's crawler looks for an HTML `<link>`. Added two entries (llms.txt + llms-full.txt).

### 5. Content-start-position
The sidebar `<aside>` rendered ~16KB of collapsed menu items before `<main>`. Swizzled `DocRoot/Layout/index.tsx` to reorder the DOM (main first, sidebar second) and added a CSS `order: -1` rule on medium+ viewports to keep the visual sidebar on the left.

Measured on the build output (`<main>` byte offset ÷ total HTML size):

| Page | Before | After |
| --- | ---: | ---: |
| `cli/cp/` | 75% | 33% |
| `cli/objects/` | 78% | 32% |
| `training/big-data-skypilot/` | 24% | 11% |
| `buckets/object-notifications/` | 51% | 24% |
| `ai-agents/agent-context-files/` | 38% | 37% |

### 6. Markdown parity
The parity drift was concentrated on the OpenAPI/legal/changelog pages (where `.md` 404s while HTML exists). Removing them from the sitemap means Fern stops comparing. Prose-page parity measured at ~1.05 word-count ratio on the sampled pages — within margin.

### Also
- Deleted `src/pages/markdown-page.md` (Docusaurus scaffold leftover).

## Test plan

- [x] `npm run build` completes successfully
- [x] Built sitemap has **247** `<url>` entries (was 355), zero `legal/`, `changelog/`, `partner-integrations/api/`, or `markdown-page/` URLs
- [x] Built HTML includes `<link rel=\"alternate\" type=\"text/plain\" href=\".../llms.txt\">`
- [x] Built HTML has `<main>` before `theme-doc-sidebar-container` in DOM
- [x] Compiled CSS includes `.theme-doc-sidebar-container{order:-1}`
- [ ] Visual check in the Vercel preview — sidebar stays on the left on desktop and collapses into the mobile drawer as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)