### PR TITLE
style: stack CLI setup steps vertically

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1103,21 +1103,21 @@ table td {
 .cli-setup-steps {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 16px;
+  gap: 8px;
   margin: 1.5rem 0;
 }
 
 .cli-setup-steps .step {
   border: 1px solid var(--docs-color-border);
   border-radius: 8px;
-  padding: 1.25rem;
+  padding: 0.75rem 1rem;
 }
 
 .cli-setup-steps .step-header {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.4rem;
 }
 
 .cli-setup-steps .step-number {
@@ -1142,7 +1142,7 @@ table td {
 .cli-setup-steps .step p {
   color: var(--docs-color-text-100);
   font-size: 14px;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.4rem;
 }
 
 .cli-setup-steps .step pre {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1149,6 +1149,11 @@ table td {
   margin-bottom: 0;
 }
 
+.cli-setup-steps .step > *:last-child,
+.cli-setup-steps .step .theme-code-block:last-child {
+  margin-bottom: 0;
+}
+
 /* Partner Dashboard doc: screenshot styling */
 .dashboard-screenshot {
   margin: 1.5rem 0;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1102,7 +1102,7 @@ table td {
 
 .cli-setup-steps {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: 16px;
   margin: 1.5rem 0;
 }
@@ -1147,12 +1147,6 @@ table td {
 
 .cli-setup-steps .step pre {
   margin-bottom: 0;
-}
-
-@media screen and (max-width: 768px) {
-  .cli-setup-steps {
-    grid-template-columns: 1fr;
-  }
 }
 
 /* Partner Dashboard doc: screenshot styling */


### PR DESCRIPTION
## Summary
- Change the three CLI setup step cards on `/docs/cli/` from a 3-column grid to a single full-width column so they stack vertically instead of sitting side by side.
- Remove the now-redundant `max-width: 768px` media query since the base layout is already single-column.

## Test plan
- [ ] Run `npm start` and visit `/docs/cli/`
- [ ] Confirm all three steps (Install / Run / Update) render full-width, stacked top-to-bottom
- [ ] Verify each of the NPM / Homebrew / Native tabs renders the same way
- [ ] Check layout on narrow viewport still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)