### PR TITLE
docs: update agent-shell examples for mount-all behavior

### DIFF
--- a/docs/ai/agent-shell/index.mdx
+++ b/docs/ai/agent-shell/index.mdx
@@ -77,19 +77,16 @@ Authenticate with access keys:
 
 ```
 $ configure --key tid_... --secret tsec_...
-Available buckets:
-  my-bucket
-  shared-data
+Mounted 2 bucket(s) at /. Run 'df' to list them.
 
-Mounted my-bucket at /my-bucket
-
-$ echo "hello" > greeting.txt
-$ cat greeting.txt
+/ $ ls
+my-bucket  shared-data
+/ $ cd my-bucket
+/my-bucket $ echo "hello" > greeting.txt
+/my-bucket $ cat greeting.txt
 hello
-$ ls
-greeting.txt
-$ flush
-Flushed 1 mount(s)
+/my-bucket $ flush
+Flushed 2 mount(s)
 ```
 
 Or login with your Tigris account:
@@ -102,7 +99,7 @@ Open this URL in your browser:
 Waiting for authorization... done!
 Logged in as you@example.com
 
-Mounted my-bucket at /my-bucket
+Mounted 2 bucket(s) at /. Run 'df' to list them.
 ```
 
 You can also pass credentials as flags:


### PR DESCRIPTION
## Summary

- Update interactive shell examples to reflect mount-all behavior (all buckets mounted at `/<name>`, cwd starts at `/`)

Mirrors changes in tigrisdata/agent-shell#19.

Assisted-by: Claude Opus 4.6 via Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating example output/commands to match the new default of mounting all buckets at `/` and flushing all mounts.
> 
> **Overview**
> Updates the `agent-shell` interactive shell docs to reflect the new *mount-all* behavior: after `configure`/`login`, the shell starts at `/` with multiple buckets visible (e.g., `my-bucket`, `shared-data`) and examples now show navigating into a bucket directory before writing files.
> 
> Adjusts the example `flush` output to indicate all mounts are flushed (e.g., `Flushed 2 mount(s)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb9d2820992530c37e9443a0bf2af49085ac791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->