### PR TITLE
fix: broken admonition in agent-shell docs

### DIFF
--- a/docs/ai/agent-shell/index.mdx
+++ b/docs/ai/agent-shell/index.mdx
@@ -156,8 +156,12 @@ try {
 | `organizationId`  | `string` | No\*     | Organization ID (required with token) |
 | `endpoint`        | `string` | No       | Tigris endpoint URL                   |
 
-:::note At least one auth mode is required: (accessKeyId + secretAccessKey) or
-(sessionToken + organizationId). :::
+:::note
+
+At least one auth mode is required: (accessKeyId + secretAccessKey) or
+(sessionToken + organizationId).
+
+:::
 
 ### ShellOptions
 


### PR DESCRIPTION
## Summary

- Fix `:::note` admonition syntax — closing `:::` was on the same line as content, breaking Docusaurus rendering

## Test plan

- [ ] https://www.tigrisdata.com/docs/ai/agent-shell/ renders correctly after deploy

Assisted-by: Claude Opus 4.6 via Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts Docusaurus admonition formatting; no runtime or API behavior is affected.
> 
> **Overview**
> Fixes the `:::note` admonition in `docs/ai/agent-shell/index.mdx` by moving the content and closing `:::` onto separate lines so it renders correctly in Docusaurus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit accc05415ae9b7864228996525b7c541e1337dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->