### PR TITLE
docs: add tigris buckets migrate and ls --source flag

### DIFF
--- a/docs/cli/buckets.mdx
+++ b/docs/cli/buckets.mdx
@@ -23,6 +23,7 @@ t3 b <operation> [flags]
 | [`set`](set)                             | Update bucket settings                           |
 | [`set-ttl`](set-ttl)                     | Configure object expiration (TTL)                |
 | [`set-migration`](set-migration)         | Configure data migration from an external source |
+| [`migrate`](migrate)                     | Actively migrate objects from a shadow bucket    |
 | [`set-transition`](set-transition)       | Configure lifecycle storage class transitions    |
 | [`set-notifications`](set-notifications) | Configure object event notifications             |
 | [`set-locations`](set-locations)         | Set the data locations for a bucket              |

--- a/docs/cli/buckets/migrate.mdx
+++ b/docs/cli/buckets/migrate.mdx
@@ -1,0 +1,29 @@
+# tigris buckets migrate
+
+Actively migrate all objects from a shadow bucket to Tigris by scheduling
+server-side migration for unmigrated objects. Pairs with
+[`set-migration`](set-migration), which configures the shadow source.
+
+## Usage
+
+```bash
+tigris buckets migrate <path>
+t3 b migrate <path>
+```
+
+`<path>` is a bucket name, optionally with a key prefix. When a prefix is given,
+only objects under that prefix are migrated. Paths accept the optional `t3://`
+(or `tigris://`) scheme.
+
+## Examples
+
+```bash
+# Migrate every unmigrated object in the bucket
+tigris buckets migrate my-bucket
+
+# Migrate only objects under a prefix
+tigris buckets migrate my-bucket/images/
+
+# Using the t3:// scheme
+tigris buckets migrate t3://my-bucket/prefix/
+```

--- a/docs/cli/buckets/migrate.mdx
+++ b/docs/cli/buckets/migrate.mdx
@@ -2,7 +2,7 @@
 
 Actively migrate all objects from a shadow bucket to Tigris by scheduling
 server-side migration for unmigrated objects. Pairs with
-[`set-migration`](set-migration), which configures the shadow source.
+[`set-migration`](./set-migration.mdx), which configures the shadow source.
 
 ## Usage
 

--- a/docs/cli/ls.mdx
+++ b/docs/cli/ls.mdx
@@ -15,6 +15,12 @@ t3 list [path]
 Paths support the optional `t3://` (or `tigris://`) prefix (e.g.
 `t3://my-bucket/path` or just `my-bucket/path`).
 
+## Flags
+
+| Name       | Description                                                                          |
+| ---------- | ------------------------------------------------------------------------------------ |
+| `--source` | List objects from a specific storage source on buckets with shadow migration enabled |
+
 ## Examples
 
 ```bash

--- a/docs/cli/ls.mdx
+++ b/docs/cli/ls.mdx
@@ -17,9 +17,9 @@ Paths support the optional `t3://` (or `tigris://`) prefix (e.g.
 
 ## Flags
 
-| Name       | Description                                                                          |
-| ---------- | ------------------------------------------------------------------------------------ |
-| `--source` | List objects from a specific storage source on buckets with shadow migration enabled |
+| Name       | Required | Default | Description                                                                                                                                                                                |
+| ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--source` | No       | —       | List objects from a specific storage source on buckets with shadow migration enabled. Accepted values: `tigris` (objects already in Tigris), `shadow` (objects still on the shadow source) |
 
 ## Examples
 
@@ -35,4 +35,10 @@ tigris ls my-bucket/images/
 
 # Using t3:// prefix
 tigris ls t3://my-bucket/prefix/
+
+# On a shadow-migrated bucket, list only objects still on the source
+tigris ls my-bucket --source shadow
+
+# Or only objects already migrated into Tigris
+tigris ls my-bucket --source tigris
 ```

--- a/sidebars.js
+++ b/sidebars.js
@@ -855,6 +855,7 @@ const sidebars = {
             "cli/buckets/set",
             "cli/buckets/set-ttl",
             "cli/buckets/set-migration",
+            "cli/buckets/migrate",
             "cli/buckets/set-transition",
             "cli/buckets/set-locations",
             "cli/buckets/set-notifications",


### PR DESCRIPTION
## Summary

- New page `docs/cli/buckets/migrate.mdx` for the `tigris buckets migrate` command (active shadow-bucket migration).
- Added a row in the `tigris buckets` commands table and registered the page in `sidebars.js`.
- Added a `--source` flag section to `docs/cli/ls.mdx` for reading from a specific storage source on shadow-migrated buckets.

Pairs with the CLI-side README regeneration in tigrisdata/cli.

## Test plan

- [ ] `npm run start` and verify the new page renders in the sidebar under **tigris buckets**
- [ ] Verify the link to `migrate` from `buckets.mdx` resolves
- [ ] Verify the `ls` page shows the new **Flags** section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that add a new CLI command page and describe an additional `ls` flag; no runtime behavior changes.
> 
> **Overview**
> Adds documentation for a new `tigris buckets migrate` command, including usage and examples for actively migrating objects from a shadow bucket (and linking it as a companion to `set-migration`).
> 
> Updates the `tigris buckets` command index and `sidebars.js` to surface the new `migrate` doc in navigation, and extends `tigris ls` docs with a `--source` flag to list objects specifically from `tigris` or `shadow` on shadow-migrated buckets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 684e3f857ecf5f59a0bbee4c28792bf65ccf4346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->