### PR TITLE
docs: Add Mastra integration guide

### DIFF
--- a/docs/agents/agent-flue.md
+++ b/docs/agents/agent-flue.md
@@ -1,8 +1,8 @@
 # Use Tigris with Flue
 
-[Flue](https://github.com/withastro/flue) is a TypeScript framework for
-building agents with a built-in agent harness. Its `@flue/sdk/s3` module mounts
-any S3-compatible bucket as the agent's filesystem. This page documents the
+[Flue](https://github.com/withastro/flue) is a TypeScript framework for building
+agents with a built-in agent harness. Its `@flue/sdk/s3` module mounts any
+S3-compatible bucket as the agent's filesystem. This page documents the
 configuration values for using Tigris as that bucket and shows how to compose
 the result with `@tigrisdata/agent-kit` for per-run workspaces, forks, and
 checkpoints.
@@ -31,21 +31,21 @@ explicitly when using `getS3Sandbox`.
 
 ```ts
 // .flue/agents/support.ts
-import type { FlueContext } from '@flue/sdk/client';
-import { getS3Sandbox } from '@flue/sdk/s3';
+import type { FlueContext } from "@flue/sdk/client";
+import { getS3Sandbox } from "@flue/sdk/s3";
 
 export const triggers = { webhook: true };
 
 export default async function ({ init, env, payload }: FlueContext) {
   const sandbox = await getS3Sandbox({
     bucket: env.TIGRIS_KNOWLEDGE_BASE,
-    endpoint: 'https://t3.storage.dev',
-    region: 'auto',
+    endpoint: "https://t3.storage.dev",
+    region: "auto",
     accessKeyId: env.TIGRIS_STORAGE_ACCESS_KEY_ID,
     secretAccessKey: env.TIGRIS_STORAGE_SECRET_ACCESS_KEY,
   });
 
-  const agent = await init({ sandbox, model: 'anthropic/claude-sonnet-4-6' });
+  const agent = await init({ sandbox, model: "anthropic/claude-sonnet-4-6" });
   const session = await agent.session();
 
   return await session.prompt(
@@ -53,24 +53,24 @@ export default async function ({ init, env, payload }: FlueContext) {
      articles and write a helpful response.
 
      Customer: ${payload.message}`,
-    { role: 'triager' },
+    { role: "triager" },
   );
 }
 ```
 
 The values that matter for Tigris:
 
-| Field             | Value                                  |
-| ----------------- | -------------------------------------- |
-| `endpoint`        | `https://t3.storage.dev`               |
-| `region`          | `auto`                                 |
-| `forcePathStyle`  | `false` (default; do not override)     |
-| `accessKeyId`     | `TIGRIS_STORAGE_ACCESS_KEY_ID`         |
-| `secretAccessKey` | `TIGRIS_STORAGE_SECRET_ACCESS_KEY`     |
+| Field             | Value                              |
+| ----------------- | ---------------------------------- |
+| `endpoint`        | `https://t3.storage.dev`           |
+| `region`          | `auto`                             |
+| `forcePathStyle`  | `false` (default; do not override) |
+| `accessKeyId`     | `TIGRIS_STORAGE_ACCESS_KEY_ID`     |
+| `secretAccessKey` | `TIGRIS_STORAGE_SECRET_ACCESS_KEY` |
 
 Anything Flue's `just-bash` runtime does on the agent's filesystem — `grep`,
-`find`, `cat`, the read/write/glob tools — is translated into S3 calls
-against the bucket.
+`find`, `cat`, the read/write/glob tools — is translated into S3 calls against
+the bucket.
 
 ## Per-run workspaces
 
@@ -80,29 +80,29 @@ agent run its own isolated filesystem:
 
 ```ts
 // .flue/agents/triage.ts
-import type { FlueContext } from '@flue/sdk/client';
-import { getS3Sandbox } from '@flue/sdk/s3';
-import { createWorkspace, teardownWorkspace } from '@tigrisdata/agent-kit';
+import type { FlueContext } from "@flue/sdk/client";
+import { getS3Sandbox } from "@flue/sdk/s3";
+import { createWorkspace, teardownWorkspace } from "@tigrisdata/agent-kit";
 
 export const triggers = { webhook: true };
 
 export default async function ({ init, id, payload }: FlueContext) {
   const { data: workspace, error } = await createWorkspace(`triage-${id}`, {
-    ttl: { days: 1 },                 // backstop cleanup
-    enableSnapshots: true,            // forkable later
-    credentials: { role: 'Editor' },  // bucket-scoped key
+    ttl: { days: 1 }, // backstop cleanup
+    enableSnapshots: true, // forkable later
+    credentials: { role: "Editor" }, // bucket-scoped key
   });
   if (error || !workspace) throw error;
 
   try {
     const sandbox = await getS3Sandbox({
       bucket: workspace.bucket,
-      endpoint: 'https://t3.storage.dev',
+      endpoint: "https://t3.storage.dev",
       accessKeyId: workspace.credentials!.accessKeyId,
       secretAccessKey: workspace.credentials!.secretAccessKey,
     });
 
-    const agent = await init({ sandbox, model: 'anthropic/claude-sonnet-4-6' });
+    const agent = await init({ sandbox, model: "anthropic/claude-sonnet-4-6" });
     return await agent.session().prompt(payload.message);
   } finally {
     await teardownWorkspace(workspace);
@@ -110,28 +110,28 @@ export default async function ({ init, id, payload }: FlueContext) {
 }
 ```
 
-The agent runs with credentials that can only touch its own bucket. On
-teardown the bucket and its access key are removed. If the run crashes
-before teardown executes, the TTL deletes the contents the next day.
+The agent runs with credentials that can only touch its own bucket. On teardown
+the bucket and its access key are removed. If the run crashes before teardown
+executes, the TTL deletes the contents the next day.
 
 ## Forks for parallel agents
 
-`createForks` snapshots a base bucket and produces N independent forks.
-Mount each fork as its own Flue sandbox to run variants of the same agent
-over the same dataset without copying the data:
+`createForks` snapshots a base bucket and produces N independent forks. Mount
+each fork as its own Flue sandbox to run variants of the same agent over the
+same dataset without copying the data:
 
 ```ts
-import { createForks, teardownForks } from '@tigrisdata/agent-kit';
-import { getS3Sandbox } from '@flue/sdk/s3';
+import { createForks, teardownForks } from "@tigrisdata/agent-kit";
+import { getS3Sandbox } from "@flue/sdk/s3";
 
-const variants = ['conservative', 'balanced', 'aggressive'];
+const variants = ["conservative", "balanced", "aggressive"];
 
 const { data: forkSet, error } = await createForks(
-  'rag-corpus',
+  "rag-corpus",
   variants.length,
   {
     prefix: `triage-${Date.now()}`,
-    credentials: { role: 'Editor' },
+    credentials: { role: "Editor" },
   },
 );
 if (error || !forkSet) throw error;
@@ -141,7 +141,7 @@ try {
     forkSet.forks.map(async (fork, i) => {
       const sandbox = await getS3Sandbox({
         bucket: fork.bucket,
-        endpoint: 'https://t3.storage.dev',
+        endpoint: "https://t3.storage.dev",
         accessKeyId: fork.credentials!.accessKeyId,
         secretAccessKey: fork.credentials!.secretAccessKey,
       });
@@ -149,7 +149,7 @@ try {
       const agent = await init({
         id: `variant-${i}`,
         sandbox,
-        model: 'anthropic/claude-sonnet-4-6',
+        model: "anthropic/claude-sonnet-4-6",
       });
       return agent.session().prompt(payload.prompt, { role: variants[i] });
     }),
@@ -160,22 +160,22 @@ try {
 }
 ```
 
-Forks are copy-on-write, so the source bucket pays nothing for the fan-out
-until a fork actually writes. Teardown removes all of them in one call.
+Forks are copy-on-write, so the source bucket pays nothing for the fan-out until
+a fork actually writes. Teardown removes all of them in one call.
 
 ## Checkpoints
 
-`checkpoint` records a snapshot of a bucket; `restore` forks from a
-snapshot. Use this to capture an agent's filesystem state between phases
-and reproduce it later for debugging or replay:
+`checkpoint` records a snapshot of a bucket; `restore` forks from a snapshot.
+Use this to capture an agent's filesystem state between phases and reproduce it
+later for debugging or replay:
 
 ```ts
-import { checkpoint, restore } from '@tigrisdata/agent-kit';
+import { checkpoint, restore } from "@tigrisdata/agent-kit";
 
-const { data: ckpt } = await checkpoint(workspace.bucket, { name: 'pre-edit' });
+const { data: ckpt } = await checkpoint(workspace.bucket, { name: "pre-edit" });
 
 try {
-  await session.skill('apply-edits', { args: payload });
+  await session.skill("apply-edits", { args: payload });
 } catch (err) {
   const { data: replay } = await restore(workspace.bucket, ckpt!.snapshotId, {
     forkName: `${workspace.bucket}-replay-${Date.now()}`,
@@ -183,7 +183,7 @@ try {
   // Mount the restored bucket as a fresh sandbox and re-run with logging.
   const replaySandbox = await getS3Sandbox({
     bucket: replay!.bucket,
-    endpoint: 'https://t3.storage.dev',
+    endpoint: "https://t3.storage.dev",
     accessKeyId: env.TIGRIS_STORAGE_ACCESS_KEY_ID,
     secretAccessKey: env.TIGRIS_STORAGE_SECRET_ACCESS_KEY,
   });
@@ -200,27 +200,30 @@ TIGRIS_STORAGE_ACCESS_KEY_ID=tid_...
 TIGRIS_STORAGE_SECRET_ACCESS_KEY=tsec_...
 ```
 
-Pass them to `getS3Sandbox` explicitly (as in the examples above) or build
-an `S3Client` once and pass it through the `client` option:
+Pass them to `getS3Sandbox` explicitly (as in the examples above) or build an
+`S3Client` once and pass it through the `client` option:
 
 ```ts
-import { S3Client } from '@aws-sdk/client-s3';
-import { getS3Sandbox } from '@flue/sdk/s3';
+import { S3Client } from "@aws-sdk/client-s3";
+import { getS3Sandbox } from "@flue/sdk/s3";
 
 const client = new S3Client({
-  region: 'auto',
-  endpoint: 'https://t3.storage.dev',
+  region: "auto",
+  endpoint: "https://t3.storage.dev",
   credentials: {
     accessKeyId: process.env.TIGRIS_STORAGE_ACCESS_KEY_ID!,
     secretAccessKey: process.env.TIGRIS_STORAGE_SECRET_ACCESS_KEY!,
   },
 });
 
-const sandbox = await getS3Sandbox({ bucket: 'agent-store', client });
+const sandbox = await getS3Sandbox({ bucket: "agent-store", client });
 ```
 
 ## See also
 
-- [`@flue/sdk/s3` reference](https://github.com/withastro/flue/blob/main/docs/storage-s3.md) — Flue's documentation for the underlying API.
-- [`@tigrisdata/agent-kit`](https://www.npmjs.com/package/@tigrisdata/agent-kit) — workspaces, forks, checkpoints, coordination.
-- [Snapshots and forks](/docs/forks/) — how Tigris implements copy-on-write bucket forks.
+- [`@flue/sdk/s3` reference](https://github.com/withastro/flue/blob/main/docs/storage-s3.md)
+  — Flue's documentation for the underlying API.
+- [`@tigrisdata/agent-kit`](https://www.npmjs.com/package/@tigrisdata/agent-kit)
+  — workspaces, forks, checkpoints, coordination.
+- [Snapshots and forks](/docs/forks/) — how Tigris implements copy-on-write
+  bucket forks.

--- a/docs/agents/agent-flue.md
+++ b/docs/agents/agent-flue.md
@@ -1,0 +1,226 @@
+# Use Tigris with Flue
+
+[Flue](https://github.com/withastro/flue) is a TypeScript framework for
+building agents with a built-in agent harness. Its `@flue/sdk/s3` module mounts
+any S3-compatible bucket as the agent's filesystem. This page documents the
+configuration values for using Tigris as that bucket and shows how to compose
+the result with `@tigrisdata/agent-kit` for per-run workspaces, forks, and
+checkpoints.
+
+For the full reference of the underlying Flue API, see Flue's own documentation:
+[`docs/storage-s3.md`](https://github.com/withastro/flue/blob/main/docs/storage-s3.md).
+
+## Prerequisites
+
+- A Tigris account and an access key pair (`tid_…` / `tsec_…`).
+- A bucket. Enable snapshots on it if you plan to use forks or checkpoints
+  later.
+- A Flue project (`@flue/sdk` ^0.4.0 or later — the version that ships
+  `@flue/sdk/s3`).
+
+## Install the dependencies
+
+```bash
+npm install @flue/sdk @aws-sdk/client-s3
+```
+
+`@aws-sdk/client-s3` is an optional peer dependency of Flue. Install it
+explicitly when using `getS3Sandbox`.
+
+## Mount a Tigris bucket as the agent's filesystem
+
+```ts
+// .flue/agents/support.ts
+import type { FlueContext } from '@flue/sdk/client';
+import { getS3Sandbox } from '@flue/sdk/s3';
+
+export const triggers = { webhook: true };
+
+export default async function ({ init, env, payload }: FlueContext) {
+  const sandbox = await getS3Sandbox({
+    bucket: env.TIGRIS_KNOWLEDGE_BASE,
+    endpoint: 'https://t3.storage.dev',
+    region: 'auto',
+    accessKeyId: env.TIGRIS_STORAGE_ACCESS_KEY_ID,
+    secretAccessKey: env.TIGRIS_STORAGE_SECRET_ACCESS_KEY,
+  });
+
+  const agent = await init({ sandbox, model: 'anthropic/claude-sonnet-4-6' });
+  const session = await agent.session();
+
+  return await session.prompt(
+    `You are a support agent. Search the knowledge base for relevant
+     articles and write a helpful response.
+
+     Customer: ${payload.message}`,
+    { role: 'triager' },
+  );
+}
+```
+
+The values that matter for Tigris:
+
+| Field             | Value                                  |
+| ----------------- | -------------------------------------- |
+| `endpoint`        | `https://t3.storage.dev`               |
+| `region`          | `auto`                                 |
+| `forcePathStyle`  | `false` (default; do not override)     |
+| `accessKeyId`     | `TIGRIS_STORAGE_ACCESS_KEY_ID`         |
+| `secretAccessKey` | `TIGRIS_STORAGE_SECRET_ACCESS_KEY`     |
+
+Anything Flue's `just-bash` runtime does on the agent's filesystem — `grep`,
+`find`, `cat`, the read/write/glob tools — is translated into S3 calls
+against the bucket.
+
+## Per-run workspaces
+
+`@tigrisdata/agent-kit` provisions a fresh Tigris bucket on demand, with
+optional TTL and scoped credentials. Pair it with `getS3Sandbox` to give every
+agent run its own isolated filesystem:
+
+```ts
+// .flue/agents/triage.ts
+import type { FlueContext } from '@flue/sdk/client';
+import { getS3Sandbox } from '@flue/sdk/s3';
+import { createWorkspace, teardownWorkspace } from '@tigrisdata/agent-kit';
+
+export const triggers = { webhook: true };
+
+export default async function ({ init, id, payload }: FlueContext) {
+  const { data: workspace, error } = await createWorkspace(`triage-${id}`, {
+    ttl: { days: 1 },                 // backstop cleanup
+    enableSnapshots: true,            // forkable later
+    credentials: { role: 'Editor' },  // bucket-scoped key
+  });
+  if (error || !workspace) throw error;
+
+  try {
+    const sandbox = await getS3Sandbox({
+      bucket: workspace.bucket,
+      endpoint: 'https://t3.storage.dev',
+      accessKeyId: workspace.credentials!.accessKeyId,
+      secretAccessKey: workspace.credentials!.secretAccessKey,
+    });
+
+    const agent = await init({ sandbox, model: 'anthropic/claude-sonnet-4-6' });
+    return await agent.session().prompt(payload.message);
+  } finally {
+    await teardownWorkspace(workspace);
+  }
+}
+```
+
+The agent runs with credentials that can only touch its own bucket. On
+teardown the bucket and its access key are removed. If the run crashes
+before teardown executes, the TTL deletes the contents the next day.
+
+## Forks for parallel agents
+
+`createForks` snapshots a base bucket and produces N independent forks.
+Mount each fork as its own Flue sandbox to run variants of the same agent
+over the same dataset without copying the data:
+
+```ts
+import { createForks, teardownForks } from '@tigrisdata/agent-kit';
+import { getS3Sandbox } from '@flue/sdk/s3';
+
+const variants = ['conservative', 'balanced', 'aggressive'];
+
+const { data: forkSet, error } = await createForks(
+  'rag-corpus',
+  variants.length,
+  {
+    prefix: `triage-${Date.now()}`,
+    credentials: { role: 'Editor' },
+  },
+);
+if (error || !forkSet) throw error;
+
+try {
+  const results = await Promise.all(
+    forkSet.forks.map(async (fork, i) => {
+      const sandbox = await getS3Sandbox({
+        bucket: fork.bucket,
+        endpoint: 'https://t3.storage.dev',
+        accessKeyId: fork.credentials!.accessKeyId,
+        secretAccessKey: fork.credentials!.secretAccessKey,
+      });
+
+      const agent = await init({
+        id: `variant-${i}`,
+        sandbox,
+        model: 'anthropic/claude-sonnet-4-6',
+      });
+      return agent.session().prompt(payload.prompt, { role: variants[i] });
+    }),
+  );
+  return pickBest(results);
+} finally {
+  await teardownForks(forkSet);
+}
+```
+
+Forks are copy-on-write, so the source bucket pays nothing for the fan-out
+until a fork actually writes. Teardown removes all of them in one call.
+
+## Checkpoints
+
+`checkpoint` records a snapshot of a bucket; `restore` forks from a
+snapshot. Use this to capture an agent's filesystem state between phases
+and reproduce it later for debugging or replay:
+
+```ts
+import { checkpoint, restore } from '@tigrisdata/agent-kit';
+
+const { data: ckpt } = await checkpoint(workspace.bucket, { name: 'pre-edit' });
+
+try {
+  await session.skill('apply-edits', { args: payload });
+} catch (err) {
+  const { data: replay } = await restore(workspace.bucket, ckpt!.snapshotId, {
+    forkName: `${workspace.bucket}-replay-${Date.now()}`,
+  });
+  // Mount the restored bucket as a fresh sandbox and re-run with logging.
+  const replaySandbox = await getS3Sandbox({
+    bucket: replay!.bucket,
+    endpoint: 'https://t3.storage.dev',
+    accessKeyId: env.TIGRIS_STORAGE_ACCESS_KEY_ID,
+    secretAccessKey: env.TIGRIS_STORAGE_SECRET_ACCESS_KEY,
+  });
+  await debugReplay(replaySandbox, err);
+}
+```
+
+## Configuration reference
+
+Environment variables Tigris recommends for any client using its S3 API:
+
+```env
+TIGRIS_STORAGE_ACCESS_KEY_ID=tid_...
+TIGRIS_STORAGE_SECRET_ACCESS_KEY=tsec_...
+```
+
+Pass them to `getS3Sandbox` explicitly (as in the examples above) or build
+an `S3Client` once and pass it through the `client` option:
+
+```ts
+import { S3Client } from '@aws-sdk/client-s3';
+import { getS3Sandbox } from '@flue/sdk/s3';
+
+const client = new S3Client({
+  region: 'auto',
+  endpoint: 'https://t3.storage.dev',
+  credentials: {
+    accessKeyId: process.env.TIGRIS_STORAGE_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.TIGRIS_STORAGE_SECRET_ACCESS_KEY!,
+  },
+});
+
+const sandbox = await getS3Sandbox({ bucket: 'agent-store', client });
+```
+
+## See also
+
+- [`@flue/sdk/s3` reference](https://github.com/withastro/flue/blob/main/docs/storage-s3.md) — Flue's documentation for the underlying API.
+- [`@tigrisdata/agent-kit`](https://www.npmjs.com/package/@tigrisdata/agent-kit) — workspaces, forks, checkpoints, coordination.
+- [Snapshots and forks](/docs/forks/) — how Tigris implements copy-on-write bucket forks.

--- a/docs/agents/agent-mastra.mdx
+++ b/docs/agents/agent-mastra.mdx
@@ -14,12 +14,14 @@ checkpoints, coordination — each with a matching teardown. This guide wires
 Agent Kit into a Mastra setup so every run gets an isolated bucket and,
 optionally, a writable copy of a dataset for the price of one copy._
 
-_The architecture: an **orchestrator** (your code that starts and ends each run)
-calls Agent Kit to provision storage, passes the resulting bucket and scoped
-credentials to the agent through Mastra's `RequestContext`, and tears storage
-down when the run ends. The agent itself never decides whether to provision
-storage — it just uses the storage that's there. This keeps the LLM out of
-infrastructure decisions and keeps credentials out of the prompt context._
+## The Architecture
+
+An **orchestrator** (your code that starts and ends each run) calls Agent Kit to
+provision storage, passes the resulting bucket and scoped credentials to the
+agent through Mastra's `RequestContext`, and tears storage down when the run
+ends. The agent itself never decides whether to provision storage — it just uses
+the storage that's there. This keeps the LLM out of infrastructure decisions and
+keeps credentials out of the prompt context.\_
 
 <div className="mermaid-frame">
   <AgentMastraDiagram />
@@ -339,42 +341,46 @@ Point the webhook at a Mastra server route (`registerApiRoute` from
 `@mastra/core/server`) and the next stage runs the moment a report lands in
 `reports/`.
 
-:::warning At-least-once delivery Webhook delivery is at-least-once with retries
-on `5xx`. Make the endpoint idempotent or deduplicate on the object key. :::
+:::warning At-least-once delivery
+
+Webhook delivery is at-least-once with retries on `5xx`. Make the endpoint
+idempotent or deduplicate on the object key.
+
+:::
 
 ## Production considerations
 
 _What changes when you take this past a prototype: where Mastra's Memory ends
 and Agent Kit begins, credential scoping, and partial-failure handling._
 
-**Memory vs. Agent Kit.** Mastra's `Memory` handles conversation state —
-threads, messages, working memory, semantic recall — backed by adapters like
-`@mastra/libsql` or `@mastra/postgres`. Agent Kit handles artifacts — files an
-agent produces, datasets it forks, snapshots it pins. They don't replace each
-other.
+- **Memory vs. Agent Kit.** Mastra's `Memory` handles conversation state —
+  threads, messages, working memory, semantic recall — backed by adapters like
+  `@mastra/libsql` or `@mastra/postgres`. Agent Kit handles artifacts — files an
+  agent produces, datasets it forks, snapshots it pins. They don't replace each
+  other.
 
-**Credential scoping.** Pass `credentials: { role: "Editor" }` (or `"ReadOnly"`)
-to every Agent Kit call. A leaked key then scopes the blast radius to one fork
-or one workspace, not the whole Tigris account. Because the agent only ever sees
-scoped credentials via `RequestContext`, those keys never end up in the prompt
-or chat transcript.
+- **Credential scoping.** Pass `credentials: { role: "Editor" }` (or
+  `"ReadOnly"`) to every Agent Kit call. A leaked key then scopes the blast
+  radius to one fork or one workspace, not the whole Tigris account. Because the
+  agent only ever sees scoped credentials via `RequestContext`, those keys never
+  end up in the prompt or chat transcript.
 
-**Teardown is best-effort.** `teardownForks`, `teardownWorkspace`, and
-`teardownCoordination` continue through individual failures and report every
-error in a single aggregated result. Inspect the result instead of assuming
-success. Always pair the teardown with a TTL on the workspace as a backstop in
-case the orchestrator process dies before `finally` runs.
+- **Teardown is best-effort.** `teardownForks`, `teardownWorkspace`, and
+  `teardownCoordination` continue through individual failures and report every
+  error in a single aggregated result. Inspect the result instead of assuming
+  success. Always pair the teardown with a TTL on the workspace as a backstop in
+  case the orchestrator process dies before `finally` runs.
 
-**Concurrency.** `createForks` provisions N buckets and N keys in one call. For
-very large N (hundreds), batch across calls and watch project-level bucket
-quotas.
+- **Concurrency.** `createForks` provisions N buckets and N keys in one call.
+  For very large N (hundreds), batch across calls and watch project-level bucket
+  quotas.
 
-**When to wrap Agent Kit as a tool instead.** The orchestrator pattern is the
-right default because provisioning is deterministic — every run needs storage at
-the start. Wrap an Agent Kit primitive as a Mastra tool only when the agent
-genuinely needs to make a runtime decision: "I might fork this dataset _if_ I
-discover it's too large to read in place." For the common case, keep
-provisioning out of the model.
+- **When to wrap Agent Kit as a tool instead.** The orchestrator pattern is the
+  right default because provisioning is deterministic — every run needs storage
+  at the start. Wrap an Agent Kit primitive as a Mastra tool only when the agent
+  genuinely needs to make a runtime decision: "I might fork this dataset _if_ I
+  discover it's too large to read in place." For the common case, keep
+  provisioning out of the model.
 
 ## Troubleshooting
 

--- a/docs/agents/agent-mastra.mdx
+++ b/docs/agents/agent-mastra.mdx
@@ -1,0 +1,391 @@
+---
+id: agent-mastra
+title: "Build Agents with Mastra and Tigris"
+---
+
+import AgentMastraDiagram from "@site/src/components/diagrams/AgentMastraDiagram";
+
+# Build Agents with Mastra and Tigris
+
+_Mastra is a TypeScript agent framework.
+[`@tigrisdata/agent-kit`](/docs/ai/agent-kit/) is the Tigris SDK that turns
+bucket and IAM APIs into four agent-shaped primitives — forks, workspaces,
+checkpoints, coordination — each with a matching teardown. This guide wires
+Agent Kit into a Mastra setup so every run gets an isolated bucket and,
+optionally, a writable copy of a dataset for the price of one copy._
+
+_The architecture: an **orchestrator** (your code that starts and ends each run)
+calls Agent Kit to provision storage, passes the resulting bucket and scoped
+credentials to the agent through Mastra's `RequestContext`, and tears storage
+down when the run ends. The agent itself never decides whether to provision
+storage — it just uses the storage that's there. This keeps the LLM out of
+infrastructure decisions and keeps credentials out of the prompt context._
+
+<div className="mermaid-frame">
+  <AgentMastraDiagram />
+</div>
+<div className="mermaid-caption">
+  Two paths into Tigris: the orchestrator calls Agent Kit to provision buckets
+  and credentials; the agent's tools read those values from RequestContext and
+  read or write objects directly.
+</div>
+
+## Prerequisites
+
+_Before starting: confirm Tigris credentials, Node.js, an LLM provider key, and
+(only if you'll fork a dataset) a snapshot-enabled source bucket._
+
+1. **Tigris credentials.** `TIGRIS_STORAGE_ACCESS_KEY_ID` (starts with `tid_`)
+   and `TIGRIS_STORAGE_SECRET_ACCESS_KEY` (starts with `tsec_`). Create via the
+   [Tigris Access Key guide](/docs/iam/manage-access-key/).
+2. **Node.js 20+** with `npm`, `pnpm`, or `yarn`.
+3. **LLM provider API key.** This guide uses OpenAI (`OPENAI_API_KEY`); swap for
+   any provider Mastra supports.
+4. **Source bucket with snapshots enabled** — only required for Step 7 (forks
+   and checkpoints). Create with
+   `tigris buckets create <name> --enable-snapshots`.
+
+## Step 1: Install dependencies
+
+_Installs Mastra core, the memory adapter, the OpenAI provider, Agent Kit, the
+Tigris storage SDK (for object operations from inside tools), and Zod._
+
+```bash
+npm install @mastra/core @mastra/memory @tigrisdata/agent-kit \
+  @tigrisdata/storage @ai-sdk/openai zod
+```
+
+What each package does: `@mastra/core` provides `Agent`, `createTool`, `Mastra`,
+and `RequestContext`. `@mastra/memory` is the default memory adapter.
+`@ai-sdk/openai` is one model provider — swap for `@ai-sdk/anthropic` or others.
+`@tigrisdata/agent-kit` is the SDK the orchestrator calls to provision storage.
+`@tigrisdata/storage` is the Tigris-native S3 client the agent's tools use to
+read and write objects in the workspace bucket.
+
+:::info Pre-1.0
+
+Agent Kit is published as `0.1.x`. Pin the version if you need stability.
+
+:::
+
+## Step 2: Configure environment variables
+
+_Sets the credentials Agent Kit and the model provider read from `process.env`._
+
+Create `.env` in the project root:
+
+```bash
+TIGRIS_STORAGE_ACCESS_KEY_ID=tid_YOUR_ACCESS_KEY_ID
+TIGRIS_STORAGE_SECRET_ACCESS_KEY=tsec_YOUR_SECRET_ACCESS_KEY
+OPENAI_API_KEY=sk-...
+```
+
+Mastra does not auto-load `.env`. Add `import "dotenv/config";` at the top of
+the entry file before any Mastra or Agent Kit imports.
+
+## Step 3: Define a tool that reads storage from RequestContext
+
+_The agent's tools don't provision storage — the orchestrator does that. The
+tool reads the per-run bucket and scoped credentials out of `RequestContext` and
+uses them to read or write objects in Tigris._
+
+Create `src/tools/append-note.ts`:
+
+```typescript
+import { createTool } from "@mastra/core/tools";
+import { put } from "@tigrisdata/storage";
+import { z } from "zod";
+
+export const appendNoteTool = createTool({
+  id: "append-note",
+  description:
+    "Persist a research note to the agent's workspace bucket on Tigris.",
+  inputSchema: z.object({
+    filename: z.string(),
+    content: z.string(),
+  }),
+  execute: async ({ filename, content }, context) => {
+    const bucket = context?.requestContext?.get("bucket") as string | undefined;
+    const accessKeyId = context?.requestContext?.get("accessKeyId") as
+      | string
+      | undefined;
+    const secretAccessKey = context?.requestContext?.get("secretAccessKey") as
+      | string
+      | undefined;
+    if (!bucket || !accessKeyId || !secretAccessKey) {
+      throw new Error("missing storage credentials in RequestContext");
+    }
+
+    const { data, error } = await put(`notes/${filename}`, content, {
+      config: { bucket, accessKeyId, secretAccessKey },
+    });
+    if (error) throw error;
+
+    return { written: data.path, url: data.url };
+  },
+});
+```
+
+The tool's job is to write a note. It does not know how the bucket was
+provisioned or whether it's a workspace, a fork, or a long-lived bucket — it
+just uses whatever's in `RequestContext`. Add a matching `readNoteTool`,
+`listNotesTool`, etc. as the application needs.
+
+## Step 4: Define the agent
+
+_Wires the tool into a Mastra agent. The agent's instructions tell it when to
+call `append-note`; Mastra executes the call with the live `RequestContext`._
+
+Create `src/agents/research-agent.ts`:
+
+```typescript
+import { Agent } from "@mastra/core/agent";
+import { Memory } from "@mastra/memory";
+import { openai } from "@ai-sdk/openai";
+import { appendNoteTool } from "../tools/append-note";
+
+export const researchAgent = new Agent({
+  id: "research-agent",
+  name: "Research Agent",
+  description:
+    "Researches a topic and writes intermediate notes to its workspace.",
+  instructions: `
+    You are a research agent. Use the append-note tool to persist
+    intermediate findings — one note per topic. The bucket and credentials
+    are configured for you; you do not need to ask for them.
+  `,
+  model: openai("gpt-4o-mini"),
+  tools: { appendNoteTool },
+  memory: new Memory(),
+});
+```
+
+Two storage layers now exist behind the agent: `Memory` for conversation state,
+and the workspace bucket for artifacts. They never overlap.
+
+## Step 5: Register the agent with Mastra
+
+_Mounts the agent on a `Mastra` instance so it can be served by the dev
+playground or your own server adapter._
+
+Create `src/mastra/index.ts`:
+
+```typescript
+import { Mastra } from "@mastra/core";
+import { researchAgent } from "../agents/research-agent";
+
+export const mastra = new Mastra({
+  agents: { researchAgent },
+});
+```
+
+Access elsewhere with `mastra.getAgent("researchAgent")`.
+
+## Step 6: Provision a workspace and run the agent
+
+_The orchestrator creates a workspace, hands the bucket and scoped credentials
+to the agent via `RequestContext`, runs the agent, and tears the workspace down
+— even if the run throws._
+
+Create `src/runs/research.ts`:
+
+```typescript
+import "dotenv/config";
+import { createWorkspace, teardownWorkspace } from "@tigrisdata/agent-kit";
+import { RequestContext } from "@mastra/core/request-context";
+import { mastra } from "../mastra";
+
+type RunContext = {
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+};
+
+export async function runResearch(sessionId: string, query: string) {
+  // 1. Provision the workspace bucket and a scoped Editor key.
+  const { data: workspace, error } = await createWorkspace(sessionId, {
+    ttl: { days: 1 },
+    credentials: { role: "Editor" },
+  });
+  if (error) throw error;
+  if (!workspace.credentials) {
+    await teardownWorkspace(workspace);
+    throw new Error("workspace credential mint failed");
+  }
+
+  try {
+    // 2. Hand bucket + credentials to the agent via RequestContext.
+    const ctx = new RequestContext<RunContext>();
+    ctx.set("bucket", workspace.bucket);
+    ctx.set("accessKeyId", workspace.credentials.accessKeyId);
+    ctx.set("secretAccessKey", workspace.credentials.secretAccessKey);
+
+    // 3. Run the agent. Its append-note tool reads bucket+creds from ctx.
+    const agent = mastra.getAgent("researchAgent");
+    return await agent.generate(query, { requestContext: ctx });
+  } finally {
+    // 4. Teardown is unconditional. Bucket deleted, credentials revoked.
+    await teardownWorkspace(workspace);
+  }
+}
+```
+
+The orchestrator owns the lifecycle. The agent never sees `createWorkspace` or
+`teardownWorkspace` — it only sees its own tools and a `RequestContext` that has
+bucket and credentials in it. If the run throws, the `finally` block still tears
+down the workspace.
+
+:::tip TTL is your safety net
+
+Even with the `finally` teardown, set `ttl: { days: 1 }`. If the process is
+killed before `finally` runs, Tigris will still expire the bucket's contents on
+its own.
+
+:::
+
+## Step 7: Run multiple agents on dataset forks
+
+_Same orchestrator pattern, but the orchestrator forks a dataset N times instead
+of creating an empty workspace. Each agent gets a per-fork `RequestContext`._
+
+Create `src/runs/eval.ts`:
+
+```typescript
+import "dotenv/config";
+import { createForks, teardownForks, checkpoint } from "@tigrisdata/agent-kit";
+import { RequestContext } from "@mastra/core/request-context";
+import { mastra } from "../mastra";
+
+type ForkContext = {
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  checkpointId: string;
+};
+
+export async function runEval() {
+  // 1. Pin the corpus's known-good state with a named checkpoint. This is
+  //    separate from the snapshot createForks takes internally — the fork's
+  //    snapshot is consumed when teardownForks runs, while a named checkpoint
+  //    persists indefinitely (snapshot metadata is free) so you can restore
+  //    it into a fresh debug fork later.
+  const { data: baseline, error: ckptErr } = await checkpoint("training-data", {
+    name: "pre-eval-baseline",
+  });
+  if (ckptErr) throw ckptErr;
+
+  // 2. Fork the corpus 5 times — 1× the storage cost, 5 writable copies.
+  const { data: forkSet, error: forkErr } = await createForks(
+    "training-data",
+    5,
+    { credentials: { role: "Editor" } },
+  );
+  if (forkErr) throw forkErr;
+
+  try {
+    const agent = mastra.getAgent("researchAgent");
+
+    // 3. Run one agent per fork; per-fork credentials via RequestContext.
+    await Promise.all(
+      forkSet.forks.map(async (fork) => {
+        if (!fork.credentials) return; // skip forks whose key mint failed
+
+        const ctx = new RequestContext<ForkContext>();
+        ctx.set("bucket", fork.bucket);
+        ctx.set("accessKeyId", fork.credentials.accessKeyId);
+        ctx.set("secretAccessKey", fork.credentials.secretAccessKey);
+        ctx.set("checkpointId", baseline.snapshotId);
+
+        await agent.generate(`Evaluate the dataset at ${fork.bucket}.`, {
+          requestContext: ctx,
+        });
+      }),
+    );
+  } finally {
+    // 4. Tear down every fork bucket and revoke its credentials in one call.
+    await teardownForks(forkSet);
+  }
+}
+```
+
+The baseline checkpoint persists on `training-data` after teardown — snapshot
+metadata is free. Restore it with
+`restore("training-data", baseline.snapshotId, { forkName: "debug-..." })` if a
+run produced a surprising result.
+
+## Step 8: Trigger the next stage with coordination
+
+_Optional. Fires a webhook when an agent writes to a watched prefix, so a
+downstream pipeline runs without polling._
+
+```typescript
+import { setupCoordination } from "@tigrisdata/agent-kit";
+
+await setupCoordination("eval-reports", {
+  webhookUrl: "https://orchestrator.example.com/eval-complete",
+  filter: 'WHERE `key` REGEXP "^reports/"',
+  auth: { token: process.env.WEBHOOK_SECRET },
+});
+```
+
+Point the webhook at a Mastra server route (`registerApiRoute` from
+`@mastra/core/server`) and the next stage runs the moment a report lands in
+`reports/`. Webhook delivery is at-least-once with retries on `5xx` — make the
+endpoint idempotent or deduplicate on object key.
+
+## Production considerations
+
+_What changes when you take this past a prototype: where Mastra's Memory ends
+and Agent Kit begins, credential scoping, and partial-failure handling._
+
+**Memory vs. Agent Kit.** Mastra's `Memory` handles conversation state —
+threads, messages, working memory, semantic recall — backed by adapters like
+`@mastra/libsql` or `@mastra/postgres`. Agent Kit handles artifacts — files an
+agent produces, datasets it forks, snapshots it pins. They don't replace each
+other.
+
+**Credential scoping.** Pass `credentials: { role: "Editor" }` (or `"ReadOnly"`)
+to every Agent Kit call. A leaked key then scopes the blast radius to one fork
+or one workspace, not the whole Tigris account. Because the agent only ever sees
+scoped credentials via `RequestContext`, those keys never end up in the prompt
+or chat transcript.
+
+**Teardown is best-effort.** `teardownForks`, `teardownWorkspace`, and
+`teardownCoordination` continue through individual failures and report every
+error in a single aggregated result. Inspect the result instead of assuming
+success. Always pair the teardown with a TTL on the workspace as a backstop in
+case the orchestrator process dies before `finally` runs.
+
+**Concurrency.** `createForks` provisions N buckets and N keys in one call. For
+very large N (hundreds), batch across calls and watch project-level bucket
+quotas.
+
+**When to wrap Agent Kit as a tool instead.** The orchestrator pattern is the
+right default because provisioning is deterministic — every run needs storage at
+the start. Wrap an Agent Kit primitive as a Mastra tool only when the agent
+genuinely needs to make a runtime decision: "I might fork this dataset _if_ I
+discover it's too large to read in place." For the common case, keep
+provisioning out of the model.
+
+## Troubleshooting
+
+_Symptom-to-fix for common errors._
+
+| Issue                                                       | Fix                                                                                                                                                  |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createForks` reports "snapshots not enabled"               | Enable on the source bucket: `tigris buckets create <name> --enable-snapshots`, or pass `enableSnapshots: true` when creating it.                    |
+| Workspace returned but `workspace.credentials` is undefined | IAM mint failed silently. Tear down (`teardownWorkspace`) and retry, or mint a key directly with `@tigrisdata/iam`.                                  |
+| Tool can't read Tigris credentials                          | Add `import "dotenv/config";` at the top of the entry file. Mastra does not auto-load `.env`.                                                        |
+| Agent's `append-note` tool throws "missing credentials"     | The orchestrator didn't set `accessKeyId` / `secretAccessKey` on `RequestContext`, or `agent.generate` was called without `{ requestContext: ctx }`. |
+| Webhook not firing                                          | Confirm endpoint returns `2xx` and the `filter` regex matches the keys being written. Delivery is at-least-once; expect retries.                     |
+| `createForks` returns fewer forks than requested            | Naming collision or bucket quota stopped creation partway. Tear down the partial result, vary `prefix`, or reduce `count`.                           |
+
+## References
+
+_External docs and source for both projects._
+
+- [Agent Kit documentation](/docs/ai/agent-kit/)
+- [Mastra documentation](https://mastra.ai/docs)
+- [Mastra GitHub](https://github.com/mastra-ai/mastra)
+- [`@tigrisdata/agent-kit` on npm](https://www.npmjs.com/package/@tigrisdata/agent-kit)
+- [Snapshots and forks on Tigris](/docs/buckets/snapshots-and-forks/)

--- a/docs/agents/agent-mastra.mdx
+++ b/docs/agents/agent-mastra.mdx
@@ -248,6 +248,10 @@ its own.
 _Same orchestrator pattern, but the orchestrator forks a dataset N times instead
 of creating an empty workspace. Each agent gets a per-fork `RequestContext`._
 
+A common use case is running the same dataset against different model variants
+in parallel. Each fork gives one model an isolated writable copy, so agents can
+write intermediate artifacts without colliding.
+
 Create `src/runs/eval.ts`:
 
 ```typescript
@@ -296,9 +300,12 @@ export async function runEval() {
         ctx.set("secretAccessKey", fork.credentials.secretAccessKey);
         ctx.set("checkpointId", baseline.snapshotId);
 
-        await agent.generate(`Evaluate the dataset at ${fork.bucket}.`, {
-          requestContext: ctx,
-        });
+        await agent.generate(
+          `Evaluate the dataset in ${fork.bucket} and score it for your assigned model.`,
+          {
+            requestContext: ctx,
+          },
+        );
       }),
     );
   } finally {
@@ -330,8 +337,10 @@ await setupCoordination("eval-reports", {
 
 Point the webhook at a Mastra server route (`registerApiRoute` from
 `@mastra/core/server`) and the next stage runs the moment a report lands in
-`reports/`. Webhook delivery is at-least-once with retries on `5xx` — make the
-endpoint idempotent or deduplicate on object key.
+`reports/`.
+
+:::warning At-least-once delivery Webhook delivery is at-least-once with retries
+on `5xx`. Make the endpoint idempotent or deduplicate on the object key. :::
 
 ## Production considerations
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -444,6 +444,11 @@ const sidebars = {
                 },
                 {
                   type: "doc",
+                  label: "Mastra",
+                  id: "agents/agent-mastra",
+                },
+                {
+                  type: "doc",
                   label: "Weka",
                   id: "guides/weka",
                 },

--- a/src/components/diagrams/AgentMastraDiagram.tsx
+++ b/src/components/diagrams/AgentMastraDiagram.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import ExcalidrawDiagram from "./ExcalidrawDiagram";
+import elements from "./data/agent-mastra.json";
+
+export default function AgentMastraDiagram() {
+  return <ExcalidrawDiagram elements={elements} />;
+}

--- a/src/components/diagrams/data/agent-mastra.json
+++ b/src/components/diagrams/data/agent-mastra.json
@@ -1,0 +1,331 @@
+[
+  {
+    "type": "text",
+    "id": "title",
+    "x": 280,
+    "y": 0,
+    "text": "Mastra agents + Agent Kit on Tigris",
+    "fontSize": 18,
+    "fontFamily": 1,
+    "strokeColor": "#62FEB5"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "orch-box",
+    "x": 60,
+    "y": 50,
+    "width": 320,
+    "height": 90,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "orch-lbl",
+    "x": 90,
+    "y": 65,
+    "text": "Orchestrator",
+    "fontSize": 16,
+    "fontFamily": 1,
+    "strokeColor": "#5BA4CF"
+  },
+  {
+    "type": "text",
+    "id": "orch-sub",
+    "x": 90,
+    "y": 95,
+    "text": "your code: starts and ends each run",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "arrow",
+    "id": "orch-to-agent",
+    "x": 380,
+    "y": 95,
+    "width": 100,
+    "height": 0,
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "points": [
+      [0, 0],
+      [100, 0]
+    ]
+  },
+  {
+    "type": "text",
+    "id": "ctx-lbl",
+    "x": 380,
+    "y": 65,
+    "text": "RequestContext",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "agent-box",
+    "x": 480,
+    "y": 50,
+    "width": 320,
+    "height": 90,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#5BA4CF",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "agent-lbl",
+    "x": 510,
+    "y": 65,
+    "text": "Mastra Agent",
+    "fontSize": 16,
+    "fontFamily": 1,
+    "strokeColor": "#5BA4CF"
+  },
+  {
+    "type": "text",
+    "id": "agent-sub",
+    "x": 510,
+    "y": 95,
+    "text": "instructions + tools + memory",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "arrow",
+    "id": "orch-down",
+    "x": 220,
+    "y": 140,
+    "width": 0,
+    "height": 60,
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "points": [
+      [0, 0],
+      [0, 60]
+    ]
+  },
+  {
+    "type": "text",
+    "id": "orch-down-lbl",
+    "x": 230,
+    "y": 158,
+    "text": "provision",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "arrow",
+    "id": "agent-down",
+    "x": 640,
+    "y": 140,
+    "width": 0,
+    "height": 60,
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "points": [
+      [0, 0],
+      [0, 60]
+    ]
+  },
+  {
+    "type": "text",
+    "id": "agent-down-lbl",
+    "x": 650,
+    "y": 158,
+    "text": "tool calls",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "ak-box",
+    "x": 60,
+    "y": 200,
+    "width": 320,
+    "height": 110,
+    "backgroundColor": "#0e1920",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "ak-lbl",
+    "x": 90,
+    "y": 215,
+    "text": "Agent Kit",
+    "fontSize": 16,
+    "fontFamily": 1,
+    "strokeColor": "#CF8E5B"
+  },
+  {
+    "type": "text",
+    "id": "ak-sub1",
+    "x": 90,
+    "y": 245,
+    "text": "createWorkspace · createForks",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+  {
+    "type": "text",
+    "id": "ak-sub2",
+    "x": 90,
+    "y": 268,
+    "text": "checkpoint · setupCoordination",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+  {
+    "type": "text",
+    "id": "ak-sub3",
+    "x": 90,
+    "y": 290,
+    "text": "+ matching teardowns",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "rectangle",
+    "id": "tools-box",
+    "x": 480,
+    "y": 200,
+    "width": 320,
+    "height": 110,
+    "backgroundColor": "#0e1920",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#CF8E5B",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "tools-lbl",
+    "x": 510,
+    "y": 215,
+    "text": "Application tools",
+    "fontSize": 16,
+    "fontFamily": 1,
+    "strokeColor": "#CF8E5B"
+  },
+  {
+    "type": "text",
+    "id": "tools-sub1",
+    "x": 510,
+    "y": 245,
+    "text": "read bucket + scoped key",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+  {
+    "type": "text",
+    "id": "tools-sub2",
+    "x": 510,
+    "y": 268,
+    "text": "from RequestContext",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+  {
+    "type": "text",
+    "id": "tools-sub3",
+    "x": 510,
+    "y": 290,
+    "text": "via @tigrisdata/storage",
+    "fontSize": 12,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  },
+
+  {
+    "type": "arrow",
+    "id": "ak-to-tigris",
+    "x": 220,
+    "y": 310,
+    "width": 0,
+    "height": 50,
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "points": [
+      [0, 0],
+      [0, 50]
+    ]
+  },
+  {
+    "type": "arrow",
+    "id": "tools-to-tigris",
+    "x": 640,
+    "y": 310,
+    "width": 0,
+    "height": 50,
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "points": [
+      [0, 0],
+      [0, 50]
+    ]
+  },
+
+  {
+    "type": "rectangle",
+    "id": "tigris",
+    "x": 60,
+    "y": 360,
+    "width": 740,
+    "height": 90,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "roundness": { "type": 3 },
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 2
+  },
+  {
+    "type": "text",
+    "id": "tigris-lbl",
+    "x": 290,
+    "y": 375,
+    "text": "Tigris Object Storage",
+    "fontSize": 16,
+    "fontFamily": 1,
+    "strokeColor": "#62FEB5"
+  },
+  {
+    "type": "text",
+    "id": "tigris-sub",
+    "x": 195,
+    "y": 405,
+    "text": "buckets  ·  scoped IAM keys  ·  snapshots  ·  object notifications",
+    "fontSize": 13,
+    "fontFamily": 1,
+    "strokeColor": "#8fa3b0"
+  }
+]


### PR DESCRIPTION
[PREVIEW
](https://tigris-os-docs-git-myriel-mastra-agents-tigrisdata.vercel.app/docs/agents/agent-mastra/)
Adds a new docs page at docs/agents/agent-mastra.mdx walking developers through using @tigrisdata/agent-kit with Mastra, the TypeScript agent framework.

The guide uses the orchestrator pattern end-to-end: your code calls Agent Kit to provision a workspace (or fork a dataset), hands the resulting bucket and scoped credentials to the agent through Mastra's RequestContext, runs the agent, and tears storage down — even if the run throws. This keeps the LLM out of infrastructure decisions and keeps credentials out of the prompt context.

Eight steps cover install through cleanup, including a single-agent workspace example, a multi-agent eval pattern that forks a dataset 5× for parallel runs, and an optional coordination section that fires a webhook when an agent writes to a watched prefix. 