### PR TITLE
docs: add DuckLake guide

### DIFF
--- a/docs/quickstarts/duckdb.mdx
+++ b/docs/quickstarts/duckdb.mdx
@@ -8,10 +8,12 @@ queries. Tigris dynamically distributes your data based on access patterns and
 handles lots of small files efficiently, enabling additional performance gains
 while using DuckDB.
 
-Tigris is also compatible with [DuckLake](https://github.com/duckdb/ducklake), a
-lakehouse format that simplifies lakehouses by using a standard SQL database for
-all metadata, instead of complex file-based systems, while still storing data in
-open formats like Parquet, in object storage.
+If you want a full SQL lakehouse on top of Tigris — with tables, transactions,
+snapshots, and time travel rather than ad-hoc queries against files in a bucket
+— see the [DuckLake guide](./ducklake.mdx).
+[DuckLake](https://github.com/duckdb/ducklake) stores data as Parquet files in
+your bucket and metadata in a separate SQL database, so you get an open
+lakehouse without the file-based-catalog complexity of Iceberg or Delta.
 
 ## Prerequisites
 

--- a/docs/quickstarts/ducklake.mdx
+++ b/docs/quickstarts/ducklake.mdx
@@ -1,0 +1,257 @@
+import DuckLakeArchitectureDiagram from "@site/src/components/diagrams/DuckLakeArchitectureDiagram";
+
+# Build a lakehouse with DuckLake on Tigris
+
+[DuckLake](https://ducklake.select/) is an open lakehouse format that stores
+table metadata in a SQL database and table data as Parquet files in object
+storage. Pair it with Tigris and you get a globally distributed, S3-compatible
+storage layer with no egress fees — so the run-anywhere promise of a separated
+catalog and storage actually pays off. DuckLake handles concurrent writes
+through the catalog database (Postgres, MySQL, SQLite, or an embedded DuckDB
+file), so you don't need DynamoDB or another coordination service the way
+Iceberg or Delta on plain S3 do.
+
+Tigris also handles small-file workloads efficiently, which matters for
+DuckLake: every `INSERT` writes a new Parquet file, so a busy lake produces a
+lot of small objects.
+
+## How DuckLake fits together
+
+The mental model worth holding onto: DuckLake splits a lakehouse into two
+pieces. A SQL database keeps the bookkeeping — what tables exist, what columns
+they have, which Parquet files belong to which snapshot. A bucket holds the
+actual data as immutable Parquet files. Your DuckDB process reads from both at
+query time and writes to both when you change anything.
+
+<div className="mermaid-frame">
+  <DuckLakeArchitectureDiagram />
+</div>
+
+The catalog and the bucket are independent: you can swap Postgres for SQLite
+without touching the data, or move the data between buckets without touching the
+catalog (assuming the paths still match).
+
+## Prerequisites
+
+Before you start, make sure you have credentials for Tigris, a bucket to write
+into, and a recent DuckDB on your machine. The catalog database is optional for
+local hacking but required if more than one process needs to write.
+
+You'll need:
+
+- A Tigris **Access Key ID** and **Secret Access Key**. Create one with the
+  [Access Key guide](https://www.tigrisdata.com/docs/iam/manage-access-key/) if
+  you don't have credentials yet.
+- A Tigris **bucket** to hold your Parquet files.
+- [DuckDB](https://duckdb.org/docs/installation/) v1.3 or newer installed
+  locally.
+- Optional: a Postgres database if you want to share the lake across machines.
+  For local experimentation you can skip this and use a DuckDB metadata file.
+
+## Install the DuckLake extension
+
+DuckLake ships as a DuckDB extension. You install it once per DuckDB instance,
+then load it at the start of every session.
+
+Open the DuckDB shell:
+
+```sql
+INSTALL ducklake;
+LOAD ducklake;
+```
+
+The extension ships with recent DuckDB releases. If you want the latest
+development build, use `FORCE INSTALL ducklake FROM core_nightly` instead.
+
+## Configure DuckDB to talk to Tigris
+
+DuckDB needs an S3 secret so it can read and write Parquet files in your bucket.
+Persistent secrets survive across DuckDB sessions, so you only do this once per
+machine.
+
+```sql
+CREATE OR REPLACE PERSISTENT SECRET tigris
+  (      TYPE  s3
+  ,  PROVIDER  config
+  ,    KEY_ID  'tid_access_key_id'
+  ,    SECRET  'tsec_secret_access_key'
+  ,    REGION  'auto'
+  ,  ENDPOINT  't3.storage.dev'
+  , URL_STYLE  'vhost'
+  );
+```
+
+Replace the key ID and secret with your own. The same secret works for every
+DuckLake you attach against Tigris.
+
+## Attach a DuckLake
+
+Attaching a DuckLake tells DuckDB where the catalog lives and where to put the
+Parquet files. You have two reasonable choices for the catalog: a local DuckDB
+file (great for one-machine work), or a shared Postgres database (necessary once
+a second process needs to write). The data path stays the same in both cases — a
+prefix in your Tigris bucket.
+
+### Option 1: local DuckDB metadata (single-machine development)
+
+Use this when you're hacking on a laptop and nobody else needs to write to the
+lake. The metadata file lives next to your DuckDB shell; the data lives in
+Tigris.
+
+```sql
+ATTACH 'ducklake:metadata.ducklake' AS my_lake
+  ( DATA_PATH 's3://my-bucket/lake/'
+  );
+
+USE my_lake;
+```
+
+### Option 2: Postgres metadata (shared, production)
+
+Use this when more than one machine needs to write to the lake — Lambda
+functions, multiple developers, scheduled jobs across regions. The Postgres
+database becomes the coordination point for concurrent writers.
+
+```sql
+INSTALL postgres;
+LOAD postgres;
+
+ATTACH 'ducklake:postgres:dbname=lake host=db.example.com user=lake password=...'
+  AS my_lake
+  ( DATA_PATH 's3://my-bucket/lake/'
+  );
+
+USE my_lake;
+```
+
+DuckLake creates its bookkeeping tables (`ducklake_table`, `ducklake_snapshot`,
+`ducklake_data_file`, etc.) the first time you attach. For other catalog options
+— MySQL, SQLite, MotherDuck — see
+[Choosing a Catalog Database](https://ducklake.select/docs/stable/duckdb/usage/choosing_a_catalog_database).
+
+## Create a table and insert data
+
+Once attached, DuckLake tables behave like normal SQL tables. Create them with
+`CREATE TABLE`, write to them with `INSERT`, query them with `SELECT`. Behind
+the scenes each write produces a new Parquet file in your bucket and a new
+snapshot row in the catalog.
+
+```sql
+CREATE TABLE my_lake.events
+  ( id          INTEGER NOT NULL
+  , user_id     INTEGER NOT NULL
+  , action      VARCHAR NOT NULL
+  , created_at  TIMESTAMP NOT NULL
+  );
+
+INSERT INTO my_lake.events VALUES
+  (1, 1337, 'CreateDocument', '2026-04-28 09:00:00'),
+  (2, 1337, 'OpenDocument',   '2026-04-28 09:01:00');
+
+SELECT * FROM my_lake.events;
+```
+
+Each `INSERT` writes a new Parquet file under
+`s3://my-bucket/lake/main/events/`. The Parquet files are immutable; DuckLake
+never rewrites them.
+
+## Query data already in Tigris
+
+If raw data is already sitting in your bucket as JSON, CSV, or Parquet, you can
+pull it into a DuckLake table without first copying it locally. The same
+`READ_*` functions that query files in place also work as a source for `INSERT`.
+
+```sql
+CREATE TABLE my_lake.telemetry
+  ( created_at  TIMESTAMP NOT NULL
+  , user_id     INTEGER NOT NULL
+  , action      VARCHAR NOT NULL
+  , metadata    MAP(VARCHAR, VARCHAR)
+  );
+
+INSERT INTO my_lake.telemetry
+  ( created_at, user_id, action, metadata )
+SELECT *
+FROM READ_JSON
+  ( 's3://my-bucket/raw-events/**/*.jsonl'
+  , columns =
+    { created_at: 'TIMESTAMP NOT NULL'
+    , user_id:    'INTEGER NOT NULL'
+    , action:     'VARCHAR NOT NULL'
+    , metadata:   'MAP(VARCHAR, VARCHAR)'
+    }
+  , format = 'nd'
+  );
+```
+
+## Time travel with snapshots
+
+Because Parquet files are never overwritten, every past version of every table
+is still on disk. DuckLake records each write as a snapshot in the catalog, so
+you can query the lake as it looked at any past moment without restoring from
+backups.
+
+List the snapshots:
+
+```sql
+FROM ducklake_snapshots('my_lake');
+```
+
+Query a single table at a previous version:
+
+```sql
+SELECT * FROM my_lake.events AT (VERSION => 4);
+```
+
+Attach the entire database at a previous version, useful for forking a timeline
+locally:
+
+```sql
+ATTACH 'ducklake:metadata.ducklake' AS my_lake_past
+  ( DATA_PATH 's3://my-bucket/lake/'
+  , SNAPSHOT_VERSION 4
+  );
+```
+
+Time travel costs nothing extra — you're just asking the catalog for an older
+view of the same files that are already in your bucket.
+
+## Schema evolution
+
+You can add or drop columns without rewriting the underlying Parquet files.
+DuckLake records the schema change as a snapshot, and reads of older snapshots
+still see the old shape.
+
+```sql
+ALTER TABLE my_lake.events ADD COLUMN session_id VARCHAR;
+```
+
+Reads of the current snapshot see the new column; reads of older snapshots see
+the schema as it was then.
+
+## Read-only access
+
+When a process should be able to read the lake but never modify it — a
+dashboard, an agent running with reduced privileges, a spot-instance worker —
+attach in read-only mode.
+
+```sql
+ATTACH 'ducklake:metadata.ducklake' AS my_lake_ro
+  ( DATA_PATH 's3://my-bucket/lake/'
+  , READ_ONLY
+  );
+```
+
+Any `INSERT`, `UPDATE`, `DELETE`, or `ALTER` against `my_lake_ro` will fail with
+a clear error rather than mutating the lake.
+
+## Further reading
+
+- [Get your data ducks in a row with DuckLake](https://www.tigrisdata.com/blog/ducklake/)
+  — why DuckLake matters, with a longer walkthrough.
+- [Data Time Travel with DuckLake and Tigris](https://www.tigrisdata.com/blog/ducklake-time-travel/)
+  — using snapshots to roll back changes and fork timelines.
+- [DuckDB on Tigris](https://www.tigrisdata.com/docs/quickstarts/duckdb/) — for
+  ad-hoc queries against files in a bucket without setting up a lakehouse.
+- [DuckLake usage guide](https://ducklake.select/docs/stable/duckdb/introduction)
+  —

--- a/docs/quickstarts/ducklake.mdx
+++ b/docs/quickstarts/ducklake.mdx
@@ -254,4 +254,4 @@ a clear error rather than mutating the lake.
 - [DuckDB on Tigris](https://www.tigrisdata.com/docs/quickstarts/duckdb/) — for
   ad-hoc queries against files in a bucket without setting up a lakehouse.
 - [DuckLake usage guide](https://ducklake.select/docs/stable/duckdb/introduction)
-  —
+  — the official DuckLake docs covering all catalog options and advanced features.

--- a/docs/quickstarts/ducklake.mdx
+++ b/docs/quickstarts/ducklake.mdx
@@ -254,4 +254,5 @@ a clear error rather than mutating the lake.
 - [DuckDB on Tigris](https://www.tigrisdata.com/docs/quickstarts/duckdb/) — for
   ad-hoc queries against files in a bucket without setting up a lakehouse.
 - [DuckLake usage guide](https://ducklake.select/docs/stable/duckdb/introduction)
-  — the official DuckLake docs covering all catalog options and advanced features.
+  — the official DuckLake docs covering all catalog options and advanced
+  features.

--- a/sidebars.js
+++ b/sidebars.js
@@ -467,6 +467,11 @@ const sidebars = {
                 },
                 {
                   type: "doc",
+                  label: "DuckLake",
+                  id: "quickstarts/ducklake",
+                },
+                {
+                  type: "doc",
                   label: "Databricks",
                   id: "libraries/databricks/index",
                 },

--- a/src/components/diagrams/DuckLakeArchitectureDiagram.tsx
+++ b/src/components/diagrams/DuckLakeArchitectureDiagram.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import ExcalidrawDiagram from "./ExcalidrawDiagram";
+import elements from "./data/ducklake-architecture.json";
+
+export default function DuckLakeArchitectureDiagram() {
+  return <ExcalidrawDiagram elements={elements} />;
+}

--- a/src/components/diagrams/DuckLakeArchitectureDiagram.tsx
+++ b/src/components/diagrams/DuckLakeArchitectureDiagram.tsx
@@ -1,7 +1,212 @@
 import React from "react";
-import ExcalidrawDiagram from "./ExcalidrawDiagram";
-import elements from "./data/ducklake-architecture.json";
+
+const STYLES = `
+  .dl text { font-family: "Hanken Grotesk", system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .dl .title { font-size: 22px; fill: #c8d6de; font-weight: 600; }
+  .dl .subtitle { font-size: 14px; fill: #94a3b8; }
+  .dl .zone-title { font-size: 18px; fill: #62FEB5; font-weight: 600; }
+  .dl .zone-sub { font-size: 13px; fill: #94a3b8; }
+  .dl .node-label { font-size: 16px; fill: #e2e8f0; font-weight: 600; }
+  .dl .node-sub { font-size: 13px; fill: #94a3b8; }
+  .dl .arrow-label { font-size: 15px; fill: #c8d6de; font-weight: 600; }
+  .dl .arrow-sub { font-size: 12px; fill: #8fa3b0; font-style: italic; }
+  .dl .bullet { font-size: 15px; fill: #e2e8f0; }
+  .dl .annotation { font-size: 13px; fill: #8fa3b0; font-style: italic; }
+  .dl .node { fill: #142229; stroke: #2a4050; stroke-width: 1.5; }
+  .dl .zone-catalog { fill: #142229; stroke: #2a4050; stroke-width: 1.5; }
+  .dl .zone-tigris { fill: #142229; stroke: #62FEB5; stroke-width: 1.5; stroke-opacity: 0.7; }
+  .dl .parquet { fill: rgba(98, 254, 181, 0.08); stroke: rgba(98, 254, 181, 0.55); stroke-width: 1.25; }
+`;
 
 export default function DuckLakeArchitectureDiagram() {
-  return <ExcalidrawDiagram elements={elements} />;
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 960 520"
+      width="100%"
+      style={{ background: "transparent" }}
+      className="dl"
+    >
+      <style>{STYLES}</style>
+      <defs>
+        <marker
+          id="dl-arrow"
+          markerWidth="10"
+          markerHeight="10"
+          refX="9"
+          refY="5"
+          orient="auto"
+        >
+          <path d="M0,0 L10,5 L0,10 Z" fill="#62FEB5" />
+        </marker>
+      </defs>
+
+      {/* Header */}
+      <text x="480" y="34" textAnchor="middle" className="title">
+        DuckLake on Tigris
+      </text>
+      <text x="480" y="58" textAnchor="middle" className="subtitle">
+        SQL catalog for metadata · object storage for data
+      </text>
+
+      {/* DuckDB process node */}
+      <rect
+        x="370"
+        y="84"
+        width="220"
+        height="84"
+        rx="10"
+        ry="10"
+        className="node"
+      />
+      <text x="480" y="118" textAnchor="middle" className="node-label">
+        DuckDB process
+      </text>
+      <text x="480" y="142" textAnchor="middle" className="node-sub">
+        laptop · Lambda · CI
+      </text>
+
+      {/* Arrow to catalog (metadata) */}
+      <line
+        x1="430"
+        y1="172"
+        x2="245"
+        y2="238"
+        stroke="#62FEB5"
+        strokeWidth="2"
+        markerEnd="url(#dl-arrow)"
+      />
+      <text x="200" y="215" textAnchor="middle" className="arrow-label">
+        metadata
+      </text>
+
+      {/* Arrow to bucket (data) */}
+      <line
+        x1="530"
+        y1="172"
+        x2="715"
+        y2="238"
+        stroke="#62FEB5"
+        strokeWidth="2"
+        markerEnd="url(#dl-arrow)"
+      />
+      <text x="760" y="215" textAnchor="middle" className="arrow-label">
+        data
+      </text>
+
+      {/* Catalog database zone */}
+      <rect
+        x="40"
+        y="234"
+        width="400"
+        height="252"
+        rx="12"
+        ry="12"
+        className="zone-catalog"
+      />
+      <text x="240" y="268" textAnchor="middle" className="zone-title">
+        Catalog database
+      </text>
+      <text x="240" y="290" textAnchor="middle" className="zone-sub">
+        Postgres · DuckDB file · MySQL · SQLite
+      </text>
+
+      <g transform="translate(80, 320)">
+        <circle cx="0" cy="0" r="4" fill="#62FEB5" />
+        <text x="16" y="5" className="bullet">
+          tables and schemas
+        </text>
+      </g>
+      <g transform="translate(80, 355)">
+        <circle cx="0" cy="0" r="4" fill="#62FEB5" />
+        <text x="16" y="5" className="bullet">
+          snapshots (versions of the lake)
+        </text>
+      </g>
+      <g transform="translate(80, 390)">
+        <circle cx="0" cy="0" r="4" fill="#62FEB5" />
+        <text x="16" y="5" className="bullet">
+          file references
+        </text>
+      </g>
+
+      <text x="240" y="455" textAnchor="middle" className="annotation">
+        Coordinates concurrent writers
+      </text>
+
+      {/* Tigris bucket zone */}
+      <rect
+        x="520"
+        y="234"
+        width="400"
+        height="252"
+        rx="12"
+        ry="12"
+        className="zone-tigris"
+      />
+      <text x="720" y="268" textAnchor="middle" className="zone-title">
+        Tigris bucket
+      </text>
+      <text x="720" y="290" textAnchor="middle" className="zone-sub">
+        s3://my-bucket/lake/
+      </text>
+
+      <rect
+        x="548"
+        y="320"
+        width="112"
+        height="96"
+        rx="10"
+        ry="10"
+        className="parquet"
+      />
+      <text x="604" y="356" textAnchor="middle" className="node-label">
+        Parquet
+      </text>
+      <text x="604" y="378" textAnchor="middle" className="node-sub">
+        snap 1
+      </text>
+
+      <rect
+        x="668"
+        y="320"
+        width="112"
+        height="96"
+        rx="10"
+        ry="10"
+        className="parquet"
+      />
+      <text x="724" y="356" textAnchor="middle" className="node-label">
+        Parquet
+      </text>
+      <text x="724" y="378" textAnchor="middle" className="node-sub">
+        snap 2
+      </text>
+
+      <rect
+        x="788"
+        y="320"
+        width="112"
+        height="96"
+        rx="10"
+        ry="10"
+        className="parquet"
+      />
+      <text x="844" y="356" textAnchor="middle" className="node-label">
+        Parquet
+      </text>
+      <text x="844" y="378" textAnchor="middle" className="node-sub">
+        snap 3
+      </text>
+
+      <text x="720" y="455" textAnchor="middle" className="annotation">
+        Immutable — written, never rewritten
+      </text>
+
+      {/* Footnote */}
+      <text x="480" y="508" textAnchor="middle" className="subtitle">
+        Each INSERT writes one new Parquet file and one new snapshot row.
+      </text>
+    </svg>
+  );
 }

--- a/src/components/diagrams/data/ducklake-architecture.json
+++ b/src/components/diagrams/data/ducklake-architecture.json
@@ -1,0 +1,195 @@
+[
+  {
+    "type": "rectangle",
+    "id": "client",
+    "x": 240,
+    "y": 40,
+    "width": 240,
+    "height": 80,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "strokeColor": "#2a4050",
+    "strokeWidth": 1.2,
+    "roundness": { "type": 3 },
+    "label": {
+      "text": "DuckDB process\n(laptop · Lambda · CI)",
+      "fontSize": 18,
+      "color": "#c8d6de"
+    }
+  },
+  {
+    "type": "arrow",
+    "id": "a_client_catalog",
+    "x": 320,
+    "y": 120,
+    "width": -140,
+    "height": 100,
+    "points": [
+      [0, 0],
+      [-140, 100]
+    ],
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "label": { "text": "metadata", "fontSize": 16, "color": "#c8d6de" }
+  },
+  {
+    "type": "arrow",
+    "id": "a_client_tigris",
+    "x": 400,
+    "y": 120,
+    "width": 140,
+    "height": 100,
+    "points": [
+      [0, 0],
+      [140, 100]
+    ],
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1.5,
+    "endArrowhead": "arrow",
+    "label": { "text": "data", "fontSize": 16, "color": "#c8d6de" }
+  },
+  {
+    "type": "rectangle",
+    "id": "catalog",
+    "x": 40,
+    "y": 220,
+    "width": 280,
+    "height": 220,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "strokeColor": "#2a4050",
+    "strokeWidth": 1.2,
+    "roundness": { "type": 3 }
+  },
+  {
+    "type": "text",
+    "id": "catalogTitle",
+    "x": 60,
+    "y": 240,
+    "text": "Catalog database",
+    "fontSize": 18,
+    "strokeColor": "#c8d6de"
+  },
+  {
+    "type": "text",
+    "id": "catalogSub",
+    "x": 60,
+    "y": 274,
+    "text": "Postgres · DuckDB file\nMySQL · SQLite",
+    "fontSize": 14,
+    "strokeColor": "#8fa3b0"
+  },
+  {
+    "type": "text",
+    "id": "catalogList",
+    "x": 60,
+    "y": 340,
+    "text": "tables and schemas\nsnapshots\nfile references",
+    "fontSize": 15,
+    "strokeColor": "#62FEB5"
+  },
+  {
+    "type": "rectangle",
+    "id": "tigris",
+    "x": 400,
+    "y": 220,
+    "width": 280,
+    "height": 220,
+    "backgroundColor": "#101c24",
+    "fillStyle": "solid",
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1.2,
+    "roundness": { "type": 3 }
+  },
+  {
+    "type": "text",
+    "id": "tigrisTitle",
+    "x": 420,
+    "y": 240,
+    "text": "Tigris bucket",
+    "fontSize": 18,
+    "strokeColor": "#62FEB5"
+  },
+  {
+    "type": "text",
+    "id": "tigrisPath",
+    "x": 420,
+    "y": 274,
+    "text": "s3://my-bucket/lake/",
+    "fontSize": 14,
+    "strokeColor": "#8fa3b0"
+  },
+  {
+    "type": "rectangle",
+    "id": "parq1",
+    "x": 420,
+    "y": 320,
+    "width": 78,
+    "height": 100,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1,
+    "roundness": { "type": 3 },
+    "label": {
+      "text": "Parquet\nsnap 1",
+      "fontSize": 14,
+      "color": "#c8d6de"
+    }
+  },
+  {
+    "type": "rectangle",
+    "id": "parq2",
+    "x": 511,
+    "y": 320,
+    "width": 78,
+    "height": 100,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1,
+    "roundness": { "type": 3 },
+    "label": {
+      "text": "Parquet\nsnap 2",
+      "fontSize": 14,
+      "color": "#c8d6de"
+    }
+  },
+  {
+    "type": "rectangle",
+    "id": "parq3",
+    "x": 602,
+    "y": 320,
+    "width": 78,
+    "height": 100,
+    "backgroundColor": "#142229",
+    "fillStyle": "solid",
+    "strokeColor": "#62FEB5",
+    "strokeWidth": 1,
+    "roundness": { "type": 3 },
+    "label": {
+      "text": "Parquet\nsnap 3",
+      "fontSize": 14,
+      "color": "#c8d6de"
+    }
+  },
+  {
+    "type": "text",
+    "id": "annotation1",
+    "x": 40,
+    "y": 470,
+    "text": "Every INSERT, UPDATE, or DELETE writes a new immutable Parquet",
+    "fontSize": 14,
+    "strokeColor": "#8fa3b0"
+  },
+  {
+    "type": "text",
+    "id": "annotation2",
+    "x": 40,
+    "y": 492,
+    "text": "file in Tigris and a new snapshot row in the catalog.",
+    "fontSize": 14,
+    "strokeColor": "#8fa3b0"
+  }
+]


### PR DESCRIPTION
Adds a guide for running a DuckLake lakehouse on Tigris. Sits next
to the DuckDB quickstart under Guides → Integrations → Data &
Analytics.

Covers install, the S3 secret, attaching with either local DuckDB
or Postgres metadata, reads and writes, time travel, schema
evolution, and read-only mounts. Each section opens with a short
explanation in plain English; the SQL underneath is copy-pasteable.

Includes a small architecture diagram showing the catalog/data
split, in the same style as the existing diagrams.

Also fixes a stale link in the DuckDB quickstart
(iam/create-access-key → iam/manage-access-key) and points it at
the new guide instead of GitHub.
