### PR TITLE
docs: support multiple lifecycle and expiration rules per bucket

### DIFF
--- a/docs/buckets/object-lifecycle-rules.md
+++ b/docs/buckets/object-lifecycle-rules.md
@@ -3,10 +3,10 @@
 As your data storage needs evolve, you may want to optimize costs by moving less
 frequently accessed objects to more cost-effective storage tiers. Tigris
 provides object lifecycle rules to automatically move objects between storage
-tiers. For example, you might want to move older log files or archived data to
-a lower-cost storage tier while keeping frequently accessed data in the
-standard tier. This helps to maintain optimal performance for active data while
-reducing storage costs for infrequently accessed objects.
+tiers. For example, you might want to move older log files or archived data to a
+lower-cost storage tier while keeping frequently accessed data in the standard
+tier. This helps to maintain optimal performance for active data while reducing
+storage costs for infrequently accessed objects.
 
 ## Configuring Object Lifecycle Rules
 
@@ -15,15 +15,14 @@ transition between storage tiers. Rules are configured at the bucket level and
 each rule can target the entire bucket or a subset of objects scoped by a key
 prefix.
 
-A bucket can have up to **10 lifecycle rules**, which can be a mix of
-transition and expiration rules scoped to different prefixes. See
+A bucket can have up to **10 lifecycle rules**, which can be a mix of transition
+and expiration rules scoped to different prefixes. See
 [Object Expiration](/docs/buckets/objects-expiration/) for the expiration form
 of these rules.
 
 The transition timing can be set in two ways:
 
-- **Days**: The objects will be transitioned after the specified number of
-  days.
+- **Days**: The objects will be transitioned after the specified number of days.
 - **Date**: The objects will be transitioned on the specified date.
 
 Tigris currently supports transitioning an object from **STANDARD** to one of
@@ -42,11 +41,11 @@ these three storage tiers:
    records, or completed projects.
 
 3. **GLACIER_IA**: Glacier Infrequent Access storage is designed for data that
-   requires immediate access but is accessed very infrequently. This tier
-   offers a balance between cost and retrieval time - it's more expensive than
-   GLACIER but provides faster access times. Ideal for data that needs to be
-   available quickly when requested, such as monthly reports, quarterly
-   analytics, or seasonal data that might be needed on short notice.
+   requires immediate access but is accessed very infrequently. This tier offers
+   a balance between cost and retrieval time - it's more expensive than GLACIER
+   but provides faster access times. Ideal for data that needs to be available
+   quickly when requested, such as monthly reports, quarterly analytics, or
+   seasonal data that might be needed on short notice.
 
 ### Specifying Object Lifecycle rules via the Tigris Dashboard
 
@@ -62,8 +61,8 @@ a bucket:
 
 ### Specifying Object Lifecycle rules via the AWS CLI
 
-You can configure Object Lifecycle rules for objects in the bucket using the
-AWS CLI. Below are some examples.
+You can configure Object Lifecycle rules for objects in the bucket using the AWS
+CLI. Below are some examples.
 
 #### Transition objects after 30 days
 
@@ -100,7 +99,7 @@ aws s3api put-bucket-lifecycle-configuration --bucket my-bucket --lifecycle-conf
 #### Transition objects at the end of the year 2025
 
 Here's an example of an Object lifecycle configuration that transitions objects
-at the end of the year 2026.
+at the end of the year 2025.
 
 Create a JSON file named `lifecycle.json` with the following content:
 
@@ -131,10 +130,10 @@ aws s3api put-bucket-lifecycle-configuration --bucket my-bucket --lifecycle-conf
 
 #### Multiple rules with prefix filters
 
-Each rule can be scoped to a key prefix using `Filter.Prefix`. The example
-below moves objects under `logs/` to `STANDARD_IA` after 30 days, archives
-objects under `archive/` to `GLACIER` after 90 days, and leaves the rest of
-the bucket on `STANDARD`.
+Each rule can be scoped to a key prefix using `Filter.Prefix`. The example below
+moves objects under `logs/` to `STANDARD_IA` after 30 days, archives objects
+under `archive/` to `GLACIER` after 90 days, and leaves the rest of the bucket
+on `STANDARD`.
 
 ```json
 {

--- a/docs/buckets/object-lifecycle-rules.md
+++ b/docs/buckets/object-lifecycle-rules.md
@@ -2,21 +2,28 @@
 
 As your data storage needs evolve, you may want to optimize costs by moving less
 frequently accessed objects to more cost-effective storage tiers. Tigris
-provides an object lifecycle rule to automatically move objects between storage
-tiers. For example, you might want to move older log files or archived data to a
-lower-cost storage tier while keeping frequently accessed data in the standard
-tier. This helps to maintain optimal performance for active data while reducing
-storage costs for infrequently accessed objects.
+provides object lifecycle rules to automatically move objects between storage
+tiers. For example, you might want to move older log files or archived data to
+a lower-cost storage tier while keeping frequently accessed data in the
+standard tier. This helps to maintain optimal performance for active data while
+reducing storage costs for infrequently accessed objects.
 
-## Configuring an Object Lifecycle Rule
+## Configuring Object Lifecycle Rules
 
 With Object Lifecycle rules, you can configure when and how your objects
-transition between storage tiers. This is done at the bucket level and applies
-to all objects within that bucket.
+transition between storage tiers. Rules are configured at the bucket level and
+each rule can target the entire bucket or a subset of objects scoped by a key
+prefix.
+
+A bucket can have up to **10 lifecycle rules**, which can be a mix of
+transition and expiration rules scoped to different prefixes. See
+[Object Expiration](/docs/buckets/objects-expiration/) for the expiration form
+of these rules.
 
 The transition timing can be set in two ways:
 
-- **Days**: The objects will be transitioned after the specified number of days.
+- **Days**: The objects will be transitioned after the specified number of
+  days.
 - **Date**: The objects will be transitioned on the specified date.
 
 Tigris currently supports transitioning an object from **STANDARD** to one of
@@ -35,13 +42,13 @@ these three storage tiers:
    records, or completed projects.
 
 3. **GLACIER_IA**: Glacier Infrequent Access storage is designed for data that
-   requires immediate access but is accessed very infrequently. This tier offers
-   a balance between cost and retrieval time - it's more expensive than GLACIER
-   but provides faster access times. Ideal for data that needs to be available
-   quickly when requested, such as monthly reports, quarterly analytics, or
-   seasonal data that might be needed on short notice.
+   requires immediate access but is accessed very infrequently. This tier
+   offers a balance between cost and retrieval time - it's more expensive than
+   GLACIER but provides faster access times. Ideal for data that needs to be
+   available quickly when requested, such as monthly reports, quarterly
+   analytics, or seasonal data that might be needed on short notice.
 
-### Specifying an Object Lifecycle rule via the Tigris Dashboard
+### Specifying Object Lifecycle rules via the Tigris Dashboard
 
 You can specify lifecycle transition rules for your bucket using the
 [Tigris Dashboard](https://console.storage.dev/).
@@ -53,16 +60,15 @@ a bucket:
   <img src="https://cdn.loom.com/sessions/thumbnails/cb502607f86c443b835575681922f01c-7a7b4d8fdc70c5ed-full-play.gif"/>
 </a>
 
-### Specifying an Object Lifecycle rule via the AWS CLI
+### Specifying Object Lifecycle rules via the AWS CLI
 
-You can configure an Object Lifecycle rule for objects in the bucket using AWS
-the CLI. Below are some examples of how you can configure the lifecycle
-transition rules.
+You can configure Object Lifecycle rules for objects in the bucket using the
+AWS CLI. Below are some examples.
 
 #### Transition objects after 30 days
 
-Here's an example of an Object Lifecycle configuration that transitions objects
-after 30 days.
+Here's an example of an Object Lifecycle configuration that transitions all
+objects in the bucket after 30 days.
 
 Create a JSON file named `lifecycle.json` with the following content:
 
@@ -70,7 +76,9 @@ Create a JSON file named `lifecycle.json` with the following content:
 {
   "Rules": [
     {
+      "ID": "transition-ia",
       "Status": "Enabled",
+      "Filter": {},
       "Transitions": [
         {
           "Days": 30,
@@ -92,7 +100,7 @@ aws s3api put-bucket-lifecycle-configuration --bucket my-bucket --lifecycle-conf
 #### Transition objects at the end of the year 2025
 
 Here's an example of an Object lifecycle configuration that transitions objects
-at the end of the year 2025.
+at the end of the year 2026.
 
 Create a JSON file named `lifecycle.json` with the following content:
 
@@ -100,7 +108,9 @@ Create a JSON file named `lifecycle.json` with the following content:
 {
   "Rules": [
     {
+      "ID": "archive-eoy",
       "Status": "Enabled",
+      "Filter": {},
       "Transitions": [
         {
           "Date": "2025-12-31T00:00:00Z",
@@ -119,10 +129,53 @@ bucket:
 aws s3api put-bucket-lifecycle-configuration --bucket my-bucket --lifecycle-configuration file://lifecycle.json
 ```
 
+#### Multiple rules with prefix filters
+
+Each rule can be scoped to a key prefix using `Filter.Prefix`. The example
+below moves objects under `logs/` to `STANDARD_IA` after 30 days, archives
+objects under `archive/` to `GLACIER` after 90 days, and leaves the rest of
+the bucket on `STANDARD`.
+
+```json
+{
+  "Rules": [
+    {
+      "ID": "logs-to-ia",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "logs/" },
+      "Transitions": [
+        {
+          "Days": 30,
+          "StorageClass": "STANDARD_IA"
+        }
+      ]
+    },
+    {
+      "ID": "archive-to-glacier",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "archive/" },
+      "Transitions": [
+        {
+          "Days": 90,
+          "StorageClass": "GLACIER"
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## Things to note
 
+- A bucket can have at most 10 lifecycle rules. The 10-rule limit is shared
+  across transition and expiration rules.
+- Each rule may include an `ID` (up to 36 characters). If you omit `ID`, Tigris
+  generates one.
+- Use `Filter.Prefix` on a rule to scope it to a subset of objects. Omit
+  `Filter` (or pass an empty object `{}`) to apply the rule to every object in
+  the bucket.
+- Each rule can include at most one transition.
 - Tigris always rounds the transition time to UTC midnight for the scheduled
   date.
-- Only one Object Lifecycle rule can be applied to a bucket at a time.
 - When using the AWS CLI to apply an Object Lifecycle configuration, the JSON
   can only contain the fields shown in the examples above.

--- a/docs/buckets/object-lifecycle-rules.md
+++ b/docs/buckets/object-lifecycle-rules.md
@@ -43,12 +43,20 @@ full description of each):
    archival purposes but rarely need to access, such as old backups, historical
    records, or completed projects.
 
-3. **GLACIER_IA**: Glacier Infrequent Access storage is designed for data that
-   requires immediate access but is accessed very infrequently. This tier offers
-   a balance between cost and retrieval time - it's more expensive than GLACIER
-   but provides faster access times. Ideal for data that needs to be available
-   quickly when requested, such as monthly reports, quarterly analytics, or
-   seasonal data that might be needed on short notice.
+3. **GLACIER_IR**: Archive Instant Retrieval storage offers archive-tier pricing
+   while still serving GET requests directly, with no restore step. It's more
+   expensive than `GLACIER` but cheaper than `STANDARD_IA` for cold-but-still-
+   readable data. Ideal for backups, compliance archives, or historical
+   datasets that are queried rarely but must respond immediately when they are.
+
+:::note Restore required for GLACIER
+
+Objects in the `GLACIER` storage class return a `403 InvalidObjectState` error
+on GET until you initiate a restore. See
+[Restoring objects from Archive tier](/docs/objects/tiers/#restoring-objects-from-archive-tier).
+`GLACIER_IR` does not require restore.
+
+:::
 
 ### Specifying Object Lifecycle rules via the Tigris Dashboard
 
@@ -99,10 +107,10 @@ bucket:
 aws s3api put-bucket-lifecycle-configuration --bucket my-bucket --lifecycle-configuration file://lifecycle.json
 ```
 
-#### Transition objects at the end of the year 2025
+#### Transition objects at the end of the year
 
 Here's an example of an Object lifecycle configuration that transitions objects
-at the end of the year 2025.
+at the end of the year 2026.
 
 Create a JSON file named `lifecycle.json` with the following content:
 
@@ -115,7 +123,7 @@ Create a JSON file named `lifecycle.json` with the following content:
       "Filter": {},
       "Transitions": [
         {
-          "Date": "2025-12-31T00:00:00Z",
+          "Date": "2026-12-31T00:00:00Z",
           "StorageClass": "GLACIER"
         }
       ]
@@ -199,12 +207,68 @@ expiration side.
 To chain multiple transitions (for example, `STANDARD → STANDARD_IA → GLACIER`),
 use one rule per transition.
 
+#### Inspect the current configuration
+
+```bash
+aws s3api get-bucket-lifecycle-configuration --bucket my-bucket
+```
+
+Returns the current set of rules. If no configuration is set, AWS returns a
+`NoSuchLifecycleConfiguration` error — this is expected on a bucket that has
+never had rules applied.
+
+#### Remove all rules
+
+```bash
+aws s3api delete-bucket-lifecycle --bucket my-bucket
+```
+
+To remove a single rule rather than all of them, fetch the current config with
+`get-bucket-lifecycle-configuration`, edit the JSON to drop the rule you don't
+want, and re-apply with `put-bucket-lifecycle-configuration`.
+
+### Specifying rules via the Tigris CLI
+
+For the common case of a single transition or expiration on a bucket, the
+[Tigris CLI](/docs/cli/) is a one-line shortcut:
+
+```bash
+# Move objects to Infrequent Access after 30 days
+tigris buckets set-transition my-bucket --storage-class STANDARD_IA --days 30
+
+# Disable existing transition rules (keeps them defined, pauses execution)
+tigris buckets set-transition my-bucket --disable
+```
+
+See [`tigris buckets set-transition`](/docs/cli/buckets/set-transition/) and
+[`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/). For multi-rule or
+prefix-filtered configurations, use the AWS CLI with a `lifecycle.json` file
+as shown above.
+
+## How rules are evaluated
+
+Each rule runs on its own worker, walking the bucket oldest-first. If two
+rules match the same object, whichever worker reaches it first does the work
+— there is no preferred ordering between rules with overlapping prefixes.
+
+Transitions are one-way toward colder tiers. Once an object lands in
+`GLACIER`, no rule can pull it back to `STANDARD_IA` or `STANDARD`. When two
+transitions race on the same object, the one that fires first wins; the other
+has nothing to do by the time it arrives.
+
+After you apply a new configuration, expect the first action within a few
+minutes, or up to fifteen to twenty minutes if the scheduler just finished a
+sweep. There is no backfill flag — rules apply on the next scan, oldest-first.
+
 ## Things to note
 
 - A bucket can have at most 10 lifecycle rules. The 10-rule limit is shared
   across transition and expiration rules.
 - Each rule may include an `ID` (up to 36 characters). If you omit `ID`, Tigris
   generates one.
+- `Status` accepts `Enabled` or `Disabled`. A `Disabled` rule stays in the
+  configuration but does not execute — useful for pausing a rule without
+  losing the definition.
 - Use `Filter.Prefix` on a rule to scope it to a subset of objects. Omit
   `Filter` (or pass an empty object `{}`) to apply the rule to every object in
   the bucket.
@@ -222,6 +286,9 @@ use one rule per transition.
 - [Object Expiration](/docs/buckets/objects-expiration/) — the expiration form
   of lifecycle rules.
 - [Storage Tiers](/docs/objects/tiers/) — details on `STANDARD`, `STANDARD_IA`,
-  `GLACIER`, and `GLACIER_IA`.
+  `GLACIER`, and `GLACIER_IR`, plus how to restore objects from `GLACIER`.
 - [Create a bucket](/docs/buckets/create-bucket/) — set a default tier at
   bucket creation time.
+- [`tigris buckets set-transition`](/docs/cli/buckets/set-transition/) and
+  [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/) — Tigris CLI
+  shortcuts for single-rule configurations.

--- a/docs/buckets/object-lifecycle-rules.md
+++ b/docs/buckets/object-lifecycle-rules.md
@@ -46,8 +46,8 @@ full description of each):
 3. **GLACIER_IR**: Archive Instant Retrieval storage offers archive-tier pricing
    while still serving GET requests directly, with no restore step. It's more
    expensive than `GLACIER` but cheaper than `STANDARD_IA` for cold-but-still-
-   readable data. Ideal for backups, compliance archives, or historical
-   datasets that are queried rarely but must respond immediately when they are.
+   readable data. Ideal for backups, compliance archives, or historical datasets
+   that are queried rarely but must respond immediately when they are.
 
 :::note Restore required for GLACIER
 
@@ -177,9 +177,9 @@ on `STANDARD`.
 
 #### Combining a transition and an expiration in one rule
 
-A single rule may carry **one transition and one expiration**. The example
-below moves objects under `logs/` to `STANDARD_IA` after 30 days and deletes
-them after 540 days, expressed in one rule. See
+A single rule may carry **one transition and one expiration**. The example below
+moves objects under `logs/` to `STANDARD_IA` after 30 days and deletes them
+after 540 days, expressed in one rule. See
 [Object Expiration](/docs/buckets/objects-expiration/) for more on the
 expiration side.
 
@@ -242,19 +242,19 @@ tigris buckets set-transition my-bucket --disable
 
 See [`tigris buckets set-transition`](/docs/cli/buckets/set-transition/) and
 [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/). For multi-rule or
-prefix-filtered configurations, use the AWS CLI with a `lifecycle.json` file
-as shown above.
+prefix-filtered configurations, use the AWS CLI with a `lifecycle.json` file as
+shown above.
 
 ## How rules are evaluated
 
-Each rule runs on its own worker, walking the bucket oldest-first. If two
-rules match the same object, whichever worker reaches it first does the work
-— there is no preferred ordering between rules with overlapping prefixes.
+Each rule runs on its own worker, walking the bucket oldest-first. If two rules
+match the same object, whichever worker reaches it first does the work — there
+is no preferred ordering between rules with overlapping prefixes.
 
-Transitions are one-way toward colder tiers. Once an object lands in
-`GLACIER`, no rule can pull it back to `STANDARD_IA` or `STANDARD`. When two
-transitions race on the same object, the one that fires first wins; the other
-has nothing to do by the time it arrives.
+Transitions are one-way toward colder tiers. Once an object lands in `GLACIER`,
+no rule can pull it back to `STANDARD_IA` or `STANDARD`. When two transitions
+race on the same object, the one that fires first wins; the other has nothing to
+do by the time it arrives.
 
 After you apply a new configuration, expect the first action within a few
 minutes, or up to fifteen to twenty minutes if the scheduler just finished a
@@ -267,8 +267,8 @@ sweep. There is no backfill flag — rules apply on the next scan, oldest-first.
 - Each rule may include an `ID` (up to 36 characters). If you omit `ID`, Tigris
   generates one.
 - `Status` accepts `Enabled` or `Disabled`. A `Disabled` rule stays in the
-  configuration but does not execute — useful for pausing a rule without
-  losing the definition.
+  configuration but does not execute — useful for pausing a rule without losing
+  the definition.
 - Use `Filter.Prefix` on a rule to scope it to a subset of objects. Omit
   `Filter` (or pass an empty object `{}`) to apply the rule to every object in
   the bucket.
@@ -287,8 +287,8 @@ sweep. There is no backfill flag — rules apply on the next scan, oldest-first.
   of lifecycle rules.
 - [Storage Tiers](/docs/objects/tiers/) — details on `STANDARD`, `STANDARD_IA`,
   `GLACIER`, and `GLACIER_IR`, plus how to restore objects from `GLACIER`.
-- [Create a bucket](/docs/buckets/create-bucket/) — set a default tier at
-  bucket creation time.
+- [Create a bucket](/docs/buckets/create-bucket/) — set a default tier at bucket
+  creation time.
 - [`tigris buckets set-transition`](/docs/cli/buckets/set-transition/) and
-  [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/) — Tigris CLI
-  shortcuts for single-rule configurations.
+  [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/) — Tigris CLI shortcuts
+  for single-rule configurations.

--- a/docs/buckets/object-lifecycle-rules.md
+++ b/docs/buckets/object-lifecycle-rules.md
@@ -234,16 +234,15 @@ For the common case of a single transition or expiration on a bucket, the
 
 ```bash
 # Move objects to Infrequent Access after 30 days
-tigris buckets set-transition my-bucket --storage-class STANDARD_IA --days 30
+tigris buckets lifecycle create my-bucket --storage-class STANDARD_IA --days 30
 
-# Disable existing transition rules (keeps them defined, pauses execution)
-tigris buckets set-transition my-bucket --disable
+# List existing rules (use the id to edit or remove a rule)
+tigris buckets lifecycle list my-bucket
 ```
 
-See [`tigris buckets set-transition`](/docs/cli/buckets/set-transition/) and
-[`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/). For multi-rule or
-prefix-filtered configurations, use the AWS CLI with a `lifecycle.json` file as
-shown above.
+See [`tigris buckets lifecycle`](/docs/cli/buckets/lifecycle/). For multi-rule
+or prefix-filtered configurations, use the AWS CLI with a `lifecycle.json` file
+as shown above.
 
 ## How rules are evaluated
 
@@ -289,6 +288,5 @@ sweep. There is no backfill flag — rules apply on the next scan, oldest-first.
   `GLACIER`, and `GLACIER_IR`, plus how to restore objects from `GLACIER`.
 - [Create a bucket](/docs/buckets/create-bucket/) — set a default tier at bucket
   creation time.
-- [`tigris buckets set-transition`](/docs/cli/buckets/set-transition/) and
-  [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/) — Tigris CLI shortcuts
-  for single-rule configurations.
+- [`tigris buckets lifecycle`](/docs/cli/buckets/lifecycle/) — Tigris CLI
+  shortcut for single-rule configurations.

--- a/docs/buckets/object-lifecycle-rules.md
+++ b/docs/buckets/object-lifecycle-rules.md
@@ -11,12 +11,14 @@ storage costs for infrequently accessed objects.
 ## Configuring Object Lifecycle Rules
 
 With Object Lifecycle rules, you can configure when and how your objects
-transition between storage tiers. Rules are configured at the bucket level and
-each rule can target the entire bucket or a subset of objects scoped by a key
-prefix.
+transition between [storage tiers](/docs/objects/tiers/). Rules are configured
+at the bucket level and each rule can target the entire bucket or a subset of
+objects scoped by a key prefix.
 
 A bucket can have up to **10 lifecycle rules**, which can be a mix of transition
-and expiration rules scoped to different prefixes. See
+and expiration rules scoped to different prefixes. A single rule can include
+**one transition and one expiration**, so you can move objects to a colder tier
+and later delete them with the same rule. See
 [Object Expiration](/docs/buckets/objects-expiration/) for the expiration form
 of these rules.
 
@@ -26,7 +28,8 @@ The transition timing can be set in two ways:
 - **Date**: The objects will be transitioned on the specified date.
 
 Tigris currently supports transitioning an object from **STANDARD** to one of
-these three storage tiers:
+these three storage tiers (see [Storage Tiers](/docs/objects/tiers/) for the
+full description of each):
 
 1. **STANDARD_IA**: Infrequent Access storage is designed for data that is
    accessed less frequently, but requires rapid access when needed. This tier
@@ -164,6 +167,38 @@ on `STANDARD`.
 }
 ```
 
+#### Combining a transition and an expiration in one rule
+
+A single rule may carry **one transition and one expiration**. The example
+below moves objects under `logs/` to `STANDARD_IA` after 30 days and deletes
+them after 540 days, expressed in one rule. See
+[Object Expiration](/docs/buckets/objects-expiration/) for more on the
+expiration side.
+
+```json
+{
+  "Rules": [
+    {
+      "ID": "logs-tiered-retention",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "logs/" },
+      "Transitions": [
+        {
+          "Days": 30,
+          "StorageClass": "STANDARD_IA"
+        }
+      ],
+      "Expiration": {
+        "Days": 540
+      }
+    }
+  ]
+}
+```
+
+To chain multiple transitions (for example, `STANDARD → STANDARD_IA → GLACIER`),
+use one rule per transition.
+
 ## Things to note
 
 - A bucket can have at most 10 lifecycle rules. The 10-rule limit is shared
@@ -173,8 +208,20 @@ on `STANDARD`.
 - Use `Filter.Prefix` on a rule to scope it to a subset of objects. Omit
   `Filter` (or pass an empty object `{}`) to apply the rule to every object in
   the bucket.
-- Each rule can include at most one transition.
+- Each rule can include **at most one transition and at most one expiration**.
+  Chain multiple transitions by writing one rule per transition.
+- Transitions are one-way to a colder tier. Once an object lands in `GLACIER`,
+  no rule can pull it back to `STANDARD_IA` or `STANDARD`.
 - Tigris always rounds the transition time to UTC midnight for the scheduled
   date.
 - When using the AWS CLI to apply an Object Lifecycle configuration, the JSON
   can only contain the fields shown in the examples above.
+
+## Related
+
+- [Object Expiration](/docs/buckets/objects-expiration/) — the expiration form
+  of lifecycle rules.
+- [Storage Tiers](/docs/objects/tiers/) — details on `STANDARD`, `STANDARD_IA`,
+  `GLACIER`, and `GLACIER_IA`.
+- [Create a bucket](/docs/buckets/create-bucket/) — set a default tier at
+  bucket creation time.

--- a/docs/buckets/object-notifications.md
+++ b/docs/buckets/object-notifications.md
@@ -141,5 +141,6 @@ single region then collates those events and sends them to the webhook. The
 
 ## Next steps
 
-- Check out the [Example Webhook](/docs/sdks/s3/aws-go-sdk.mdx#webhook) for more
+- Check out the
+  [Example Webhook](/docs/sdks/s3/aws-go-sdk/#object-notifications) for more
   details on how to use them in your application.

--- a/docs/buckets/objects-expiration.md
+++ b/docs/buckets/objects-expiration.md
@@ -1,14 +1,19 @@
 # Object Expiration
 
-If you use Tigris to store objects that have a limited lifetime, you can now set
+If you use Tigris to store objects that have a limited lifetime, you can set
 up bucket lifecycle configuration rules to automatically delete them after a
 specified period.
 
 ## Configuring object expiration
 
-Tigris allows you to set up a expiration configuration for objects in a bucket
+Tigris allows you to set up expiration configuration for objects in a bucket
 through bucket lifecycle rules. The expiration is based on the last modified
 time of the object.
+
+A bucket can have up to **10 lifecycle rules**, which can be a mix of
+expiration and transition rules scoped to different prefixes. See
+[Object Lifecycle Rules](/docs/buckets/object-lifecycle-rules/) for the
+transition form of these rules.
 
 The expiration can be set in two ways:
 
@@ -29,13 +34,13 @@ bucket:
 
 ### Specifying expiration rules via the AWS CLI
 
-You can configure expiration rules for objects in the bucket using AWS the CLI.
-Below are some examples of how you can configure the expiration rules.
+You can configure expiration rules for objects in the bucket using the AWS
+CLI. Below are some examples.
 
 #### Expire objects after 30 days
 
-Here's an example of a bucket lifecycle configuration that expires objects after
-30 days.
+Here's an example of a bucket lifecycle configuration that expires every
+object in the bucket after 30 days.
 
 Create a JSON file named `lifecycle.json` with the following content:
 
@@ -43,7 +48,9 @@ Create a JSON file named `lifecycle.json` with the following content:
 {
   "Rules": [
     {
+      "ID": "expire-30d",
       "Status": "Enabled",
+      "Filter": {},
       "Expiration": {
         "Days": 30
       }
@@ -70,7 +77,9 @@ Create a JSON file named `lifecycle.json` with the following content:
 {
   "Rules": [
     {
+      "ID": "expire-eoy",
       "Status": "Enabled",
+      "Filter": {},
       "Expiration": {
         "Date": "2025-12-31T00:00:00Z"
       }
@@ -86,11 +95,47 @@ bucket:
 aws s3api put-bucket-lifecycle-configuration --bucket my-bucket --lifecycle-configuration file://lifecycle.json
 ```
 
+#### Different expirations per prefix
+
+Each rule can be scoped to a key prefix using `Filter.Prefix`, so different
+parts of a bucket can have different expirations. The example below deletes
+objects under `tmp/` after 1 day and objects under `logs/` after 30 days,
+while leaving everything else untouched.
+
+```json
+{
+  "Rules": [
+    {
+      "ID": "expire-tmp",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "tmp/" },
+      "Expiration": {
+        "Days": 1
+      }
+    },
+    {
+      "ID": "expire-logs",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "logs/" },
+      "Expiration": {
+        "Days": 30
+      }
+    }
+  ]
+}
+```
+
 ## Things to note
 
+- A bucket can have at most 10 lifecycle rules. The 10-rule limit is shared
+  across expiration and transition rules.
+- Each rule may include an `ID` (up to 36 characters). If you omit `ID`, Tigris
+  generates one.
+- Use `Filter.Prefix` on a rule to scope it to a subset of objects. Omit
+  `Filter` (or pass an empty object `{}`) to apply the rule to every object in
+  the bucket.
 - Tigris always rounds the expiration time to UTC midnight for the scheduled
   date.
 - The expiration time is based on the last modified time of the object.
-- Only one object expiration rule can be applied to a bucket at a time.
-- When using the AWS CLI to apply a bucket lifecycle configuration, the JSON can
-  only contain the fields shown in the examples above.
+- When using the AWS CLI to apply a bucket lifecycle configuration, the JSON
+  can only contain the fields shown in the examples above.

--- a/docs/buckets/objects-expiration.md
+++ b/docs/buckets/objects-expiration.md
@@ -1,7 +1,7 @@
 # Object Expiration
 
-If you use Tigris to store objects that have a limited lifetime, you can set
-up bucket lifecycle configuration rules to automatically delete them after a
+If you use Tigris to store objects that have a limited lifetime, you can set up
+bucket lifecycle configuration rules to automatically delete them after a
 specified period.
 
 ## Configuring object expiration
@@ -10,8 +10,8 @@ Tigris allows you to set up expiration configuration for objects in a bucket
 through bucket lifecycle rules. The expiration is based on the last modified
 time of the object.
 
-A bucket can have up to **10 lifecycle rules**, which can be a mix of
-expiration and transition rules scoped to different prefixes. See
+A bucket can have up to **10 lifecycle rules**, which can be a mix of expiration
+and transition rules scoped to different prefixes. See
 [Object Lifecycle Rules](/docs/buckets/object-lifecycle-rules/) for the
 transition form of these rules.
 
@@ -34,13 +34,13 @@ bucket:
 
 ### Specifying expiration rules via the AWS CLI
 
-You can configure expiration rules for objects in the bucket using the AWS
-CLI. Below are some examples.
+You can configure expiration rules for objects in the bucket using the AWS CLI.
+Below are some examples.
 
 #### Expire objects after 30 days
 
-Here's an example of a bucket lifecycle configuration that expires every
-object in the bucket after 30 days.
+Here's an example of a bucket lifecycle configuration that expires every object
+in the bucket after 30 days.
 
 Create a JSON file named `lifecycle.json` with the following content:
 
@@ -99,8 +99,8 @@ aws s3api put-bucket-lifecycle-configuration --bucket my-bucket --lifecycle-conf
 
 Each rule can be scoped to a key prefix using `Filter.Prefix`, so different
 parts of a bucket can have different expirations. The example below deletes
-objects under `tmp/` after 1 day and objects under `logs/` after 30 days,
-while leaving everything else untouched.
+objects under `tmp/` after 1 day and objects under `logs/` after 30 days, while
+leaving everything else untouched.
 
 ```json
 {
@@ -137,5 +137,5 @@ while leaving everything else untouched.
 - Tigris always rounds the expiration time to UTC midnight for the scheduled
   date.
 - The expiration time is based on the last modified time of the object.
-- When using the AWS CLI to apply a bucket lifecycle configuration, the JSON
-  can only contain the fields shown in the examples above.
+- When using the AWS CLI to apply a bucket lifecycle configuration, the JSON can
+  only contain the fields shown in the examples above.

--- a/docs/buckets/objects-expiration.md
+++ b/docs/buckets/objects-expiration.md
@@ -68,10 +68,10 @@ bucket:
 aws s3api put-bucket-lifecycle-configuration --bucket my-bucket --lifecycle-configuration file://lifecycle.json
 ```
 
-#### Expire objects at the end of the year 2025
+#### Expire objects at the end of the year
 
 Here's an example of a bucket lifecycle configuration that expires objects at
-the end of the year 2025.
+the end of the year 2026.
 
 Create a JSON file named `lifecycle.json` with the following content:
 
@@ -83,7 +83,7 @@ Create a JSON file named `lifecycle.json` with the following content:
       "Status": "Enabled",
       "Filter": {},
       "Expiration": {
-        "Date": "2025-12-31T00:00:00Z"
+        "Date": "2026-12-31T00:00:00Z"
       }
     }
   ]
@@ -127,12 +127,56 @@ leaving everything else untouched.
 }
 ```
 
+#### Inspect or remove the current configuration
+
+```bash
+# Show the current set of rules
+aws s3api get-bucket-lifecycle-configuration --bucket my-bucket
+
+# Remove all rules (transition and expiration alike)
+aws s3api delete-bucket-lifecycle --bucket my-bucket
+```
+
+`get-bucket-lifecycle-configuration` returns `NoSuchLifecycleConfiguration` on
+a bucket that has never had rules applied — this is expected.
+
+### Specifying expiration via the Tigris CLI
+
+For a single expiration on a whole bucket, the
+[Tigris CLI](/docs/cli/) is a one-line shortcut:
+
+```bash
+# Expire every object 30 days after it was last modified
+tigris buckets set-ttl my-bucket --days 30
+
+# Pause the rule without removing it
+tigris buckets set-ttl my-bucket --disable
+```
+
+See [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/). For prefix-scoped
+or multi-rule expirations, use the AWS CLI with a `lifecycle.json` file as
+shown above.
+
+## How rules are evaluated
+
+Each rule runs on its own worker, walking the bucket oldest-first. If two
+rules match the same object, whichever worker reaches it first does the work.
+When a transition and an expiration fire on the same object at roughly the
+same moment, the timestamp of each metadata update settles the outcome.
+
+After you apply a new configuration, expect the first deletions within a few
+minutes, or up to fifteen to twenty minutes if the scheduler just finished a
+sweep. There is no backfill flag — rules apply on the next scan, oldest-first.
+
 ## Things to note
 
 - A bucket can have at most 10 lifecycle rules. The 10-rule limit is shared
   across expiration and transition rules.
 - Each rule may include an `ID` (up to 36 characters). If you omit `ID`, Tigris
   generates one.
+- `Status` accepts `Enabled` or `Disabled`. A `Disabled` rule stays in the
+  configuration but does not execute — useful for pausing a rule without
+  losing the definition.
 - Use `Filter.Prefix` on a rule to scope it to a subset of objects. Omit
   `Filter` (or pass an empty object `{}`) to apply the rule to every object in
   the bucket.
@@ -151,3 +195,5 @@ leaving everything else untouched.
 - [Storage Tiers](/docs/objects/tiers/) — the storage tiers expiration rules
   apply to.
 - [Create a bucket](/docs/buckets/create-bucket/) — bucket-level defaults.
+- [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/) — Tigris CLI shortcut
+  for single-rule expiration.

--- a/docs/buckets/objects-expiration.md
+++ b/docs/buckets/objects-expiration.md
@@ -137,13 +137,13 @@ aws s3api get-bucket-lifecycle-configuration --bucket my-bucket
 aws s3api delete-bucket-lifecycle --bucket my-bucket
 ```
 
-`get-bucket-lifecycle-configuration` returns `NoSuchLifecycleConfiguration` on
-a bucket that has never had rules applied — this is expected.
+`get-bucket-lifecycle-configuration` returns `NoSuchLifecycleConfiguration` on a
+bucket that has never had rules applied — this is expected.
 
 ### Specifying expiration via the Tigris CLI
 
-For a single expiration on a whole bucket, the
-[Tigris CLI](/docs/cli/) is a one-line shortcut:
+For a single expiration on a whole bucket, the [Tigris CLI](/docs/cli/) is a
+one-line shortcut:
 
 ```bash
 # Expire every object 30 days after it was last modified
@@ -153,16 +153,16 @@ tigris buckets set-ttl my-bucket --days 30
 tigris buckets set-ttl my-bucket --disable
 ```
 
-See [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/). For prefix-scoped
-or multi-rule expirations, use the AWS CLI with a `lifecycle.json` file as
-shown above.
+See [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/). For prefix-scoped or
+multi-rule expirations, use the AWS CLI with a `lifecycle.json` file as shown
+above.
 
 ## How rules are evaluated
 
-Each rule runs on its own worker, walking the bucket oldest-first. If two
-rules match the same object, whichever worker reaches it first does the work.
-When a transition and an expiration fire on the same object at roughly the
-same moment, the timestamp of each metadata update settles the outcome.
+Each rule runs on its own worker, walking the bucket oldest-first. If two rules
+match the same object, whichever worker reaches it first does the work. When a
+transition and an expiration fire on the same object at roughly the same moment,
+the timestamp of each metadata update settles the outcome.
 
 After you apply a new configuration, expect the first deletions within a few
 minutes, or up to fifteen to twenty minutes if the scheduler just finished a
@@ -175,8 +175,8 @@ sweep. There is no backfill flag — rules apply on the next scan, oldest-first.
 - Each rule may include an `ID` (up to 36 characters). If you omit `ID`, Tigris
   generates one.
 - `Status` accepts `Enabled` or `Disabled`. A `Disabled` rule stays in the
-  configuration but does not execute — useful for pausing a rule without
-  losing the definition.
+  configuration but does not execute — useful for pausing a rule without losing
+  the definition.
 - Use `Filter.Prefix` on a rule to scope it to a subset of objects. Omit
   `Filter` (or pass an empty object `{}`) to apply the rule to every object in
   the bucket.

--- a/docs/buckets/objects-expiration.md
+++ b/docs/buckets/objects-expiration.md
@@ -147,15 +147,15 @@ one-line shortcut:
 
 ```bash
 # Expire every object 30 days after it was last modified
-tigris buckets set-ttl my-bucket --days 30
+tigris buckets lifecycle create my-bucket --expire-days 30
 
-# Pause the rule without removing it
-tigris buckets set-ttl my-bucket --disable
+# List existing rules (use the id to edit or remove a rule)
+tigris buckets lifecycle list my-bucket
 ```
 
-See [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/). For prefix-scoped or
-multi-rule expirations, use the AWS CLI with a `lifecycle.json` file as shown
-above.
+See [`tigris buckets lifecycle`](/docs/cli/buckets/lifecycle/). For
+prefix-scoped or multi-rule expirations, use the AWS CLI with a `lifecycle.json`
+file as shown above.
 
 ## How rules are evaluated
 
@@ -195,5 +195,5 @@ sweep. There is no backfill flag — rules apply on the next scan, oldest-first.
 - [Storage Tiers](/docs/objects/tiers/) — the storage tiers expiration rules
   apply to.
 - [Create a bucket](/docs/buckets/create-bucket/) — bucket-level defaults.
-- [`tigris buckets set-ttl`](/docs/cli/buckets/set-ttl/) — Tigris CLI shortcut
-  for single-rule expiration.
+- [`tigris buckets lifecycle`](/docs/cli/buckets/lifecycle/) — Tigris CLI
+  shortcut for single-rule expiration.

--- a/docs/buckets/objects-expiration.md
+++ b/docs/buckets/objects-expiration.md
@@ -11,9 +11,11 @@ through bucket lifecycle rules. The expiration is based on the last modified
 time of the object.
 
 A bucket can have up to **10 lifecycle rules**, which can be a mix of expiration
-and transition rules scoped to different prefixes. See
+and transition rules scoped to different prefixes. A single rule can include
+**one transition and one expiration**, so the same rule can move an object to a
+colder [storage tier](/docs/objects/tiers/) and later delete it. See
 [Object Lifecycle Rules](/docs/buckets/object-lifecycle-rules/) for the
-transition form of these rules.
+transition form of these rules and an example of combining the two.
 
 The expiration can be set in two ways:
 
@@ -134,8 +136,18 @@ leaving everything else untouched.
 - Use `Filter.Prefix` on a rule to scope it to a subset of objects. Omit
   `Filter` (or pass an empty object `{}`) to apply the rule to every object in
   the bucket.
+- Each rule can include **at most one expiration and at most one transition**,
+  so the same rule can move an object to a colder tier and later delete it.
 - Tigris always rounds the expiration time to UTC midnight for the scheduled
   date.
 - The expiration time is based on the last modified time of the object.
 - When using the AWS CLI to apply a bucket lifecycle configuration, the JSON can
   only contain the fields shown in the examples above.
+
+## Related
+
+- [Object Lifecycle Rules](/docs/buckets/object-lifecycle-rules/) — transition
+  rules, including how to combine a transition and an expiration in one rule.
+- [Storage Tiers](/docs/objects/tiers/) — the storage tiers expiration rules
+  apply to.
+- [Create a bucket](/docs/buckets/create-bucket/) — bucket-level defaults.

--- a/docs/objects/acl.md
+++ b/docs/objects/acl.md
@@ -31,7 +31,7 @@ bucket settings.
 </a>
 
 For the object ACLs migration rules see the
-[Copying objects ACLs](/docs/migration/#copying-object-acls)
+[Copying object ACLs](/docs/migration/#copying-object-acls).
 
 ## Applying ACLs to objects
 

--- a/examples/go/cmd/rename-objects/main.go
+++ b/examples/go/cmd/rename-objects/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -32,7 +33,16 @@ func main() {
 	}
 
 	bucketName := flag.Arg(0)
-	keyName := "examplefile-go.js"
+
+	// Use a timestamp suffix on both keys so re-runs (and concurrent CI
+	// jobs sharing the bucket) cannot collide with leftover state from a
+	// previous run that died between the rename and the cleanup delete.
+	// Tigris rename is atomic and does NOT silently overwrite — a 409
+	// KeyAlreadyExists from a stale destination key is the API working
+	// as designed, not a bug to paper over.
+	suffix := time.Now().UTC().Format("20060102-150405.000000000")
+	keyName := fmt.Sprintf("examplefile-go-%s.js", suffix)
+	targetName := fmt.Sprintf("examplefile-go-rename-%s.js", suffix)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -64,8 +74,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Unable to put object. Here's why: %v", err)
 	}
-
-	targetName := "examplefile-go-rename.js"
 
 	fmt.Println("Renaming object in the bucket:", keyName)
 

--- a/src/components/FeaturesGrid/index.jsx
+++ b/src/components/FeaturesGrid/index.jsx
@@ -33,7 +33,7 @@ export default function FeaturesGrid() {
           icon="img/lightning"
           title="Global Distribution"
           description="Data automatically stored close to users for low latency everywhere."
-          to="/overview/#global-low-latency-access"
+          to="/overview/features/#global-distribution"
         />
         <FeatureTile
           icon="img/lightning"

--- a/static/api/extensions/v1/api.yaml
+++ b/static/api/extensions/v1/api.yaml
@@ -712,12 +712,12 @@ paths:
       description: |
         Creates a new IAM policy with the given name and document.
         Returns 409 if a policy with the same name already exists — use
-        [Update Policy](#tag/iam/operation/Tigris_UpdatePolicy) to modify existing policies.
+        [Update Policy](/docs/partner-integrations/api/tigris-update-policy/) to modify existing policies.
 
         The policy document follows the [AWS IAM policy syntax](https://www.tigrisdata.com/docs/iam/policies/).
 
         After creating a policy, attach it to an access key using the
-        [Update Access Key](#tag/iam/operation/Tigris_UpdateAccessKey) endpoint
+        [Update Access Key](/docs/partner-integrations/api/tigris-update-access-key/) endpoint
         with the `add_policies` field.
 
         ##### Example: Read-write access to a prefix


### PR DESCRIPTION
## Summary

- Updates Object Lifecycle Rules and Object Expiration docs to reflect [tigrisdata/tigris-os#4229](https://github.com/tigrisdata/tigris-os/pull/4229), which raises the per-bucket rule limit from 1 to 10.
- Documents the new per-rule `ID` (max 36 chars; `desc` and `*-desc` reserved) and `Filter.Prefix` for scoping a rule to a subset of objects.
- Adds multi-rule examples: per-prefix transitions (`logs/` → `STANDARD_IA`, `archive/` → `GLACIER`) and per-prefix expirations (`tmp/` after 1 day, `logs/` after 30 days).

## Test plan

- [ ] `npm run dev` and visually inspect /docs/buckets/object-lifecycle-rules and /docs/buckets/objects-expiration
- [ ] Confirm cross-links between the two pages render
- [ ] `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily documentation/link updates plus a small sample-code tweak to avoid key collisions; no production logic changes.
> 
> **Overview**
> **Docs now reflect multi-rule bucket lifecycle support.** The lifecycle transition and expiration pages were expanded to document up to `10` rules per bucket, per-rule `ID`, `Filter.Prefix` scoping, and the ability to combine *one* transition + *one* expiration in a single rule, with new AWS CLI and Tigris CLI examples plus guidance on evaluation/ordering.
> 
> Also updates tier naming/details (including `GLACIER_IR` and restore behavior for `GLACIER`), fixes a broken webhook doc link, tweaks the Go rename example to use timestamp-suffixed keys to avoid rerun/CI collisions, updates the features grid “Global Distribution” link target, and replaces OpenAPI description anchors with docs URLs for IAM policy/access-key cross-references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b959afb1cd35bfe2a11bf8a42a3bd6b47167b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->