### PR TITLE
Document object versioning commands supported by snapshot-enabled buckets

### DIFF
--- a/docs/buckets/sharing.md
+++ b/docs/buckets/sharing.md
@@ -113,6 +113,7 @@ permissions (e.g. deleting the bucket).
 - List object parts (`ListObjectParts`)
 - List objects (V1) (`ListObjectsV1`)
 - List objects (V2) (`ListObjectsV2`)
+- List object versions (`ListObjectVersions`)
 - Start new multipart uploads (`NewMultipartUpload`)
 - Get bucket accelerate configuration (`GetBucketAccelerateConfiguration`)
 - Use POST policy (`PostPolicy`)

--- a/docs/buckets/snapshots-and-forks.mdx
+++ b/docs/buckets/snapshots-and-forks.mdx
@@ -3,8 +3,8 @@ import TabItem from "@theme/TabItem";
 
 # Bucket snapshots and forks
 
-This page covers how to enable and use snapshots and forks on your Tigris
-buckets. For an overview of the concepts, see
+This page covers how to enable and use snapshots, forks, and object versioning
+on your Tigris buckets. For an overview of the concepts, see
 [Snapshots and Forks](/docs/snapshots-and-forks).
 
 Snapshots and forks are opt-in features. To enable them on a bucket, you must
@@ -570,6 +570,33 @@ the **tigris-boto3-ext** repo for more details on how to use the snapshot and
 forking feature with the Python boto3 SDK.
 
 :::
+
+## Using object versioning APIs
+
+If you need more granular access to object versions in a snapshot-enabled
+bucket, you can use a subset of S3-compatible object versioning APIs without any
+additional changes. No special headers or extra steps are required. These APIs
+work with standard SDKs and tools.
+
+### Supported APIs
+
+- `ListObjectVersions`
+- `HeadObject` with the `versionId` parameter
+- `GetObject` with the `versionId` parameter
+- `DeleteObject` with the `versionId` parameter
+
+:::note
+
+As in S3, deleting an object with a specified version ID permanently removes
+that version. It is also deleted from all snapshots.
+
+:::
+
+No additional authorization permissions are required to use the `HeadObject` or
+`GetObject` APIs with the `versionId` parameter. The `ListObjectVersions`
+operation is available to users with read-only (or higher) access to the bucket.
+However, note that this is a separate operation, and some IAM policies may need
+to be updated to allow it.
 
 ## Using a forked bucket
 

--- a/docs/buckets/snapshots-and-forks.mdx
+++ b/docs/buckets/snapshots-and-forks.mdx
@@ -573,10 +573,12 @@ forking feature with the Python boto3 SDK.
 
 ## Using object versioning APIs
 
-If you need more granular access to object versions in a snapshot-enabled
-bucket, you can use a subset of S3-compatible object versioning APIs without any
-additional changes. No special headers or extra steps are required. These APIs
-work with standard SDKs and tools.
+Working with a snapshot-enabled bucket sometimes requires reading or deleting a
+specific version of an object - for example, fetching a known prior version
+directly, or permanently removing a single version across the bucket and its
+snapshots. A subset of S3-compatible object versioning APIs supports these cases
+without any additional changes. No special headers or extra steps are required,
+and standard SDKs and tools work as-is.
 
 ### Supported APIs
 

--- a/docs/concepts/authnz.md
+++ b/docs/concepts/authnz.md
@@ -101,6 +101,7 @@ based on the role assigned to the it.
 | ListObjectParts                    | ✅    | ✅     | ❌       |
 | ListObjectsV1                      | ✅    | ✅     | ✅       |
 | ListObjectsV2                      | ✅    | ✅     | ✅       |
+| ListObjectVersions                 | ✅    | ✅     | ✅       |
 | NewMultipartUpload                 | ✅    | ✅     | ❌       |
 | GetBucketAccelerateConfiguration   | ✅    | ✅     | ✅       |
 | GetBucketOwnershipControls         | ✅    | ✅     | ✅       |

--- a/docs/snapshots/index.mdx
+++ b/docs/snapshots/index.mdx
@@ -164,12 +164,16 @@ No. Snapshots are metadata-only and don't slow down reads or writes.
 
 ### Can I enable snapshots on an existing bucket?
 
-No. Snapshot support must be enabled at bucket creation and cannot be added to
-existing buckets.
+Snapshot support can be enabled for existing buckets; however, this
+functionality is not yet exposed to users. If you would like to change the type
+of your bucket, please contact us at
+[help@tigrisdata.com](mailto:help@tigrisdata.com).
 
 ### Can I disable snapshots after enabling them?
 
-No. Once enabled, snapshot support cannot be disabled.
+Snapshots can be disabled for buckets; however, this functionality is not yet
+exposed to users. If you would like to change the type of your bucket, please
+contact us at [help@tigrisdata.com](mailto:help@tigrisdata.com).
 
 ### Can I restore a bucket to a previous snapshot?
 
@@ -181,3 +185,10 @@ recover individual objects or restore full bucket state.
 
 No. Object expiration and storage tier transitions are not supported on
 snapshot-enabled buckets.
+
+### Can I use object versioning APIs on snapshot-enabled buckets?
+
+Yes, a subset of S3-compatible object versioning APIs is available for
+snapshot-enabled buckets. See
+[this section](https://www.tigrisdata.com/docs/buckets/snapshots-and-forks/#using-object-versioning-apis)
+for more details.


### PR DESCRIPTION
Documenting that the main object versioning–related APIs are supported in snapshot-enabled buckets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (no runtime behavior changes), mainly adding clarity around supported APIs and permissions.
> 
> **Overview**
> Documents that snapshot-enabled buckets support a subset of S3 object-versioning operations, including `ListObjectVersions` and `HeadObject`/`GetObject`/`DeleteObject` with `versionId`, and clarifies that version-specific deletes are permanent across all snapshots.
> 
> Updates authorization/permissions docs to include `ListObjectVersions`, and refreshes the snapshots FAQ to note snapshots can be enabled/disabled via support and to link to the new object-versioning guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74965c6f5e0a5301485cc360b7d20e804edc7818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->