### PR TITLE
fix: remove mentions of fly.storage.tigris.dev endpoint

### DIFF
--- a/docs/acceleration-gateway/configuration.md
+++ b/docs/acceleration-gateway/configuration.md
@@ -165,9 +165,8 @@ deployments.
 
 ### Endpoint validation
 
-The upstream endpoint must match one of the allowed host patterns: `localhost`,
-`*.tigris.dev`, or `*.storage.dev`. TAG exits at startup if the endpoint does
-not match.
+The upstream endpoint must match one of the allowed host patterns: `localhost`
+or `*.storage.dev`. TAG exits at startup if the endpoint does not match.
 
 ### Cluster mode
 

--- a/docs/acceleration-gateway/deployment-guide.md
+++ b/docs/acceleration-gateway/deployment-guide.md
@@ -117,8 +117,8 @@ where the old one left off.
 application's. In Kubernetes, verify the secret exists:
 `kubectl get secret -n tag tag-credentials`
 
-**"invalid upstream endpoint"** — TAG only allows connections to `localhost`,
-`*.tigris.dev`, or `*.storage.dev`. Check `TAG_UPSTREAM_ENDPOINT`.
+**"invalid upstream endpoint"** — TAG only allows connections to `localhost` or
+`*.storage.dev`. Check `TAG_UPSTREAM_ENDPOINT`.
 
 **"TLS certificate or key file not found"** — If either `TAG_TLS_CERT_FILE` or
 `TAG_TLS_KEY_FILE` is set, both must point to valid files.

--- a/docs/acceleration-gateway/security.mdx
+++ b/docs/acceleration-gateway/security.mdx
@@ -116,11 +116,10 @@ SSRF attacks.
 
 **Allowed hosts:**
 
-| Pattern         | Example                          | Use case                  |
-| --------------- | -------------------------------- | ------------------------- |
-| `localhost`     | `http://localhost:8080`          | Development and testing   |
-| `*.tigris.dev`  | `https://fly.storage.tigris.dev` | Tigris production domains |
-| `*.storage.dev` | `https://t3.storage.dev`         | Tigris storage domains    |
+| Pattern         | Example                  | Use case                |
+| --------------- | ------------------------ | ----------------------- |
+| `localhost`     | `http://localhost:8080`  | Development and testing |
+| `*.storage.dev` | `https://t3.storage.dev` | Tigris storage domains  |
 
 Any other endpoint causes a fatal startup error.
 

--- a/docs/agents/agent-cognee.mdx
+++ b/docs/agents/agent-cognee.mdx
@@ -103,7 +103,7 @@ s3.create_bucket(Bucket="my-agent-memory")
 </Tabs>
 
 :::note
-Tigris requires `virtual` addressing style when using boto3. The endpoint is `https://t3.storage.dev` for general access, or `https://fly.storage.tigris.dev` if you're running on Fly.io.
+Tigris requires `virtual` addressing style when using boto3. The endpoint is `https://t3.storage.dev`.
 :::
 
 ## Step 3: Configure environment variables

--- a/docs/buckets/bucket-rules.md
+++ b/docs/buckets/bucket-rules.md
@@ -14,8 +14,8 @@ The following naming rules apply for buckets.
   :::info
 
   Using a dot (.) will disable virtual-hosted style access (e.g.,
-  `https://foo.bucket.fly.storage.tigris.dev`) for a bucket. However, you can
-  still access it through a correctly configured
+  `https://foo.bucket.t3.storage.dev`) for a bucket. However, you can still
+  access it through a correctly configured
   [custom domain](/docs/buckets/custom-domain.md).
 
   :::

--- a/docs/buckets/create-bucket.md
+++ b/docs/buckets/create-bucket.md
@@ -49,15 +49,6 @@ To create a bucket using the Tigris Dashboard, follow these steps:
 Assuming you have the AWS CLI configured as shown in the
 [AWS CLI guide](/docs/sdks/s3/aws-cli.md), you can create a bucket as follows:
 
-:::note
-
-If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev).
-
-:::
-
 ```bash
 aws s3api --endpoint-url https://t3.storage.dev create-bucket --bucket foo-bucket
 ```

--- a/docs/buckets/public-bucket.md
+++ b/docs/buckets/public-bucket.md
@@ -55,16 +55,6 @@ accessible at:
 All three domains serve the same content without authentication and are
 interchangeable.
 
-:::info[Existing Fly.io accounts]
-
-Existing Fly.io accounts can also access public content at
-`BUCKET_NAME.fly.storage.tigris.dev`. This continues to work but is not
-available for new accounts. We recommend setting up a
-[custom domain](#custom-domain) for production use regardless of which domain
-you currently use.
-
-:::
-
 :::warning
 
 The public bucket domains don’t work with dots in bucket names because the SSL

--- a/docs/concepts/regions.md
+++ b/docs/concepts/regions.md
@@ -37,7 +37,7 @@ availability guarantees, and cost — see
 | Asia-Pacific | `sin` | Singapore              |
 | Asia-Pacific | `nrt` | Tokyo, Japan           |
 
-### fly.storage.tigris.dev
+### Fly.io available regions
 
 | Geography     | Code  | Location                   |
 | ------------- | ----- | -------------------------- |

--- a/docs/iam/manage-access-key/index.mdx
+++ b/docs/iam/manage-access-key/index.mdx
@@ -23,7 +23,6 @@ the AWS CLI.
    Optionally choose your service endpoint (`Default` or `Fly`).
 
 3. **Fill in Key Details**
-
    - **Key Name**: e.g., `ci-access`, `backup-script`
    - **Permissions**:
      - **Admin** – full access (dev use only)
@@ -32,7 +31,6 @@ the AWS CLI.
 
 4. **Click Create**  
    You’ll receive:
-
    - Access Key ID
    - Secret Access Key _(shown once—store it securely)_
    - S3 & IAM endpoint URLs

--- a/docs/iam/manage-access-key/index.mdx
+++ b/docs/iam/manage-access-key/index.mdx
@@ -23,6 +23,7 @@ the AWS CLI.
    Optionally choose your service endpoint (`Default` or `Fly`).
 
 3. **Fill in Key Details**
+
    - **Key Name**: e.g., `ci-access`, `backup-script`
    - **Permissions**:
      - **Admin** – full access (dev use only)
@@ -31,6 +32,7 @@ the AWS CLI.
 
 4. **Click Create**  
    You’ll receive:
+
    - Access Key ID
    - Secret Access Key _(shown once—store it securely)_
    - S3 & IAM endpoint URLs

--- a/docs/legal/data-processing.md
+++ b/docs/legal/data-processing.md
@@ -352,7 +352,6 @@ conflicting terms of the Agreement.
    controlled by the Customer in its sole discretion subject to any constraints
    set forth in the Agreement), which may relate to the following categories of
    Data Subjects:
-
    - Employees, agents, advisors, and contractors of Customer (in each case, who
      are natural persons).
    - Users of Customer’s systems or users of systems over which the Customer has
@@ -369,7 +368,6 @@ conflicting terms of the Agreement.
    controlled by the Customer in its sole discretion subject to any constraints
    set forth in the Agreement), which may relate to the following categories of
    Personal Data:
-
    - First and last name, title, position, employment-related and professional
      information.
    - Contact information (company, email, phone, physical address).

--- a/docs/legal/data-processing.md
+++ b/docs/legal/data-processing.md
@@ -352,6 +352,7 @@ conflicting terms of the Agreement.
    controlled by the Customer in its sole discretion subject to any constraints
    set forth in the Agreement), which may relate to the following categories of
    Data Subjects:
+
    - Employees, agents, advisors, and contractors of Customer (in each case, who
      are natural persons).
    - Users of Customer’s systems or users of systems over which the Customer has
@@ -368,6 +369,7 @@ conflicting terms of the Agreement.
    controlled by the Customer in its sole discretion subject to any constraints
    set forth in the Agreement), which may relate to the following categories of
    Personal Data:
+
    - First and last name, title, position, employment-related and professional
      information.
    - Contact information (company, email, phone, physical address).

--- a/docs/objects/acl.md
+++ b/docs/objects/acl.md
@@ -40,15 +40,6 @@ For the object ACLs migration rules see the
 If you have a private bucket and you want to make an object in it publicly
 readable, you can do so by setting the object ACL to `public-read`.
 
-:::note
-
-If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev).
-
-:::
-
 ```bash
 aws s3api --endpoint-url https://t3.storage.dev put-object --bucket foo-bucket --key bar-public.txt --body bar.txt --acl public-read
 ```

--- a/docs/objects/caching.md
+++ b/docs/objects/caching.md
@@ -85,7 +85,7 @@ the objects when requested from the Sydney region.
 
 ```curl
 GET /?list-type=2&continuation-token=ContinuationToken&delimiter=Delimiter&encoding-type=EncodingType&fetch-owner=FetchOwner&max-keys=MaxKeys&prefix=Prefix&start-after=StartAfter HTTP/1.1
-Host: bucket.fly.storage.tigris.dev
+Host: bucket.t3.storage.dev
 x-tigris-prefetch: true
 ```
 

--- a/docs/objects/multipart-uploads.mdx
+++ b/docs/objects/multipart-uploads.mdx
@@ -8,8 +8,7 @@ can re-upload that part without affecting other parts.
 Tigris is S3-compatible, so you can use the same SDKs and patterns for multipart
 uploads. Tigris also routes traffic to the nearest region by default via its
 global endpoint, providing accelerated, low-latency ingress without any extra
-configuration. Use `https://t3.storage.dev` (outside Fly.io) or
-`https://fly.storage.tigris.dev` (from Fly.io).
+configuration. Use `https://t3.storage.dev`.
 
 ## Prerequisites
 

--- a/docs/objects/presigned.md
+++ b/docs/objects/presigned.md
@@ -49,7 +49,7 @@ and generated URL would look like:
 https://t3.storage.dev/mybucket.mydomain.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=tid_<>%2F20241210%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=<>X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=<>
 ```
 
-You can remove `fly.storage.tigris.dev/` and make it look like:
+You can remove `t3.storage.dev/` and make it look like:
 
 ```bash
 https://mybucket.mydomain.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=tid_<>%2F20241210%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=<>X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=<>
@@ -58,7 +58,7 @@ https://mybucket.mydomain.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-C
 Here is the bash one-liner to do the same:
 
 ```bash
-aws s3 presign s3://mybucket.mydomain.com/hello.txt |  sed 's/fly.storage.tigris.dev\///'
+aws s3 presign s3://mybucket.mydomain.com/hello.txt |  sed 's/t3.storage.dev\///'
 ```
 
 ## Security

--- a/docs/objects/tiers.md
+++ b/docs/objects/tiers.md
@@ -64,7 +64,7 @@ aws s3api put-object --bucket my-bucket --key my-object.txt --body bar.txt --sto
 
 ```http
 PUT /my-object.txt HTTP/1.1
-Host: my-bucket.storage.fly.tigris.dev
+Host: my-bucket.t3.storage.dev
 x-amz-storage-class: STANDARD_IA
 ```
 

--- a/docs/objects/upload-via-html-form.md
+++ b/docs/objects/upload-via-html-form.md
@@ -139,7 +139,7 @@ The signature of our example policy will be
   </head>
   <body>
     <form
-      action="https://my-user-images.fly.storage.tigris.dev/"
+      action="https://my-user-images.t3.storage.dev/"
       method="post"
       enctype="multipart/form-data"
     >

--- a/docs/quickstarts/mcp.mdx
+++ b/docs/quickstarts/mcp.mdx
@@ -50,7 +50,6 @@ Delete myfile.txt from my-bucket
 ## Prerequisites
 
 - **Tigris Account & Credentials**
-
   1. Sign up at [https://storage.new](https://storage.new)
   2. Create or retrieve an access key pair (AWS-style) at
      [https://storage.new/accesskey](https://storage.new/accesskey)

--- a/docs/quickstarts/mcp.mdx
+++ b/docs/quickstarts/mcp.mdx
@@ -50,6 +50,7 @@ Delete myfile.txt from my-bucket
 ## Prerequisites
 
 - **Tigris Account & Credentials**
+
   1. Sign up at [https://storage.new](https://storage.new)
   2. Create or retrieve an access key pair (AWS-style) at
      [https://storage.new/accesskey](https://storage.new/accesskey)
@@ -68,9 +69,9 @@ Delete myfile.txt from my-bucket
 Click to install the MCP Server in your editor. Replace `YOUR_AWS_*` with your
 credentials:
 
-[![Install in VS Code](https://img.shields.io/badge/VS%20Code-Install%20Tigris%20MCP%20Server-0098FF?logo=)](https://insiders.vscode.dev/redirect/mcp/install?name=Tigris%20MCP%20Server&config=%7B%22mcpServers%22%3A%7B%22tigris-mcp-server%22%3A%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40tigrisdata%2Ftigris-mcp-server%22%2C%22run%22%5D%2C%22env%22%3A%7B%22AWS_ACCESS_KEY_ID%22%3A%22YOUR_AWS_ACCESS_KEY_ID%22%2C%22AWS_SECRET_ACCESS_KEY%22%3A%22YOUR_AWS_SECRET_ACCESS_KEY%22%2C%22AWS_ENDPOINT_URL_S3%22%3A%22https%3A%2F%2Ffly.storage.tigris.dev%22%7D%7D%7D%7D)
+[![Install in VS Code](https://img.shields.io/badge/VS%20Code-Install%20Tigris%20MCP%20Server-0098FF?logo=)](https://insiders.vscode.dev/redirect/mcp/install?name=Tigris%20MCP%20Server&config=%7B%22mcpServers%22%3A%7B%22tigris-mcp-server%22%3A%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40tigrisdata%2Ftigris-mcp-server%22%2C%22run%22%5D%2C%22env%22%3A%7B%22AWS_ACCESS_KEY_ID%22%3A%22YOUR_AWS_ACCESS_KEY_ID%22%2C%22AWS_SECRET_ACCESS_KEY%22%3A%22YOUR_AWS_SECRET_ACCESS_KEY%22%2C%22AWS_ENDPOINT_URL_S3%22%3A%22https%3A%2F%2Ft3.storage.dev%22%7D%7D%7D%7D)
 
-[![Install in VS Code Insiders](https://img.shields.io/badge/VS%20Code%20Insiders-Install%20Tigris%20MCP%20Server-24bfa5)](https://insiders.vscode.dev/redirect/mcp/install?name=Tigris%20MCP%20Server&config=%7B%22mcpServers%22%3A%7B%22tigris-mcp-server%22%3A%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40tigrisdata%2Ftigris-mcp-server%22%2C%22run%22%5D%2C%22env%22%3A%7B%22AWS_ACCESS_KEY_ID%22%3A%22YOUR_AWS_ACCESS_KEY_ID%22%2C%22AWS_SECRET_ACCESS_KEY%22%3A%22YOUR_AWS_SECRET_ACCESS_KEY%22%2C%22AWS_ENDPOINT_URL_S3%22%3A%22https%3A%2F%2Ffly.storage.tigris.dev%22%7D%7D%7D%7D&quality=insiders)
+[![Install in VS Code Insiders](https://img.shields.io/badge/VS%20Code%20Insiders-Install%20Tigris%20MCP%20Server-24bfa5)](https://insiders.vscode.dev/redirect/mcp/install?name=Tigris%20MCP%20Server&config=%7B%22mcpServers%22%3A%7B%22tigris-mcp-server%22%3A%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40tigrisdata%2Ftigris-mcp-server%22%2C%22run%22%5D%2C%22env%22%3A%7B%22AWS_ACCESS_KEY_ID%22%3A%22YOUR_AWS_ACCESS_KEY_ID%22%2C%22AWS_SECRET_ACCESS_KEY%22%3A%22YOUR_AWS_SECRET_ACCESS_KEY%22%2C%22AWS_ENDPOINT_URL_S3%22%3A%22https%3A%2F%2Ft3.storage.dev%22%7D%7D%7D%7D&quality=insiders)
 
 ### 2. Docker
 
@@ -78,7 +79,7 @@ credentials:
 docker run \
   -e AWS_ACCESS_KEY_ID \
   -e AWS_SECRET_ACCESS_KEY \
-  -e AWS_ENDPOINT_URL_S3=https://fly.storage.tigris.dev \
+  -e AWS_ENDPOINT_URL_S3=https://t3.storage.dev \
   -i --rm \
   --mount type=bind,src=$HOME/tigris-mcp-server,dst=$HOME/tigris-mcp-server \
   quay.io/tigrisdata/tigris-mcp-server:latest
@@ -97,13 +98,13 @@ npx -y @tigrisdata/tigris-mcp-server run
 
 By default, the MCP Server reads its configuration from environment variables:
 
-| Variable                | Description                                                    |
-| ----------------------- | -------------------------------------------------------------- |
-| `AWS_ACCESS_KEY_ID`     | Your Tigris access key ID                                      |
-| `AWS_SECRET_ACCESS_KEY` | Your Tigris secret access key                                  |
-| `AWS_ENDPOINT_URL_S3`   | S3-compatible endpoint (e.g. `https://fly.storage.tigris.dev`) |
-| `USE_AWS_PROFILES`      | (Optional) `true` to use existing AWS CLI profiles             |
-| `AWS_PROFILE`           | (Optional) AWS profile name to use                             |
+| Variable                | Description                                            |
+| ----------------------- | ------------------------------------------------------ |
+| `AWS_ACCESS_KEY_ID`     | Your Tigris access key ID                              |
+| `AWS_SECRET_ACCESS_KEY` | Your Tigris secret access key                          |
+| `AWS_ENDPOINT_URL_S3`   | S3-compatible endpoint (e.g. `https://t3.storage.dev`) |
+| `USE_AWS_PROFILES`      | (Optional) `true` to use existing AWS CLI profiles     |
+| `AWS_PROFILE`           | (Optional) AWS profile name to use                     |
 
 ## Manual Setup for Claude Desktop & Cursor AI
 
@@ -121,7 +122,7 @@ Add one of the following blocks to your client’s configuration file:
       "env": {
         "AWS_ACCESS_KEY_ID": "YOUR_AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY": "YOUR_AWS_SECRET_ACCESS_KEY",
-        "AWS_ENDPOINT_URL_S3": "https://fly.storage.tigris.dev",
+        "AWS_ENDPOINT_URL_S3": "https://t3.storage.dev",
       },
     },
   },
@@ -154,7 +155,7 @@ Add one of the following blocks to your client’s configuration file:
       "env": {
         "AWS_ACCESS_KEY_ID": "YOUR_AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY": "YOUR_AWS_SECRET_ACCESS_KEY",
-        "AWS_ENDPOINT_URL_S3": "https://fly.storage.tigris.dev",
+        "AWS_ENDPOINT_URL_S3": "https://t3.storage.dev",
       },
     },
   },

--- a/docs/sdks/fly/index.md
+++ b/docs/sdks/fly/index.md
@@ -84,14 +84,6 @@ https://my-assets.t3.tigrisfiles.io/logo.png
 No credentials or signed URLs are needed — the URL works directly in a browser,
 `curl`, `wget`, `<img>` tags, etc.
 
-:::info
-
-Existing Fly.io accounts can also access public content at
-`bucket-name.fly.storage.tigris.dev`. This continues to work but is not
-available for new accounts.
-
-:::
-
 For production use, we recommend setting up a
 [custom domain](/docs/buckets/custom-domain/) so your public URLs stay stable.
 See the [Public Bucket](/docs/buckets/public-bucket/) guide for full details.

--- a/docs/sdks/s3/aws-cli.md
+++ b/docs/sdks/s3/aws-cli.md
@@ -10,10 +10,7 @@ Requests to Tigris must be directed to the appropriate service endpoint, usually
 by updating your endpoint URL configuration:
 
 - IAM requests must be directed to `https://iam.storage.dev`
-- S3 requests made from outside Fly should be directed to
-  `https://t3.storage.dev`
-- S3 requests made from within Fly must be directed to
-  `https://fly.storage.tigris.dev`
+- S3 requests must be directed to `https://t3.storage.dev`
 
 When using the AWS CLI, this service endpoint is set by default based on the
 region and is not configured by the user directly. AWS S3 recommends using
@@ -36,8 +33,7 @@ Default output format [None]: json
 ```
 
 You can then use the AWS CLI as you normally would, but with the
-`--endpoint-url` flag set to `https://t3.storage.dev` or
-`https://fly.storage.tigris.dev`:
+`--endpoint-url` flag set to `https://t3.storage.dev`:
 
 ```bash
 aws s3api list-buckets --endpoint-url https://t3.storage.dev

--- a/docs/sdks/s3/aws-elixir-sdk.mdx
+++ b/docs/sdks/s3/aws-elixir-sdk.mdx
@@ -7,10 +7,7 @@ This guide assumes that you have followed the steps in the
 available.
 
 You may continue to use the ExAWS SDK as you normally would, but with the
-endpoint set to Tigris. If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev).
+endpoint set to Tigris at [https://t3.storage.dev](https://t3.storage.dev).
 
 This example reads the credentials from the environment variables
 `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.

--- a/docs/sdks/s3/aws-go-sdk.mdx
+++ b/docs/sdks/s3/aws-go-sdk.mdx
@@ -7,10 +7,7 @@ This guide assumes that you have followed the steps in the
 available.
 
 You may continue to use the AWS Go SDK as you normally would, but with the
-endpoint set to Tigris. If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev).
+endpoint set to Tigris at [https://t3.storage.dev](https://t3.storage.dev).
 
 This example uses the [AWS Go SDK v2](https://github.com/aws/aws-sdk-go-v2) and
 reads the default credentials file or the environment variables

--- a/docs/sdks/s3/aws-java-sdk.md
+++ b/docs/sdks/s3/aws-java-sdk.md
@@ -5,10 +5,7 @@ This guide assumes that you have followed the steps in the
 available.
 
 You may continue to use the AWS Java SDK as you normally would, but with the
-endpoint set to Tigris. If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev).
+endpoint set to Tigris at [https://t3.storage.dev](https://t3.storage.dev).
 
 This example uses the [AWS Java SDK v2](https://github.com/aws/aws-sdk-java-v2)
 

--- a/docs/sdks/s3/aws-js-sdk.mdx
+++ b/docs/sdks/s3/aws-js-sdk.mdx
@@ -7,11 +7,8 @@ This guide assumes that you have followed the steps in the
 available.
 
 You may continue to use the AWS JS SDK as you normally would, but with the
-endpoint set to Tigris. If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev). Also make sure
-that `s3ForcePathStyle` is set to `false`.
+endpoint set to Tigris at [https://t3.storage.dev](https://t3.storage.dev). Also
+make sure that `s3ForcePathStyle` is set to `false`.
 
 ```js
 import { S3Client } from "@aws-sdk/client-s3";

--- a/docs/sdks/s3/aws-net-sdk.mdx
+++ b/docs/sdks/s3/aws-net-sdk.mdx
@@ -7,10 +7,7 @@ This guide assumes that you have followed the steps in the
 available.
 
 You may continue to use the AWS .Net SDK as you normally would, but with the
-endpoint set to Tigris. If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev).
+endpoint set to Tigris at [https://t3.storage.dev](https://t3.storage.dev).
 
 This example uses the
 [AWS .Net SDK v3](https://www.nuget.org/packages/AWSSDK.S3) and reads the
@@ -27,10 +24,7 @@ dotnet add package AWSSDK.SSOOIDC
 ```
 
 Then you can use the SDK as you normally would, but with the endpoint set to
-Tigris. If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev).
+Tigris at [https://t3.storage.dev](https://t3.storage.dev).
 
 import gettingStarted from "!!raw-loader!../../../examples/dotnet/GettingStarted.cs";
 

--- a/docs/sdks/s3/aws-php-sdk.md
+++ b/docs/sdks/s3/aws-php-sdk.md
@@ -5,10 +5,7 @@ This guide assumes that you have followed the steps in the
 available.
 
 You may continue to use the AWS PHP SDK as you normally would, but with the
-endpoint set to Tigris. If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev).
+endpoint set to Tigris at [https://t3.storage.dev](https://t3.storage.dev).
 
 ## Getting started
 

--- a/docs/sdks/s3/aws-python-sdk.mdx
+++ b/docs/sdks/s3/aws-python-sdk.mdx
@@ -7,11 +7,8 @@ This guide assumes that you have followed the steps in the
 available.
 
 You may continue to use the AWS Python SDK as you normally would, but with the
-endpoint set to Tigris. If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev). Also ensure
-that the addressing style is set to `virtual`.
+endpoint set to Tigris at [https://t3.storage.dev](https://t3.storage.dev). Also
+ensure that the addressing style is set to `virtual`.
 
 ```python
 # Create S3 service client

--- a/docs/sdks/s3/aws-ruby-sdk.mdx
+++ b/docs/sdks/s3/aws-ruby-sdk.mdx
@@ -7,11 +7,8 @@ This guide assumes that you have followed the steps in the
 available.
 
 You may continue to use the AWS Ruby SDK as you normally would, but with the
-endpoint set to Tigris. If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev). Also make sure
-`force_path_style` is set to false:
+endpoint set to Tigris at [https://t3.storage.dev](https://t3.storage.dev). Also
+make sure `force_path_style` is set to false:
 
 ```ruby
 s3 = Aws::S3::Client.new(
@@ -32,10 +29,7 @@ import Gemfile from "!!raw-loader!../../../examples/ruby/Gemfile";
 <CodeBlock language="ruby">{Gemfile}</CodeBlock>
 
 Then you can use the SDK as you normally would, but with the endpoint set to
-Tigris. If you are using Tigris outside of Fly, use the endpoint
-[https://t3.storage.dev](https://t3.storage.dev). If you are using Tigris from
-within Fly, use the endpoint
-[https://fly.storage.tigris.dev](https://fly.storage.tigris.dev).
+Tigris at [https://t3.storage.dev](https://t3.storage.dev).
 
 import gettingStarted from "!!raw-loader!../../../examples/ruby/getting_started.rb";
 

--- a/examples/elixir/config/config.exs
+++ b/examples/elixir/config/config.exs
@@ -9,5 +9,5 @@ config :ex_aws,
 
 config :ex_aws, :s3,
   scheme: "https://",
-  host: "fly.storage.tigris.dev",
+  host: "t3.storage.dev",
   region: "auto"

--- a/src/components/SDKCards/snippets.ts
+++ b/src/components/SDKCards/snippets.ts
@@ -195,7 +195,7 @@ if config_env() == :prod do
 
   config :ex_aws, :s3,
     scheme: "https://",
-    host: "fly.storage.tigris.dev",
+    host: "t3.storage.dev",
     region: "auto"
     
 # List all buckets


### PR DESCRIPTION
## Summary

- Drop all mentions of `fly.storage.tigris.dev` from the SDK guides (Ruby, .NET, PHP, Python, JS, Go, Java, Elixir, CLI), bucket/object docs, MCP quickstart, TAG security doc, and the SDK card snippets — leaving `t3.storage.dev` as the single recommended endpoint.
- Preserve the Fly.io regions table in `docs/concepts/regions.md`, renamed from `### fly.storage.tigris.dev` to `### Fly.io available regions`, since the underlying region availability is still relevant context.
- Remove the legacy "Existing Fly.io accounts can also access ..." callout from `docs/sdks/fly/index.md` and `docs/buckets/public-bucket.md`. The `flyctl` workflow itself is unchanged.

## Why

Agents reading these docs were treating `fly.storage.tigris.dev` as authoritative because it appeared alongside or before `t3.storage.dev` in many examples. `t3.storage.dev` is the preferred endpoint for all users — pruning the fly hostname from prose, code samples, and config snippets keeps agents from defaulting to the wrong one.

## Test plan

- [ ] `npm run build` succeeds
- [ ] Spot-check rendered SDK and bucket pages — endpoint references read cleanly
- [ ] Confirm `docs/concepts/regions.md` still shows the Fly.io region list under "Fly.io available regions"