### PR TITLE
docs: move changelog to top-level sidebar item

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -713,11 +713,6 @@ const sidebars = {
           ],
         },
         "training/tigrisfs",
-        {
-          type: "doc",
-          label: "Changelog",
-          id: "changelog/index",
-        },
       ],
     },
     {
@@ -1016,6 +1011,11 @@ const sidebars = {
         "legal/data-processing",
         "legal/sla",
       ],
+    },
+    {
+      type: "doc",
+      label: "Changelog",
+      id: "changelog/index",
     },
   ],
 };

--- a/sidebars.js
+++ b/sidebars.js
@@ -992,6 +992,11 @@ const sidebars = {
       ],
     },
     {
+      type: "doc",
+      label: "Changelog",
+      id: "changelog/index",
+    },
+    {
       type: "link",
       label: "Pricing",
       href: "https://www.tigrisdata.com/pricing/",
@@ -1011,11 +1016,6 @@ const sidebars = {
         "legal/data-processing",
         "legal/sla",
       ],
-    },
-    {
-      type: "doc",
-      label: "Changelog",
-      id: "changelog/index",
     },
   ],
 };


### PR DESCRIPTION
## Summary
- Move the Changelog entry from inside the Product section to be the last top-level item in the sidebar (after Legal).

## Test plan
- [ ] Run `npm start` and verify the Changelog appears as a top-level item at the bottom of the sidebar
- [ ] Verify the Changelog no longer appears under Product

🤖 Generated with [Claude Code](https://claude.com/claude-code)