### PR TITLE
docs: correct webhook retry behavior in object notifications

### DIFF
--- a/docs/ai/agent-kit/index.mdx
+++ b/docs/ai/agent-kit/index.mdx
@@ -377,8 +377,8 @@ if (error) throw error;
 ```
 
 Once set up, every matching object event in the bucket posts a JSON payload to
-the webhook URL. Delivery is at-least-once and any non-2xx response is retried
-— your endpoint must be idempotent. See
+the webhook URL. Delivery is at-least-once and any non-2xx response is retried —
+your endpoint must be idempotent. See
 [object notifications](/docs/buckets/object-notifications) for the full payload
 schema and filter syntax.
 

--- a/docs/ai/agent-kit/index.mdx
+++ b/docs/ai/agent-kit/index.mdx
@@ -377,8 +377,8 @@ if (error) throw error;
 ```
 
 Once set up, every matching object event in the bucket posts a JSON payload to
-the webhook URL. Delivery is at-least-once with retries on 5xx — your endpoint
-must be idempotent. See
+the webhook URL. Delivery is at-least-once and any non-2xx response is retried
+— your endpoint must be idempotent. See
 [object notifications](/docs/buckets/object-notifications) for the full payload
 schema and filter syntax.
 

--- a/docs/buckets/object-notifications.md
+++ b/docs/buckets/object-notifications.md
@@ -22,8 +22,8 @@ Object notifications are delivered via a webhook, and obey the following rules:
 - Tigris will make an HTTP POST request to the webhook URL with the event
   payload.
 - A `200` status code acknowledges the request was successful.
-- If a `200` status is not received, Tigris will retry for a maximum of 3 times
-  before giving up and marking the notifications as sent.
+- Delivery is at-least-once with retries on 5xx responses, so your endpoint
+  must be idempotent.
 - If a webhook request takes longer than 10 seconds the request will be aborted
   and retried.
 

--- a/docs/buckets/object-notifications.md
+++ b/docs/buckets/object-notifications.md
@@ -21,9 +21,8 @@ Object notifications are delivered via a webhook, and obey the following rules:
 
 - Tigris will make an HTTP POST request to the webhook URL with the event
   payload.
-- A `200` status code acknowledges the request was successful.
-- Delivery is at-least-once with retries on 5xx responses, so your endpoint
-  must be idempotent.
+- A `2xx` status code acknowledges the request was successful. Any other status
+  is treated as a failure and retried.
 - If a webhook request takes longer than 10 seconds the request will be aborted
   and retried.
 


### PR DESCRIPTION
## Summary

- The webhook section of `docs/buckets/object-notifications.md` previously stated that Tigris retries a max of 3 times then gives up — that's not what actually happens.
- Replaced that line with the at-least-once + retry-on-5xx wording that matches what the Agent Kit doc already says, and reminds readers their endpoint must be idempotent.

## Test plan

- [ ] `npm run lint` passes
- [ ] Page renders correctly in the dev server

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior or APIs are modified. Main risk is limited to potential confusion if the clarified retry semantics differ from actual service behavior.
> 
> **Overview**
> Clarifies webhook delivery semantics for Tigris object notifications: delivery is *at-least-once* and **any non-`2xx` response is retried**, so webhook handlers must be idempotent.
> 
> Updates both the Agent Kit coordination docs (`docs/ai/agent-kit/index.mdx`) and the core object notifications page (`docs/buckets/object-notifications.md`) to align on the same retry/acknowledgement wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1055411dab85848f012e70b458d4e774541f7be9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->