### PR TITLE
feat: link AI section buttons to get-started AI pages

### DIFF
--- a/docs/quickstarts/mcp.mdx
+++ b/docs/quickstarts/mcp.mdx
@@ -1,5 +1,9 @@
 # MCP
 
+import MCPInstallBox from "@site/src/components/MCPInstallBox";
+
+<MCPInstallBox />
+
 ## Overview
 
 The Tigris MCP Server implements the

--- a/src/components/MCPInstallBox/index.jsx
+++ b/src/components/MCPInstallBox/index.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import "./styles.css";
+
+const CURSOR_URL =
+  "cursor://anysphere.cursor-deeplink/mcp/install?name=tigris&config=eyJ1cmwiOiJodHRwczovL21jcC5zdG9yYWdlLmRldi9tY3AifQ%3D%3D";
+
+const VSCODE_URL =
+  "vscode:mcp/install?%7B%22name%22%3A%22tigris%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.storage.dev%2Fmcp%22%7D";
+
+const CLAUDE_URL = "/docs/mcp/remote/#claude-desktop";
+
+const ALL_INTEGRATIONS_URL = "/docs/mcp/remote/";
+
+function CursorIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 256 256"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M209.74 45.16L164.84 90.06L75.44 22.32L47.74 36.52L114.42 114.52L24 147.8L24 176.2L114.08 155.2L47.74 219.48L75.44 233.68L187.64 140.16L209.74 118.06L232 95.8L232 67.34L209.74 45.16Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function VSCodeIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 100 100"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M95.4 16.4L71.9 5L29.7 42.1L12.3 28.3L4.6 31.9V68.1L12.3 71.7L29.7 57.9L71.9 95L95.4 83.6V16.4ZM29.7 62.6L12.3 50V50L29.7 37.4V62.6ZM71.9 77.4L42.1 50L71.9 22.6V77.4Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function ClaudeIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M15.3 3.8C14.2 3.3 13.1 3 12 3C7 3 3 7 3 12s4 9 9 9c1.1 0 2.2-.3 3.3-.8"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <circle cx="9" cy="10" r="1.2" fill="currentColor" />
+      <circle cx="13.5" cy="10" r="1.2" fill="currentColor" />
+      <path
+        d="M18.5 7.5L19.5 4M20 9L23 8M20.5 12L23 13"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export default function MCPInstallBox() {
+  return (
+    <aside className="mcp-install-box" aria-label="Quick install MCP server">
+      <div className="mcp-install-box-header">
+        <span className="mcp-install-box-eyebrow">Quick install</span>
+        <h3 className="mcp-install-box-title">Add Tigris MCP to your editor</h3>
+        <p className="mcp-install-box-subtitle">
+          One click connects your editor to the hosted Tigris MCP server. No
+          configuration required.
+        </p>
+      </div>
+
+      <div className="mcp-install-box-buttons">
+        <a href={CURSOR_URL} className="mcp-install-btn">
+          <CursorIcon />
+          <span>Add to Cursor</span>
+        </a>
+        <a href={VSCODE_URL} className="mcp-install-btn">
+          <VSCodeIcon />
+          <span>Add to VS Code</span>
+        </a>
+        <a href={CLAUDE_URL} className="mcp-install-btn">
+          <ClaudeIcon />
+          <span>Add to Claude</span>
+        </a>
+      </div>
+
+      <a href={ALL_INTEGRATIONS_URL} className="mcp-install-box-link">
+        See all integrations &rarr;
+      </a>
+    </aside>
+  );
+}

--- a/src/components/MCPInstallBox/styles.css
+++ b/src/components/MCPInstallBox/styles.css
@@ -1,0 +1,126 @@
+.mcp-install-box {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  margin: 1.5rem 0 2rem;
+  border-radius: 14px;
+  border: 1px solid rgba(98, 254, 181, 0.28);
+  background:
+    radial-gradient(
+      120% 120% at 0% 0%,
+      rgba(98, 254, 181, 0.1) 0%,
+      transparent 60%
+    ),
+    var(--docs-color-background-100);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset;
+}
+
+[data-theme="light"] .mcp-install-box {
+  border-color: rgba(56, 172, 140, 0.35);
+  background:
+    radial-gradient(
+      120% 120% at 0% 0%,
+      rgba(56, 172, 140, 0.08) 0%,
+      transparent 60%
+    ),
+    var(--docs-color-background-100);
+}
+
+.mcp-install-box-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.mcp-install-box-eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+}
+
+.mcp-install-box-title {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--docs-color-text);
+}
+
+.mcp-install-box-subtitle {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--docs-color-text-100);
+  margin: 0;
+  max-width: 60ch;
+}
+
+.mcp-install-box-buttons {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.mcp-install-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.7rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--docs-color-text);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  transition:
+    background-color 0.18s ease,
+    border-color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.mcp-install-btn:hover,
+.mcp-install-btn:focus-visible {
+  background: rgba(98, 254, 181, 0.12);
+  border-color: rgba(98, 254, 181, 0.4);
+  color: var(--docs-color-text);
+  text-decoration: none;
+  transform: translateY(-1px);
+  outline: none;
+}
+
+[data-theme="light"] .mcp-install-btn {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: var(--docs-color-border);
+}
+
+[data-theme="light"] .mcp-install-btn:hover,
+[data-theme="light"] .mcp-install-btn:focus-visible {
+  background: rgba(56, 172, 140, 0.08);
+  border-color: rgba(56, 172, 140, 0.45);
+}
+
+.mcp-install-box-link {
+  align-self: flex-start;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+  padding-top: 0.25rem;
+}
+
+.mcp-install-box-link:hover,
+.mcp-install-box-link:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+@media screen and (max-width: 640px) {
+  .mcp-install-box-buttons {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/ToolCards/index.jsx
+++ b/src/components/ToolCards/index.jsx
@@ -143,7 +143,7 @@ export default function ToolCards() {
           description="Manage buckets, keys, and global configurations from your terminal. Built for speed and scriptability in CI/CD pipelines."
           to="/cli/"
         >
-          <div className="tool-card-code">
+          <div className="tool-card-code tool-card-cli-code">
             <div className="tool-card-code-header">
               <div className="tool-card-dots">
                 <span />
@@ -204,81 +204,44 @@ export default function ToolCards() {
           description="Empower your AI assistants. Expose your Tigris buckets and objects to LLMs via the Model Context Protocol for seamless context integration."
           to="/quickstarts/mcp"
         >
-          <div className="tool-card-mcp-buttons">
-            <a
-              href="cursor://anysphere.cursor-deeplink/mcp/install?name=tigris&config=eyJ1cmwiOiJodHRwczovL21jcC5zdG9yYWdlLmRldi9tY3AifQ%3D%3D"
-              className="tool-card-mcp-btn"
+          <div className="tool-card-ai-buttons">
+            <Link
+              to="/skills"
+              className="tool-card-mcp-btn tool-card-ai-btn-featured"
               onClick={(e) => e.stopPropagation()}
             >
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 256 256"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
+              Agent Skills
+            </Link>
+            <div className="tool-card-ai-grid">
+              <Link
+                to="/quickstarts/mcp"
+                className="tool-card-mcp-btn"
+                onClick={(e) => e.stopPropagation()}
               >
-                <path
-                  d="M209.74 45.16L164.84 90.06L75.44 22.32L47.74 36.52L114.42 114.52L24 147.8L24 176.2L114.08 155.2L47.74 219.48L75.44 233.68L187.64 140.16L209.74 118.06L232 95.8L232 67.34L209.74 45.16Z"
-                  fill="currentColor"
-                />
-              </svg>
-              Add to Cursor
-            </a>
-            <a
-              href="vscode:mcp/install?%7B%22name%22%3A%22tigris%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.storage.dev%2Fmcp%22%7D"
-              className="tool-card-mcp-btn"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 100 100"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
+                MCP Server
+              </Link>
+              <Link
+                to="/ai/agent-plugins"
+                className="tool-card-mcp-btn"
+                onClick={(e) => e.stopPropagation()}
               >
-                <path
-                  d="M95.4 16.4L71.9 5L29.7 42.1L12.3 28.3L4.6 31.9V68.1L12.3 71.7L29.7 57.9L71.9 95L95.4 83.6V16.4ZM29.7 62.6L12.3 50V50L29.7 37.4V62.6ZM71.9 77.4L42.1 50L71.9 22.6V77.4Z"
-                  fill="currentColor"
-                />
-              </svg>
-              Add to VS Code
-            </a>
-            <a
-              href="/docs/mcp/remote/#claude-desktop"
-              className="tool-card-mcp-btn"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
+                Agent Plugins
+              </Link>
+              <Link
+                to="/ai/agent-shell/"
+                className="tool-card-mcp-btn"
+                onClick={(e) => e.stopPropagation()}
               >
-                <path
-                  d="M15.3 3.8C14.2 3.3 13.1 3 12 3C7 3 3 7 3 12s4 9 9 9c1.1 0 2.2-.3 3.3-.8"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <circle cx="9" cy="10" r="1.2" fill="currentColor" />
-                <circle cx="13.5" cy="10" r="1.2" fill="currentColor" />
-                <path
-                  d="M18.5 7.5L19.5 4M20 9L23 8M20.5 12L23 13"
-                  stroke="currentColor"
-                  strokeWidth="1.8"
-                  strokeLinecap="round"
-                />
-              </svg>
-              Add to Claude
-            </a>
-            <a
-              href="/docs/mcp/remote/"
-              className="tool-card-mcp-link"
-              onClick={(e) => e.stopPropagation()}
-            >
-              See all integrations &rarr;
-            </a>
+                Agent Shell
+              </Link>
+              <Link
+                to="/ai/agent-kit/"
+                className="tool-card-mcp-btn"
+                onClick={(e) => e.stopPropagation()}
+              >
+                Agent Kit
+              </Link>
+            </div>
           </div>
         </ToolCard>
 

--- a/src/components/ToolCards/styles.css
+++ b/src/components/ToolCards/styles.css
@@ -156,6 +156,116 @@
   gap: 8px;
 }
 
+/* CLI preview: top-align terminal with the SDK card's first terminal,
+   and stretch the terminal box to match the SDK's lower terminal bottom */
+.tool-card-preview:has(> .tool-card-cli-code) {
+  flex: 1;
+  margin-top: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.tool-card-cli-code {
+  flex: 1;
+}
+
+/* AI buttons: featured top button + 2x2 grid */
+.tool-card-preview:has(> .tool-card-ai-buttons) {
+  flex: 1;
+  margin-top: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.tool-card-ai-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+
+.tool-card-ai-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  flex: 1;
+}
+
+/* Override the shared mcp-btn look for buttons inside the AI card */
+.tool-card-ai-buttons .tool-card-mcp-btn {
+  justify-content: center;
+  text-align: center;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  padding: 0.75rem 1rem;
+  border-radius: 0.625rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  transition:
+    background-color 0.18s ease,
+    border-color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.tool-card-ai-buttons .tool-card-mcp-btn:hover {
+  background: rgba(98, 254, 181, 0.1);
+  border-color: rgba(98, 254, 181, 0.35);
+  transform: translateY(-1px);
+}
+
+[data-theme="light"] .tool-card-ai-buttons .tool-card-mcp-btn {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: var(--docs-color-border);
+}
+
+[data-theme="light"] .tool-card-ai-buttons .tool-card-mcp-btn:hover {
+  background: rgba(56, 172, 140, 0.08);
+  border-color: rgba(56, 172, 140, 0.4);
+}
+
+.tool-card-ai-btn-featured {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  padding: 0.9rem 1rem !important;
+  background: linear-gradient(
+    135deg,
+    rgba(98, 254, 181, 0.16) 0%,
+    rgba(98, 254, 181, 0.06) 100%
+  ) !important;
+  border-color: rgba(98, 254, 181, 0.32) !important;
+  color: #fff;
+}
+
+.tool-card-ai-buttons .tool-card-ai-btn-featured:hover {
+  background: linear-gradient(
+    135deg,
+    rgba(98, 254, 181, 0.24) 0%,
+    rgba(98, 254, 181, 0.12) 100%
+  ) !important;
+  border-color: rgba(98, 254, 181, 0.5) !important;
+}
+
+[data-theme="light"] .tool-card-ai-btn-featured {
+  background: linear-gradient(
+    135deg,
+    rgba(56, 172, 140, 0.14) 0%,
+    rgba(56, 172, 140, 0.05) 100%
+  ) !important;
+  border-color: rgba(56, 172, 140, 0.4) !important;
+  color: var(--docs-color-text);
+}
+
+[data-theme="light"] .tool-card-ai-buttons .tool-card-ai-btn-featured:hover {
+  background: linear-gradient(
+    135deg,
+    rgba(56, 172, 140, 0.22) 0%,
+    rgba(56, 172, 140, 0.1) 100%
+  ) !important;
+  border-color: rgba(56, 172, 140, 0.55) !important;
+}
+
 .tool-card-mcp-btn {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary

- Replace the home page AI card's MCP install deeplinks with links to the five "Use AI" pages from the get-started sidebar group: Agent Skills (featured top button) and a 2×2 grid for MCP Server, Agent Plugins, Agent Shell, and Agent Kit.
- Polish the home grid alignment: CLI terminal top now lines up with the SDK card's first terminal, the CLI box stretches so its bottom matches the SDK's lower terminal, and the AI button section fills its preview so the top aligns with the existing-code terminal.
- Move the editor install buttons (Cursor, VS Code, Claude, "See all integrations") to the MCP quickstart page as a new `MCPInstallBox` component placed near the top of `docs/quickstarts/mcp.mdx`.

## Test plan

- [ ] Visit `/docs/` and confirm the AI tool card shows the new featured "Agent Skills" button plus the 2×2 grid; click each button and verify it navigates to the correct page.
- [ ] On the home page, confirm the SDK / CLI terminal tops align and the CLI box bottom aligns with the SDK's `app.ts` box; confirm the AI buttons top aligns with the "Use Your Existing Code" terminal top.
- [ ] Visit `/docs/quickstarts/mcp` and confirm the install box renders with the eyebrow + title + subtitle, three install buttons, and the "See all integrations" link; verify the deeplinks/URLs match the previous behavior.
- [ ] Toggle light theme and confirm both the home grid and the MCP install box read correctly.
- [ ] Resize to mobile width (<640px) and confirm the install buttons collapse to one column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)