### PR TITLE
Include CopyObject among APIs for which snapshot header can be set

### DIFF
--- a/docs/buckets/snapshots-and-forks.mdx
+++ b/docs/buckets/snapshots-and-forks.mdx
@@ -473,8 +473,9 @@ when making these requests to retrieve objects from a specific snapshot.
 :::note
 
 Any UNIX nanosecond-precision timestamp (e.g., 1765889000501544464) can be used
-as a snapshot parameter value for ListObjectsV2, GetObject and HeadObject API
-calls, even if there is no snapshot created at that particular time.
+as a snapshot parameter value for `ListObjectsV2`, `GetObject`, `HeadObject` and
+`CopyObject` API calls, even if there is no snapshot created at that particular
+time.
 
 :::
 

--- a/docs/buckets/snapshots-and-forks.mdx
+++ b/docs/buckets/snapshots-and-forks.mdx
@@ -457,18 +457,23 @@ print(f"Snapshot version: {fork_info['fork_source_snapshot']}")
 </TabItem>
 </Tabs>
 
-## Listing and retrieving objects from a snapshot
+## Retrieving objects in a snapshot
 
-Objects can be listed in a snapshot with the same ListObjectsV2 API call, with
-an additional header: `X-Tigris-Snapshot-Version: SNAPSHOT_VERSION`. Similarly,
-specific versions of an object in a particular snapshot can be retrieved with
-the same GetObject API call and header. The same approach also applies to
-HeadObject requests.
+Existing APIs can be used to retrieve objects in a snapshot when an additional
+header is set:
+
+- To list objects use `ListObjectsV2`
+- To get objects use `GetObject`
+- To head objects use `HeadObject`
+- To copy objects use `CopyObject`
+
+Additional header: `X-Tigris-Snapshot-Version: SNAPSHOT_VERSION` needs to be set
+when making these requests to retrieve objects from a specific snapshot.
 
 :::note
 
 Any UNIX nanosecond-precision timestamp (e.g., 1765889000501544464) can be used
-as snapshot parameter value for ListObjectsV2, GetObject and HeadObject API
+as a snapshot parameter value for ListObjectsV2, GetObject and HeadObject API
 calls, even if there is no snapshot created at that particular time.
 
 :::


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that updates which S3 APIs accept the snapshot version header; no runtime code paths are modified.
> 
> **Overview**
> Updates `docs/buckets/snapshots-and-forks.mdx` to clarify how to retrieve data from a snapshot: renames the section and rewrites it as a list of supported S3 APIs, explicitly adding `CopyObject` alongside `ListObjectsV2`, `GetObject`, and `HeadObject`.
> 
> Also updates the note to include `CopyObject` as an API that can use a nanosecond timestamp as the `X-Tigris-Snapshot-Version` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36f5a2ba4fd21f0d5a40cddb115c405af330646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->