### PR TITLE
docs: add further reading section to duckdb quickstart

### DIFF
--- a/docs/quickstarts/duckdb.mdx
+++ b/docs/quickstarts/duckdb.mdx
@@ -111,3 +111,18 @@ FROM
 WHERE
   location LIKE 'Seattle%';
 ```
+
+## Further reading
+
+- [DuckLake on Tigris](/docs/quickstarts/ducklake/) — build a SQL lakehouse on
+  Tigris with tables, transactions, and snapshots instead of ad-hoc queries
+  against files.
+- [Get your data ducks in a row with DuckLake](https://www.tigrisdata.com/blog/ducklake/)
+  — why DuckLake matters, with a longer walkthrough.
+- [Data Time Travel with DuckLake and Tigris](https://www.tigrisdata.com/blog/ducklake-time-travel/)
+  — using DuckLake snapshots to roll back changes and fork timelines.
+- [Fending off scrapers with Tigris and DuckDB](https://www.tigrisdata.com/blog/anubis/)
+  — analyzing honeypot logs in Tigris with DuckDB.
+- [Fifty agents for the price of one bucket](https://www.tigrisdata.com/blog/fifty-agents-one-bucket/)
+  — using DuckDB alongside LanceDB for agent memory and SQL analytics over a
+  single Lance file.


### PR DESCRIPTION
Cross-link to the new DuckLake quickstart and four DuckDB-on-Tigris blog posts so readers landing on this page can find their next step. The DuckLake link is root-relative per the URL standard from #457.

Supersedes #446, which was based on an old main and re-introduced absolute docs URLs that #457 had standardized away.

