### PR TITLE
Add rb2b visitor identification to docs site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,6 +12,18 @@ const tigrisConfig = require("./tigris.config");
 const lightCodeTheme = require("prism-react-renderer").themes.github;
 const darkCodeTheme = require("prism-react-renderer").themes.dracula;
 
+const rb2bHeadTag =
+  process.env.VERCEL_ENV === "production"
+    ? [
+        {
+          tagName: "script",
+          attributes: {},
+          innerHTML:
+            '(function(){var m=document.cookie.match(/(?:^|; )tigris_geo=([^;]*)/);var c=m?decodeURIComponent(m[1]):"";if(c!=="US"&&c!=="CA")return;if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz";var f=document.getElementsByTagName("script")[0];f.parentNode.insertBefore(s,f);})();',
+        },
+      ]
+    : [];
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Tigris Object Storage Documentation",
@@ -25,6 +37,7 @@ const config = {
   trailingSlash: true,
 
   headTags: [
+    ...rb2bHeadTag,
     {
       tagName: "link",
       attributes: {


### PR DESCRIPTION
## Summary
Docs pages (served under \`tigrisdata.com/docs/\` via the marketing site's Vercel rewrite) previously had no rb2b coverage — the inline rb2b initializer only lives in the marketing site's Next.js root layout. Most docs traffic was therefore invisible to rb2b.

This PR adds the same initializer to the docs site via \`docusaurus.config.js\` \`headTags\`. The script:

- Only ships in production builds (\`VERCEL_ENV === "production"\`).
- Reads the \`tigris_geo\` cookie set by the marketing site's edge middleware (which already runs on \`/docs/*\` requests) and only fires for US/CA visitors, matching the marketing site's geo gate.
- Loads the rb2b CDN bundle via the same first-party proxy path (\`/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz\`) — that path is resolved by the marketing site's Next.js rewrites.
- Sets cookies on \`.tigrisdata.com\`, so identifications made on docs pages are visible to the marketing site (and the \`Rb2bPostHogBridge\` there will identify the PostHog session if the visitor later browses to a marketing page).

No middleware, proxy, or PostHog wiring is added here — the marketing site already handles all of those for docs requests.

## Test plan
- [ ] After deploy, visit any docs page from a US/CA IP.
- [ ] Network tab should show a request to \`/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz\` returning 200.
- [ ] \`document.cookie\` should include \`_reb2buid\`, \`_reb2bsessionID\`, etc. within a few seconds of load.
- [ ] \`window.reb2b\` should expose \`assignIdentity\` and \`collect\` functions.
- [ ] In rb2b's dashboard, identifications from docs traffic should start appearing alongside marketing-page traffic.
- [ ] Non-US/CA visitors should not load the script (verify by VPN to UK and confirming no \`/_tigris/insights/\` request and no rb2b cookies).
- [ ] Preview deployments should NOT load the script (the \`VERCEL_ENV === "production"\` gate keeps it out of previews/dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Injects a new production-only analytics/visitor-identification script into all docs pages, which can affect privacy/compliance expectations and page performance if misconfigured. Geo gating via `tigris_geo` reduces blast radius but relies on correct cookie/rewrites in production.
> 
> **Overview**
> Adds an `rb2bHeadTag` entry to `docusaurus.config.js` and prepends it to `headTags` so docs pages load rb2b visitor identification.
> 
> The injected inline script is **production-only** (`VERCEL_ENV === "production"`), **geo-gated** via the `tigris_geo` cookie (US/CA only), and loads the rb2b bundle through the first-party proxy path `/_tigris/insights/...` while guarding against double-initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 658b827cdbe421637040723086e6147bbe28a6fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->