### PR TITLE
Install PostHog on docs site with rb2b -> PostHog identify bridge

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,17 +12,29 @@ const tigrisConfig = require("./tigris.config");
 const lightCodeTheme = require("prism-react-renderer").themes.github;
 const darkCodeTheme = require("prism-react-renderer").themes.dracula;
 
-const rb2bHeadTag =
-  process.env.VERCEL_ENV === "production"
-    ? [
-        {
-          tagName: "script",
-          attributes: {},
-          innerHTML:
-            '(function(){var m=document.cookie.match(/(?:^|; )tigris_geo=([^;]*)/);var c=m?decodeURIComponent(m[1]):"";if(c!=="US"&&c!=="CA")return;if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz";var f=document.getElementsByTagName("script")[0];f.parentNode.insertBefore(s,f);})();',
-        },
-      ]
-    : [];
+const isProduction = process.env.VERCEL_ENV === "production";
+
+const posthogHeadTag = isProduction
+  ? [
+      {
+        tagName: "script",
+        attributes: {},
+        innerHTML:
+          "!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split('.');2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement('script')).type='text/javascript',p.crossOrigin='anonymous',p.async=!0,p.src=s.api_host.replace('.i.posthog.com','-assets.i.posthog.com')+'/static/array.js',(r=t.getElementsByTagName('script')[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a='posthog',u.people=u.people||[],u.toString=function(t){var e='posthog';return'posthog'!=a&&(e+='.'+a),t||(e+=' (stub)'),e},u.people.toString=function(){return u.toString(1)+'.people (stub)'},o='init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric'.split(' '),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init('phc_6a2zd9w9hGzIqYl527bL4dXk3Wz8J9pEHyXTwP1hHq4',{api_host:'https://ph.tigrisdata.com',capture_pageview:false,capture_pageleave:true});",
+      },
+    ]
+  : [];
+
+const rb2bHeadTag = isProduction
+  ? [
+      {
+        tagName: "script",
+        attributes: {},
+        innerHTML:
+          '(function(){var m=document.cookie.match(/(?:^|; )tigris_geo=([^;]*)/);var c=m?decodeURIComponent(m[1]):"";if(c!=="US"&&c!=="CA")return;if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz";var f=document.getElementsByTagName("script")[0];f.parentNode.insertBefore(s,f);})();',
+      },
+    ]
+  : [];
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -37,6 +49,7 @@ const config = {
   trailingSlash: true,
 
   headTags: [
+    ...posthogHeadTag,
     ...rb2bHeadTag,
     {
       tagName: "link",
@@ -99,7 +112,10 @@ const config = {
     },
   ],
 
-  clientModules: [require.resolve("./src/util/augmentConsoleLinks.js")],
+  clientModules: [
+    require.resolve("./src/util/posthog.js"),
+    require.resolve("./src/util/augmentConsoleLinks.js"),
+  ],
 
   presets: [
     [

--- a/src/util/augmentConsoleLinks.js
+++ b/src/util/augmentConsoleLinks.js
@@ -5,11 +5,14 @@ export function onRouteDidUpdate({ location, previousLocation }) {
     // Don't execute if we are still on the same page; the lifecycle may be fired
     // because the hash changes (e.g. when navigating between headings)
     if (location.pathname !== previousLocation?.pathname) {
-      // PostHog should be available with the exception of in the development
-      // environment
+      // PostHog's loader snippet creates a truthy stub before the library
+      // finishes loading. The stub exposes get_distinct_id / get_session_id
+      // as queued no-ops that return undefined, so we have to also check
+      // __loaded to avoid stamping ?pid=undefined&sid=undefined onto links.
+      // onRouteDidUpdate fires again on the next navigation, by which point
+      // the real library will be in place.
       const posthog = window.posthog;
-      if (!posthog) {
-        console.warn("Cannot set 'pid' for console links");
+      if (!posthog || !posthog.__loaded) {
         return;
       }
 

--- a/src/util/augmentConsoleLinks.js
+++ b/src/util/augmentConsoleLinks.js
@@ -16,29 +16,29 @@ export function onRouteDidUpdate({ location, previousLocation }) {
         return;
       }
 
+      const pid = posthog.get_distinct_id();
+      const sid = posthog.get_session_id();
+      if (!pid || !sid) return;
+
       // Get all anchors that contain the console URL
       const allSignupLinks = document.querySelectorAll(
         `a[href*="${tigrisConfig.consoleUrl}`,
       );
 
-      // Add the `pid` search parameter if it is not present
-      const existingPid = location.searchParams?.get("pid");
-      const existingSid = location.searchParams?.get("sid");
-      const pid = existingPid || posthog.get_distinct_id();
-      const sid = existingSid || posthog.get_session_id();
+      // Always overwrite pid/sid so links re-stamped on an earlier route
+      // change pick up the current PostHog identity (e.g., after the rb2b
+      // bridge calls posthog.identify and the distinct_id switches from
+      // the anonymous UUID to rb2b_<uid>).
       allSignupLinks.forEach((el) => {
         // eslint-disable-next-line no-undef
         const href = new URL(el.getAttribute("href"));
-
-        if (href.searchParams.has("pid") === false) {
+        if (href.searchParams.get("pid") !== pid) {
           href.searchParams.set("pid", pid);
-          el.setAttribute("href", href.toString());
         }
-
-        if (href.searchParams.has("sid") === false) {
+        if (href.searchParams.get("sid") !== sid) {
           href.searchParams.set("sid", sid);
-          el.setAttribute("href", href.toString());
         }
+        el.setAttribute("href", href.toString());
       });
     }
   } catch (e) {

--- a/src/util/posthog.js
+++ b/src/util/posthog.js
@@ -1,0 +1,44 @@
+function getCookie(name) {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp("(?:^|; )" + name + "=([^;]*)"),
+  );
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+let bridgeStarted = false;
+
+function startRb2bPostHogBridge() {
+  if (bridgeStarted) return;
+  bridgeStarted = true;
+
+  const country = getCookie("tigris_geo");
+  if (country !== "US" && country !== "CA") return;
+
+  let attempts = 0;
+  const iv = window.setInterval(() => {
+    attempts++;
+    const uid = getCookie("_reb2buid");
+    const posthog = window.posthog;
+    if (uid && posthog && typeof posthog.identify === "function") {
+      posthog.identify(`rb2b_${uid}`);
+      posthog.register({ rb2b_visitor_id: uid });
+      window.clearInterval(iv);
+    } else if (attempts >= 60) {
+      window.clearInterval(iv);
+    }
+  }, 500);
+}
+
+export function onRouteDidUpdate({ location, previousLocation }) {
+  if (typeof window === "undefined") return;
+
+  if (location.pathname !== previousLocation?.pathname) {
+    const posthog = window.posthog;
+    if (posthog && typeof posthog.capture === "function") {
+      posthog.capture("$pageview", { $current_url: window.location.href });
+    }
+  }
+
+  startRb2bPostHogBridge();
+}

--- a/src/util/posthog.js
+++ b/src/util/posthog.js
@@ -6,30 +6,46 @@ function getCookie(name) {
   return match ? decodeURIComponent(match[1]) : null;
 }
 
-let bridgeStarted = false;
+let pollInProgress = false;
+let lastPageviewUrl = null;
 
 function startRb2bPostHogBridge() {
-  if (bridgeStarted) return;
+  // A poll is already running for this page-load; don't start a parallel one.
+  if (pollInProgress) return;
 
   // tigris_geo may be absent on the very first render (e.g., the edge
-  // middleware didn't reach this specific request). Only commit to the
-  // bridgeStarted lock once the cookie has actually been seen as US/CA —
-  // otherwise leave the door open for retries on subsequent route changes.
+  // middleware didn't reach this specific request). Only commit to a poll
+  // once the cookie has actually been seen as US/CA — otherwise leave the
+  // door open for retries on subsequent route changes.
   const country = getCookie("tigris_geo");
   if (country !== "US" && country !== "CA") return;
 
-  bridgeStarted = true;
+  // Already identified as an rb2b person — nothing to do.
+  const posthog = window.posthog;
+  if (
+    posthog &&
+    posthog.__loaded &&
+    typeof posthog.get_distinct_id === "function" &&
+    String(posthog.get_distinct_id() ?? "").startsWith("rb2b_")
+  ) {
+    return;
+  }
 
+  pollInProgress = true;
   let attempts = 0;
   const iv = window.setInterval(() => {
     attempts++;
     const uid = getCookie("_reb2buid");
-    const posthog = window.posthog;
-    if (uid && posthog && typeof posthog.identify === "function") {
-      posthog.identify(`rb2b_${uid}`);
-      posthog.register({ rb2b_visitor_id: uid });
+    const ph = window.posthog;
+    if (uid && ph && typeof ph.identify === "function") {
+      ph.identify(`rb2b_${uid}`);
+      ph.register({ rb2b_visitor_id: uid });
+      pollInProgress = false;
       window.clearInterval(iv);
     } else if (attempts >= 60) {
+      // 30s of polling without a cookie — give up for this attempt but allow
+      // a future route change to start a fresh poll if the cookie shows up.
+      pollInProgress = false;
       window.clearInterval(iv);
     }
   }, 500);
@@ -43,16 +59,15 @@ export function onRouteDidUpdate({ location, previousLocation }) {
     if (posthog && typeof posthog.capture === "function") {
       // PostHog's capture_pageleave only fires on real tab close /
       // visibilitychange. For Docusaurus SPA navigations we have to emit
-      // $pageleave manually with the URL of the page being left so
-      // dwell-time math on the previous page is correct.
-      if (previousLocation) {
-        const prevUrl =
-          window.location.origin +
-          previousLocation.pathname +
-          (previousLocation.search || "");
-        posthog.capture("$pageleave", { $current_url: prevUrl });
+      // $pageleave manually. Use the URL we recorded when the previous
+      // $pageview fired (so the baseUrl and any search params match exactly
+      // what was captured), not a reconstruction from previousLocation
+      // which omits the Docusaurus baseUrl.
+      if (lastPageviewUrl) {
+        posthog.capture("$pageleave", { $current_url: lastPageviewUrl });
       }
       posthog.capture("$pageview", { $current_url: window.location.href });
+      lastPageviewUrl = window.location.href;
     }
   }
 

--- a/src/util/posthog.js
+++ b/src/util/posthog.js
@@ -10,10 +10,15 @@ let bridgeStarted = false;
 
 function startRb2bPostHogBridge() {
   if (bridgeStarted) return;
-  bridgeStarted = true;
 
+  // tigris_geo may be absent on the very first render (e.g., the edge
+  // middleware didn't reach this specific request). Only commit to the
+  // bridgeStarted lock once the cookie has actually been seen as US/CA —
+  // otherwise leave the door open for retries on subsequent route changes.
   const country = getCookie("tigris_geo");
   if (country !== "US" && country !== "CA") return;
+
+  bridgeStarted = true;
 
   let attempts = 0;
   const iv = window.setInterval(() => {
@@ -36,6 +41,17 @@ export function onRouteDidUpdate({ location, previousLocation }) {
   if (location.pathname !== previousLocation?.pathname) {
     const posthog = window.posthog;
     if (posthog && typeof posthog.capture === "function") {
+      // PostHog's capture_pageleave only fires on real tab close /
+      // visibilitychange. For Docusaurus SPA navigations we have to emit
+      // $pageleave manually with the URL of the page being left so
+      // dwell-time math on the previous page is correct.
+      if (previousLocation) {
+        const prevUrl =
+          window.location.origin +
+          previousLocation.pathname +
+          (previousLocation.search || "");
+        posthog.capture("$pageleave", { $current_url: prevUrl });
+      }
       posthog.capture("$pageview", { $current_url: window.location.href });
     }
   }


### PR DESCRIPTION
## Summary
\`src/util/augmentConsoleLinks.js\` already expects \`window.posthog\` to exist — it attaches PostHog \`distinct_id\` / \`session_id\` as \`pid\` / \`sid\` query params on Tigris Console signup links so console-side analytics can correlate signups back to docs sessions. But PostHog itself was never installed in this repo, so that code silently warns \`"Cannot set 'pid' for console links"\` on every route change.

PR #467 added the rb2b script via \`headTags\` but didn't install PostHog, so docs-only visitors get an rb2b cookie but never get identified in PostHog. This PR finishes the integration.

## Changes
- **\`docusaurus.config.js\` headTags**: add the standard PostHog JS snippet before the rb2b initializer, gated on \`VERCEL_ENV === "production"\`. Init points at the same project (\`phc_6a2zd9w9hGzIqYl527bL4dXk3Wz8J9pEHyXTwP1hHq4\`) and host (\`ph.tigrisdata.com\`) the marketing site uses, so docs + marketing visitors share a single PostHog person on the shared \`www.tigrisdata.com\` origin.
- **\`src/util/posthog.js\` (new client module)**:
  - Captures \`$pageview\` on each Docusaurus route change (init sets \`capture_pageview: false\` because Docusaurus is an SPA and PostHog's auto-detection doesn't fire reliably on the framework's client-side navigations).
  - Polls \`_reb2buid\` cookie for up to 30s after first route render and calls \`posthog.identify('rb2b_<uid>')\` + \`posthog.register({ rb2b_visitor_id })\`. Same pattern as \`Rb2bPostHogBridge\` in the marketing repo.
  - Polling is geo-gated on the \`tigris_geo\` cookie (US/CA only) so non-US/CA visitors don't burn 60 \`document.cookie\` reads waiting for a cookie that will never appear.
- **\`docusaurus.config.js\` clientModules**: register \`posthog.js\` before \`augmentConsoleLinks.js\` so PostHog is wired up by the time that module looks for \`window.posthog\`.

## Side effect benefit
\`augmentConsoleLinks.js\` will start working as originally intended. Console signup links clicked from docs pages will carry real \`pid\` / \`sid\` query params, enabling console-side attribution of signups back to the docs session that generated them.

## Test plan
- [ ] After deploy, open a docs page from a US/CA IP in Incognito.
- [ ] Network tab should show requests to \`ph.tigrisdata.com/static/array.js\` (PostHog loader) and \`/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz\` (rb2b script).
- [ ] DevTools console:
  - \`window.posthog.get_distinct_id()\` returns the PostHog anonymous UUID initially, then \`rb2b_<uid>\` once \`_reb2buid\` is set.
  - \`document.cookie\` contains \`tigris_geo\`, \`_reb2buid\`, \`ph_phc_…_posthog\`.
- [ ] Click a Tigris Console signup link → URL should include \`?pid=<distinct_id>&sid=<session_id>\` (proves \`augmentConsoleLinks.js\` is working).
- [ ] Navigate to a different docs page → \`$pageview\` event should appear in PostHog activity.
- [ ] Navigate to a marketing page → same PostHog person record should pick up there (same origin).
- [ ] Preview deployments should NOT load PostHog or rb2b (\`VERCEL_ENV === "production"\` gate).

## Note
The docs site also has Google Analytics installed (\`gtag: { trackingID: "G-GW2DNH9EW4" }\` in docusaurus.config.js). PostHog and GA will run side-by-side after this lands; no conflict, but two parallel analytics stacks. Consolidating onto one (likely PostHog, since marketing already uses it) is a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds production-only third-party analytics loading plus SPA pageview/pageleave instrumentation and cookie-based identify polling, which can impact privacy/compliance and client-side behavior if misconfigured.
> 
> **Overview**
> Adds **production-gated PostHog** loading to `docusaurus.config.js` (head `script` snippet) and registers a new client module `src/util/posthog.js`.
> 
> The new client module manually captures `$pageview`/`$pageleave` on Docusaurus route changes and polls for the `_reb2buid` cookie (US/CA only via `tigris_geo`) to `posthog.identify('rb2b_<uid>')` and `register` the visitor ID.
> 
> Updates `augmentConsoleLinks.js` to only stamp console links once PostHog is truly loaded (`__loaded`), and to always overwrite `pid`/`sid` so links reflect the current PostHog identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c549d2f9859a589339247cbd394c9a54e4e89f38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->