### PR TITLE
Remove dormant posthog-docusaurus plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -157,15 +157,6 @@ const config = {
 
   plugins: [
     [
-      "posthog-docusaurus",
-      {
-        apiKey: process.env.NEXT_PUBLIC_POSTHOG_APIKEY,
-        appUrl: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-        opt_in_site_apps: true,
-        enableInDevelopment: process.env.USE_POSTHOG_IN_DEVELOPMENT === "true",
-      },
-    ],
-    [
       "docusaurus-plugin-openapi-docs",
       {
         id: "openapi", // plugin id

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "dotenv": "^17.3.1",
         "follow-redirects": ">=1.15.11",
         "param-case": "^4.0.0",
-        "posthog-docusaurus": "^2.0.5",
         "prism-react-renderer": "^2.4.1",
         "raw-loader": "^4.0.2",
         "react": "^19.2.4",
@@ -23332,15 +23331,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/posthog-docusaurus": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/posthog-docusaurus/-/posthog-docusaurus-2.0.5.tgz",
-      "integrity": "sha512-Ray65LYEJrMMqDtsBUBXunEVP/g4wtATvq/xz9rchUoLy/9mSkkFgUko/8DVtGxgiP3vivpFMgfb9HpCuDrBHg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.15.1"
       }
     },
     "node_modules/postman-code-generators": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "dotenv": "^17.3.1",
     "follow-redirects": ">=1.15.11",
     "param-case": "^4.0.0",
-    "posthog-docusaurus": "^2.0.5",
     "prism-react-renderer": "^2.4.1",
     "raw-loader": "^4.0.2",
     "react": "^19.2.4",


### PR DESCRIPTION
## Summary
PR #468 installed PostHog directly via the head-tag snippet plus a manual \`\$pageview\` capture in \`src/util/posthog.js\`. After that landed, the existing \`posthog-docusaurus\` plugin entry in \`docusaurus.config.js\` (gated on \`NEXT_PUBLIC_POSTHOG_APIKEY\` and \`NEXT_PUBLIC_POSTHOG_HOST\` env vars) is a footgun: if those env vars are ever set, the plugin would init a *second* PostHog instance and start auto-capturing pageviews, producing duplicate \`\$pageview\` events alongside the manual captures.

This PR completes the cleanup:
- Drops the \`posthog-docusaurus\` plugin entry from \`docusaurus.config.js\`.
- Removes \`posthog-docusaurus\` from \`package.json\` dependencies.
- Refreshes \`package-lock.json\`.

The head-tag snippet is now the sole PostHog integration on docs, matching the marketing site (which uses \`posthog-js\` directly) and the blog (PR tigrisdata/tigris-blog#397, which makes the same change there).

## Test plan
- [ ] After merge + deploy, confirm only one PostHog instance loads (one network request to \`ph.tigrisdata.com/static/array.js\`, not two).
- [ ] Navigating between docs pages produces exactly one \`\$pageview\` event in PostHog per route change (no duplicates).
- [ ] \`window.posthog.__loaded\` is true after the snippet finishes loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only removes an unused analytics plugin/dependency; main impact is ensuring PostHog doesn’t double-initialize and emit duplicate pageview events if env vars are set.
> 
> **Overview**
> **Removes the `posthog-docusaurus` integration from the docs build** by deleting its plugin entry in `docusaurus.config.js`.
> 
> Cleans up dependencies by dropping `posthog-docusaurus` from `package.json` and updating `package-lock.json`, leaving the existing head-tag PostHog snippet + `src/util/posthog.js` route-capture as the only tracking path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9576bd5f1235fd95d09c6289a88f7b9abaf8b4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->