### PR TITLE
Defer PostHog init to dormant posthog-docusaurus plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,29 +12,17 @@ const tigrisConfig = require("./tigris.config");
 const lightCodeTheme = require("prism-react-renderer").themes.github;
 const darkCodeTheme = require("prism-react-renderer").themes.dracula;
 
-const isProduction = process.env.VERCEL_ENV === "production";
-
-const posthogHeadTag = isProduction
-  ? [
-      {
-        tagName: "script",
-        attributes: {},
-        innerHTML:
-          "!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split('.');2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement('script')).type='text/javascript',p.crossOrigin='anonymous',p.async=!0,p.src=s.api_host.replace('.i.posthog.com','-assets.i.posthog.com')+'/static/array.js',(r=t.getElementsByTagName('script')[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a='posthog',u.people=u.people||[],u.toString=function(t){var e='posthog';return'posthog'!=a&&(e+='.'+a),t||(e+=' (stub)'),e},u.people.toString=function(){return u.toString(1)+'.people (stub)'},o='init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric'.split(' '),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init('phc_6a2zd9w9hGzIqYl527bL4dXk3Wz8J9pEHyXTwP1hHq4',{api_host:'https://ph.tigrisdata.com',capture_pageview:false,capture_pageleave:true});",
-      },
-    ]
-  : [];
-
-const rb2bHeadTag = isProduction
-  ? [
-      {
-        tagName: "script",
-        attributes: {},
-        innerHTML:
-          '(function(){var m=document.cookie.match(/(?:^|; )tigris_geo=([^;]*)/);var c=m?decodeURIComponent(m[1]):"";if(c!=="US"&&c!=="CA")return;if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz";var f=document.getElementsByTagName("script")[0];f.parentNode.insertBefore(s,f);})();',
-      },
-    ]
-  : [];
+const rb2bHeadTag =
+  process.env.VERCEL_ENV === "production"
+    ? [
+        {
+          tagName: "script",
+          attributes: {},
+          innerHTML:
+            '(function(){var m=document.cookie.match(/(?:^|; )tigris_geo=([^;]*)/);var c=m?decodeURIComponent(m[1]):"";if(c!=="US"&&c!=="CA")return;if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz";var f=document.getElementsByTagName("script")[0];f.parentNode.insertBefore(s,f);})();',
+        },
+      ]
+    : [];
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -49,7 +37,6 @@ const config = {
   trailingSlash: true,
 
   headTags: [
-    ...posthogHeadTag,
     ...rb2bHeadTag,
     {
       tagName: "link",

--- a/src/util/posthog.js
+++ b/src/util/posthog.js
@@ -55,20 +55,17 @@ export function onRouteDidUpdate({ location, previousLocation }) {
   if (typeof window === "undefined") return;
 
   if (location.pathname !== previousLocation?.pathname) {
+    // posthog-docusaurus auto-captures $pageview on each route change but
+    // does not emit a corresponding $pageleave for the page being left —
+    // PostHog's built-in pageleave only fires on real tab close /
+    // visibilitychange. Without an explicit $pageleave, dwell-time math
+    // for per-page sessions is wrong. Emit it manually using the URL we
+    // recorded for the previous $pageview so the two events align.
     const posthog = window.posthog;
-    if (posthog && typeof posthog.capture === "function") {
-      // PostHog's capture_pageleave only fires on real tab close /
-      // visibilitychange. For Docusaurus SPA navigations we have to emit
-      // $pageleave manually. Use the URL we recorded when the previous
-      // $pageview fired (so the baseUrl and any search params match exactly
-      // what was captured), not a reconstruction from previousLocation
-      // which omits the Docusaurus baseUrl.
-      if (lastPageviewUrl) {
-        posthog.capture("$pageleave", { $current_url: lastPageviewUrl });
-      }
-      posthog.capture("$pageview", { $current_url: window.location.href });
-      lastPageviewUrl = window.location.href;
+    if (posthog && typeof posthog.capture === "function" && lastPageviewUrl) {
+      posthog.capture("$pageleave", { $current_url: lastPageviewUrl });
     }
+    lastPageviewUrl = window.location.href;
   }
 
   startRb2bPostHogBridge();


### PR DESCRIPTION
## Summary
PR #468 (already merged) shipped a custom PostHog install via a head-tag snippet plus a client module that called `posthog.init`, captured `$pageview` on route changes, and ran the rb2b -> PostHog bridge. The repo already had a conditional `posthog-docusaurus` plugin entry gated on `NEXT_PUBLIC_POSTHOG_APIKEY` and `NEXT_PUBLIC_POSTHOG_HOST` that does the same init + pageview work. Setting those env vars makes the plugin the single canonical PostHog integration — no need for the custom snippet or pageview capture I added.

This PR backs out the redundant pieces:

- Remove the `posthogHeadTag` from `docusaurus.config.js`.
- Strip the PostHog init + `$pageview` capture from `src/util/posthog.js`. Keep only the rb2b -> PostHog bridge and the manual `$pageleave` emit. `posthog-docusaurus` doesn't emit `$pageleave` for SPA navigations (only on real tab close / visibilitychange), so dwell-time math still needs that custom hook.
- Leave the rb2b head-tag, the `augmentConsoleLinks.js` fixes, and the `posthog-docusaurus` plugin entry + dependency in place.

## Required env var change in Vercel
Production env vars on the docs Vercel project need to be set:

- `NEXT_PUBLIC_POSTHOG_APIKEY` (the same PostHog project key used by the marketing site — pull it from the marketing site's Vercel env or from PostHog → Project Settings)
- `NEXT_PUBLIC_POSTHOG_HOST=https://ph.tigrisdata.com`

After those are set and this PR deploys, the plugin will activate and PostHog will be initialized exactly like before — same project, same person record shared across marketing / docs / blog on the `.tigrisdata.com` origin.

## Test plan
- [ ] Set the two env vars in Vercel production for the docs project.
- [ ] After merge + deploy, visit a docs page from a US/CA IP in Incognito.
- [ ] Network tab: one PostHog load from `ph.tigrisdata.com/static/array.js` (no duplicate), one rb2b script load from `/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz`.
- [ ] DevTools console: `window.posthog.__loaded === true`, `window.posthog.get_distinct_id()` returns the PostHog UUID initially, then `rb2b_<uid>` once `_reb2buid` lands.
- [ ] Click a Tigris Console signup link → URL has `?pid=...&sid=...` populated from the current (`rb2b_*` if identified) PostHog distinct_id.
- [ ] PostHog activity stream shows exactly one `$pageview` per route change (no duplicates) and a matching `$pageleave` for the page being left.
- [ ] Preview deploys: no rb2b script load (head-tag still gated on `VERCEL_ENV === "production"`), no PostHog load (plugin won't activate if env vars aren't propagated to preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)