### PR TITLE
Fire rb2b.collect() on Docusaurus SPA route changes

### DIFF
--- a/src/util/posthog.js
+++ b/src/util/posthog.js
@@ -66,6 +66,16 @@ export function onRouteDidUpdate({ location, previousLocation }) {
       posthog.capture("$pageleave", { $current_url: lastPageviewUrl });
     }
     lastPageviewUrl = window.location.href;
+
+    // rb2b's CDN bundle auto-captures the initial pageview but not
+    // subsequent SPA navigations. Without this call, every visitor looks
+    // like a single-pageview visit in rb2b's pipeline, which throttles
+    // their identification volume. Skip the initial render (handled by
+    // rb2b's own bootstrap).
+    const reb2b = window.reb2b;
+    if (previousLocation && reb2b && typeof reb2b.collect === "function") {
+      reb2b.collect();
+    }
   }
 
   startRb2bPostHogBridge();


### PR DESCRIPTION
## Summary
rb2b's CDN bundle auto-captures the initial pageview when it loads, but Docusaurus uses SPA navigation for in-app links — the page doesn't reload, so rb2b sees only one pageview per visitor session no matter how many docs pages they browse. Their support confirmed this is the cause of low identification volume: each visit looks like a single-pageview session in their pipeline, which throttles their identity-graph matching.

This PR adds a \`window.reb2b.collect()\` call to the existing \`onRouteDidUpdate\` hook in \`src/util/posthog.js\`. The call sits next to the manual \`$pageleave\` emit since both are "do something on each SPA route change."

Same pattern is also being added to:
- The blog: tigrisdata/tigris-blog#398
- The marketing site: tigrisdata/website#292

## Guards
- Only fires when \`previousLocation\` is set (skips the initial render — rb2b's bootstrap already captured that pageview).
- No-op when \`window.reb2b.collect\` isn't a function (visitor outside US/CA so the script never loaded, privacy blocker stripped it, etc.).

## Test plan
- [ ] After deploy, visit \`https://www.tigrisdata.com/docs/\` from a US/CA IP in Incognito.
- [ ] Wait for the \`_reb2buid\` cookie to land and \`window.reb2b.collect\` to be a function.
- [ ] Click an in-page sidebar link to navigate to another docs page.
- [ ] Network tab should show a new request to \`app.rb2b.com\` shortly after the URL change.
- [ ] Repeat with several more navigations — each should produce a fresh \`app.rb2b.com\` request.
- [ ] After ~24h of real traffic, rb2b's dashboard should show meaningfully higher identification volume than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a guarded `window.reb2b.collect()` call on client-side route changes, affecting only analytics/network requests and leaving behavior unchanged when rb2b isn’t loaded.
> 
> **Overview**
> Ensures rb2b receives a pageview signal on Docusaurus SPA route changes by calling `window.reb2b.collect()` inside `onRouteDidUpdate` when the path changes.
> 
> The call is *guarded* to skip the initial render (`previousLocation` must be set) and no-ops unless `window.reb2b.collect` is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874fd296cc013a6f3f74d655dd42df9abbe0e132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->