### PR TITLE
Load rb2b script directly from CloudFront

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ const rb2bHeadTag =
           tagName: "script",
           attributes: {},
           innerHTML:
-            '(function(){var m=document.cookie.match(/(?:^|; )tigris_geo=([^;]*)/);var c=m?decodeURIComponent(m[1]):"";if(c!=="US"&&c!=="CA")return;if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="/_tigris/insights/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz";var f=document.getElementsByTagName("script")[0];f.parentNode.insertBefore(s,f);})();',
+            '(function(){var m=document.cookie.match(/(?:^|; )tigris_geo=([^;]*)/);var c=m?decodeURIComponent(m[1]):"";if(c!=="US"&&c!=="CA")return;if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="https://ddwl4m2hdecbv.cloudfront.net/b/Z6PVLHQKD16R/Z6PVLHQKD16R.js.gz";var f=document.getElementsByTagName("script")[0];f.parentNode.insertBefore(s,f);})();',
         },
       ]
     : [];


### PR DESCRIPTION
## Summary
The \`/_tigris/insights/<key>/<file>\` proxy worked when first deployed and all five rb2b cookies populated correctly. Several days later, with no changes to the proxy configuration, the script started loading via the same proxy URL but no longer setting cookies or making backend calls. Direct-from-CloudFront load of the identical bytes still works in the same browser.

The script must now do hostname / origin / path validation on \`document.currentScript.src\` that refuses to operate when the URL isn't under \`cloudfront.net\`. The bundle is obfuscated so we can't see what specifically; rb2b support has been asked. Until they confirm how to satisfy the validation, this PR points \`s.src\` at their CloudFront directly so identifications flow again.

Same revert is going out on the marketing site (tigrisdata/website#294) and blog (tigrisdata/tigris-blog, separate PR).

## Trade-off
Privacy blockers (uBlock, Brave Shields, AdGuard, etc.) match on the \`cloudfront.net\` hostname and will block the script for those visitors. Acceptable to restore tracking for the ~80%+ who don't run such blockers — currently nobody is being tracked.

## Test plan
- [ ] After merge + deploy, visit \`https://www.tigrisdata.com/docs/\` from a US IP in a regular Chrome window.
- [ ] DevTools console: \`document.cookie.split('; ').filter(c => c.includes('_reb2'))\` should return all 5 rb2b cookies within a few seconds.
- [ ] Navigate between docs pages → \`window.reb2b.collect()\` fires on each route change (existing client module keeps working).
- [ ] rb2b dashboard: identification volume should rise meaningfully over the next 24–48h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it alters third-party script loading (potential adblock impact and dependency on an external CDN).
> 
> **Overview**
> Updates the production `rb2bHeadTag` injection in `docusaurus.config.js` to load the rb2b bundle from a CloudFront URL rather than the `/_tigris/insights/...` proxied path, keeping the same geo-gating and runtime loader behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e31201c93be5b57af1d25633d85606caf2b8da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->