### PR TITLE
docs: fix Slack/OG unfurls for S3 API compatibility page

### DIFF
--- a/docs/api/s3/index.mdx
+++ b/docs/api/s3/index.mdx
@@ -1,3 +1,8 @@
+---
+title: S3 API Compatibility
+description: Tigris S3 API compatibility matrix compared against Cloudflare R2 and Google Cloud Storage, generated from a shared test suite.
+---
+
 <style>{`
   .markdown table th:nth-child(2),
   .markdown table td:nth-child(2),

--- a/docs/api/s3/index.mdx
+++ b/docs/api/s3/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: S3 API Compatibility
-description: Tigris S3 API compatibility matrix compared against Cloudflare R2 and Google Cloud Storage, generated from a shared test suite.
+description:
+  Tigris S3 API compatibility matrix compared against Cloudflare R2 and Google
+  Cloud Storage, generated from a shared test suite.
 ---
 
 <style>{`
@@ -38,7 +40,10 @@ reports pass/fail results.
 | **Google Cloud Storage** | 45     | 23     | 68    | 66%   |
 
 ✅ = supported |
-<abbr title="Partial support — hover or click the note number for details">⚠️</abbr>
+
+<abbr title="Partial support — hover or click the note number for details">
+  ⚠️
+</abbr>
 = partial support | ❌ = not supported
 
 The complete list of S3 APIs is in the

--- a/docs/iam/index.md
+++ b/docs/iam/index.md
@@ -57,7 +57,7 @@ Refer to the [AWS CLI](/docs/sdks/s3/aws-cli/) and
 
 ### Access Key Operations: Tigris vs AWS IAM API
 
-Our [IAM APIs page](../api/s3/index.md#iam-apis) has more information, but at a
+Our [IAM APIs page](../api/s3/index.mdx#iam-apis) has more information, but at a
 high level:
 
 | Operation                               | Tigris Support | AWS Support | Description                                             |


### PR DESCRIPTION
## Summary

- Convert `docs/api/s3/index.md` to `.mdx` so the leading `<style>{\`…\`}</style>` JSX block at the top of the file stops rendering as literal text. In plain Markdown that block was being treated as page content, which caused Slack/OG unfurls to show `{\`` as the description.
- Add `title` and `description` frontmatter so the page no longer falls back to `"index"` for its `<title>` / `og:title` / `og:image` text.
- Update the one cross-reference in `docs/iam/index.md` from `../api/s3/index.md#iam-apis` to `.mdx`.

Verified via `npm run build` — generated `build/api/s3/index.html` now has:

- `<title>S3 API Compatibility | Tigris Object Storage Documentation</title>`
- `<meta name="description" content="Tigris S3 API compatibility matrix compared against Cloudflare R2 and Google Cloud Storage…">`
- Matching `og:title`, `og:description`, and an `og:image` rendered with the real title.

Note: existing Slack/Twitter/etc. unfurls are cached — links will need to be re-shared after this deploys for the new tags to take effect.

## Test plan

- [ ] CI build passes
- [ ] Spot-check `/docs/api/s3/` renders correctly in the deploy preview
- [ ] After merge + deploy, paste `https://www.tigrisdata.com/docs/api/s3/` into Slack and confirm the unfurl shows the correct title and description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust page rendering and metadata for correct Slack/OG unfurls; no product logic or APIs affected.
> 
> **Overview**
> Fixes rendering and social/SEO metadata for the S3 compatibility docs page by converting it to `index.mdx` (so the inline `<style>` block is treated as JSX) and adding `title`/`description` frontmatter for proper `<title>`/OG tags.
> 
> Updates the legend markup for the partial-support icon and adjusts the cross-link in `docs/iam/index.md` to reference the new `index.mdx#iam-apis` anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd73c089f46460a7926050bb519f57f4b81746c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->