### PR TITLE
partner-api: docs for lifecycle expiration rules

### DIFF
--- a/static/api/extensions/v1/api.yaml
+++ b/static/api/extensions/v1/api.yaml
@@ -1364,6 +1364,18 @@ components:
             Transitions must be in chronological order (earlier days/dates first).
           items:
             $ref: "#/components/schemas/LifecycleTransition"
+        filter:
+          $ref: "#/components/schemas/LifecycleRuleFilter"
+    LifecycleRuleFilter:
+      type: object
+      description: |
+        Optional scope for a lifecycle rule. When unset, the rule applies to every object in the bucket.
+      properties:
+        prefix:
+          type: string
+          description: |
+            Only apply this rule to objects whose keys start with the given prefix.
+            For example, `logs/` scopes the rule to objects under that prefix.
     LifecycleExpiration:
       type: object
       description: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only OpenAPI spec updates that add an optional `filter` field to lifecycle rules without changing runtime logic.
> 
> **Overview**
> Extends the Partner API OpenAPI spec to support scoping bucket lifecycle rules via an optional `filter` object on `LifecycleRule`.
> 
> Adds a new `LifecycleRuleFilter` schema with a `prefix` field to document prefix-based application of transitions/expiration rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 374a19cf0e764c014da192cf51bf7803cca8e99e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->