### PR TITLE
Update public bucket and presigned URL domain guidance

### DIFF
--- a/docs/ai-agents/vercel-object-storage.md
+++ b/docs/ai-agents/vercel-object-storage.md
@@ -198,11 +198,14 @@ async function uploadFile(file: File) {
 
 ## How Do I Serve Files from Tigris?
 
-For public buckets, files are accessible directly via the Tigris URL:
+For public buckets, files are accessible directly via a public content domain:
 
 ```text
-https://your-bucket-name.t3.storage.dev/path/to/file.jpg
+https://your-bucket-name.t3.tigrisbucket.io/path/to/file.jpg
 ```
+
+See [Public Buckets](/docs/buckets/public-bucket/) for all available domains.
+Do not use `t3.storage.dev` domain for serving public content.
 
 For private buckets, generate presigned GET URLs in your API routes:
 

--- a/docs/ai-agents/vercel-object-storage.md
+++ b/docs/ai-agents/vercel-object-storage.md
@@ -204,8 +204,8 @@ For public buckets, files are accessible directly via a public content domain:
 https://your-bucket-name.t3.tigrisbucket.io/path/to/file.jpg
 ```
 
-See [Public Buckets](/docs/buckets/public-bucket/) for all available domains.
-Do not use `t3.storage.dev` domain for serving public content.
+See [Public Buckets](/docs/buckets/public-bucket/) for all available domains. Do
+not use `t3.storage.dev` for serving public content.
 
 For private buckets, generate presigned GET URLs in your API routes:
 

--- a/docs/buckets/bucket-rules.md
+++ b/docs/buckets/bucket-rules.md
@@ -13,9 +13,9 @@ The following naming rules apply for buckets.
 
   :::info
 
-  Using a dot (.) will disable virtual-hosted style access (e.g.,
-  `https://foo.bucket.t3.storage.dev`) for a bucket. However, you can still
-  access it through a correctly configured
+  Using a dot (.) will disable virtual-hosted style access on public content
+  domains (e.g., `https://foo.bucket.t3.tigrisbucket.io`) for a bucket. However,
+  you can still access it through a correctly configured
   [custom domain](/docs/buckets/custom-domain.md).
 
   :::

--- a/docs/buckets/public-bucket.md
+++ b/docs/buckets/public-bucket.md
@@ -8,6 +8,15 @@ requirement applies to all organizations created after May 18, 2026.
 
 :::
 
+:::info
+
+`https://t3.storage.dev` is the API endpoint for authenticated SDK and CLI
+requests. Public bucket objects are not served from this domain — use the
+[public bucket domains](#public-bucket-domains) below or a
+[custom domain](./custom-domain.md).
+
+:::
+
 Sometimes you want to share your bucket with the world. You can do this by
 creating a public bucket. This will allow anyone to read the contents of your
 bucket. You can still control who can write to your bucket.

--- a/docs/objects/acl.md
+++ b/docs/objects/acl.md
@@ -44,7 +44,10 @@ readable, you can do so by setting the object ACL to `public-read`.
 aws s3api --endpoint-url https://t3.storage.dev put-object --bucket foo-bucket --key bar-public.txt --body bar.txt --acl public-read
 ```
 
-`--acl public-read` makes the object publicly viewable.
+`--acl public-read` makes the object publicly viewable at
+`https://foo-bucket.t3.tigrisbucket.io/bar-public.txt` (or another
+[public bucket domain](/docs/buckets/public-bucket#public-bucket-domains)).
+Do not use `t3.storage.dev` URLs for serving public content.
 
 ### Private objects in a public bucket
 

--- a/docs/objects/acl.md
+++ b/docs/objects/acl.md
@@ -46,8 +46,8 @@ aws s3api --endpoint-url https://t3.storage.dev put-object --bucket foo-bucket -
 
 `--acl public-read` makes the object publicly viewable at
 `https://foo-bucket.t3.tigrisbucket.io/bar-public.txt` (or another
-[public bucket domain](/docs/buckets/public-bucket#public-bucket-domains)).
-Do not use `t3.storage.dev` URLs for serving public content.
+[public bucket domain](/docs/buckets/public-bucket#public-bucket-domains)). Do
+not use `t3.storage.dev` for serving public content.
 
 ### Private objects in a public bucket
 

--- a/docs/objects/presigned.md
+++ b/docs/objects/presigned.md
@@ -1,12 +1,5 @@
 # Presigned URLs
 
-:::info
-
-`https://t3.storage.dev` is the API endpoint for authenticated SDK and CLI
-requests. Do not use it as the host in presigned URLs you share with clients.
-
-:::
-
 Presigned URLs are URLs that provide temporary access to private objects in a
 bucket. This is useful for allowing users to upload or download objects without
 requiring them to have AWS credentials or permissions.
@@ -33,63 +26,43 @@ Refer to the following examples to generate a presigned URL:
 - [AWS PHP SDK](/docs/sdks/s3/aws-php-sdk/#using-presigned-urls)
 - [AWS Python SDK](/docs/sdks/s3/aws-python-sdk/#using-presigned-urls)
 
-## Sharing presigned URLs with clients
+## Presigned URL with custom domain
 
-SDKs and the AWS CLI sign presigned URLs against `https://t3.storage.dev`. The
-generated URL uses a `t3.storage.dev` host and cannot be shared with clients
-directly.
+If you utilize a [custom domain with Tigris](../buckets/custom-domain.md), you
+can also generate the presigned URL with the custom domain. This allows you to
+have consistent branding and user experience. You can utilize any of the SDKs
+mentioned above to generate the presigned URL and do string manipulation to have
+your custom domain.
 
-After generating a presigned URL, replace the host with your
-[custom domain](../buckets/custom-domain.md) before distributing it. The query
-string (signature parameters) stays the same.
+For example:
 
-### Virtual-hosted style
-
-For bucket `foo-bucket` with custom domain `cdn.example.com`:
+For bucket `foo-bucket` with custom domain `cdn.example.com` and object key
+`hello.txt`, the AWS CLI command to generate a presigned URL looks like:
 
 ```bash
 aws s3 presign s3://foo-bucket/hello.txt --endpoint-url https://t3.storage.dev
 ```
 
-The generated URL looks like:
+The generated URL would look like:
 
 ```text
 https://foo-bucket.t3.storage.dev/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
 ```
 
-Replace the host before sharing:
-
-```text
-https://cdn.example.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
-```
-
-In code:
+Replace the host (`foo-bucket.t3.storage.dev` → `cdn.example.com`) before sharing:
 
 ```bash
 aws s3 presign s3://foo-bucket/hello.txt --endpoint-url https://t3.storage.dev \
   | sed 's/foo-bucket\.t3\.storage\.dev/cdn.example.com/'
 ```
 
-### Bucket name matches custom domain
-
-If your bucket name is the same as your custom domain (e.g. bucket
-`mybucket.mydomain.com` with domain `mybucket.mydomain.com`), the generated
-URL uses path-style addressing:
-
 ```text
-https://t3.storage.dev/mybucket.mydomain.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
-```
-
-Remove the `t3.storage.dev/` prefix:
-
-```bash
-aws s3 presign s3://mybucket.mydomain.com/hello.txt \
-  | sed 's/t3\.storage\.dev\///'
+https://cdn.example.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
 ```
 
 ## Security
 
-When utilizing a custom domain and sharing pre-signed URLs for uploading
+When utilizing a custom domain and sharing presigned URLs for uploading
 objects, be mindful that individuals could upload files like HTML, JS, SVG, or
 executable browser files. These could pose a risk of XSS (Cross-Site Scripting)
 on your domain. Proceed with caution in such scenarios.

--- a/docs/objects/presigned.md
+++ b/docs/objects/presigned.md
@@ -1,5 +1,12 @@
 # Presigned URLs
 
+:::info
+
+`https://t3.storage.dev` is the API endpoint for authenticated SDK and CLI
+requests. Do not use it as the host in presigned URLs you share with clients.
+
+:::
+
 Presigned URLs are URLs that provide temporary access to private objects in a
 bucket. This is useful for allowing users to upload or download objects without
 requiring them to have AWS credentials or permissions.
@@ -26,39 +33,58 @@ Refer to the following examples to generate a presigned URL:
 - [AWS PHP SDK](/docs/sdks/s3/aws-php-sdk/#using-presigned-urls)
 - [AWS Python SDK](/docs/sdks/s3/aws-python-sdk/#using-presigned-urls)
 
-## Presigned URL with custom domain
+## Sharing presigned URLs with clients
 
-If you utilize a [custom domain with Tigris](../buckets/custom-domain.md), you
-can also generate the presigned URL with the custom domain. This allows you to
-have consistent branding and user experience. You can utilize any of the SDKs
-mentioned above to generate the presigned URL and do string manipulation to have
-your custom domain.
+SDKs and the AWS CLI sign presigned URLs against `https://t3.storage.dev`. The
+generated URL uses a `t3.storage.dev` host and cannot be shared with clients
+directly.
 
-For example:
+After generating a presigned URL, replace the host with your
+[custom domain](../buckets/custom-domain.md) before distributing it. The query
+string (signature parameters) stays the same.
 
-For my bucket `mybucket.mydomain.com` and object key `hello.txt`, AWS CLI
-command to generate a presigned URL would look like:
+### Virtual-hosted style
+
+For bucket `foo-bucket` with custom domain `cdn.example.com`:
 
 ```bash
-aws s3 presign s3://mybucket.mydomain.com/hello.txt
+aws s3 presign s3://foo-bucket/hello.txt --endpoint-url https://t3.storage.dev
 ```
 
-and generated URL would look like:
+The generated URL looks like:
 
-```bash
-https://t3.storage.dev/mybucket.mydomain.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=tid_<>%2F20241210%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=<>X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=<>
+```text
+https://foo-bucket.t3.storage.dev/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
 ```
 
-You can remove `t3.storage.dev/` and make it look like:
+Replace the host before sharing:
 
-```bash
-https://mybucket.mydomain.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=tid_<>%2F20241210%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=<>X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=<>
+```text
+https://cdn.example.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
 ```
 
-Here is the bash one-liner to do the same:
+In code:
 
 ```bash
-aws s3 presign s3://mybucket.mydomain.com/hello.txt |  sed 's/t3.storage.dev\///'
+aws s3 presign s3://foo-bucket/hello.txt --endpoint-url https://t3.storage.dev \
+  | sed 's/foo-bucket\.t3\.storage\.dev/cdn.example.com/'
+```
+
+### Bucket name matches custom domain
+
+If your bucket name is the same as your custom domain (e.g. bucket
+`mybucket.mydomain.com` with domain `mybucket.mydomain.com`), the generated
+URL uses path-style addressing:
+
+```text
+https://t3.storage.dev/mybucket.mydomain.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
+```
+
+Remove the `t3.storage.dev/` prefix:
+
+```bash
+aws s3 presign s3://mybucket.mydomain.com/hello.txt \
+  | sed 's/t3\.storage\.dev\///'
 ```
 
 ## Security

--- a/docs/objects/presigned.md
+++ b/docs/objects/presigned.md
@@ -28,13 +28,11 @@ Refer to the following examples to generate a presigned URL:
 
 ## Presigned URL with custom domain
 
-If you utilize a [custom domain with Tigris](../buckets/custom-domain.md), you
-can also generate the presigned URL with the custom domain. This allows you to
-have consistent branding and user experience. You can utilize any of the SDKs
+If you use a [custom domain with Tigris](../buckets/custom-domain.md), you can
+also generate the presigned URL with the custom domain. This allows you to have
+consistent branding and user experience. You can utilize any of the SDKs
 mentioned above to generate the presigned URL and do string manipulation to have
 your custom domain.
-
-For example:
 
 For bucket `foo-bucket` with custom domain `cdn.example.com` and object key
 `hello.txt`, the AWS CLI command to generate a presigned URL looks like:
@@ -43,13 +41,14 @@ For bucket `foo-bucket` with custom domain `cdn.example.com` and object key
 aws s3 presign s3://foo-bucket/hello.txt --endpoint-url https://t3.storage.dev
 ```
 
-The generated URL would look like:
+The generated URL looks like this:
 
 ```text
 https://foo-bucket.t3.storage.dev/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
 ```
 
-Replace the host (`foo-bucket.t3.storage.dev` → `cdn.example.com`) before sharing:
+Replace the host (`foo-bucket.t3.storage.dev` → `cdn.example.com`) before
+sharing:
 
 ```bash
 aws s3 presign s3://foo-bucket/hello.txt --endpoint-url https://t3.storage.dev \
@@ -62,7 +61,7 @@ https://cdn.example.com/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
 
 ## Security
 
-When utilizing a custom domain and sharing presigned URLs for uploading
-objects, be mindful that individuals could upload files like HTML, JS, SVG, or
-executable browser files. These could pose a risk of XSS (Cross-Site Scripting)
-on your domain. Proceed with caution in such scenarios.
+When utilizing a custom domain and sharing presigned URLs for uploading objects,
+be mindful that individuals could upload files like HTML, JS, SVG, or executable
+browser files. These could pose a risk of XSS (Cross-Site Scripting) on your
+domain. Proceed with caution in such scenarios.

--- a/docs/sdks/s3/aws-elixir-sdk.mdx
+++ b/docs/sdks/s3/aws-elixir-sdk.mdx
@@ -88,11 +88,13 @@ import presignedUrls from "!!raw-loader!../../../examples/elixir/examples/presig
 
 ### Presigned URLs with custom domains
 
-You can also use a
-[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
+URLs with clients. Replace the host with your
+[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
+before distributing them:
 
 ```elixir
-branded_url = String.replace(presigned_url, "t3.storage.dev", "your-domain.example.com")
+branded_url = String.replace(
+  presigned_url, "foo-bucket.t3.storage.dev", "your-domain.example.com")
 IO.puts("Presigned URL for GET (custom domain): #{branded_url}")
 ```

--- a/docs/sdks/s3/aws-elixir-sdk.mdx
+++ b/docs/sdks/s3/aws-elixir-sdk.mdx
@@ -90,7 +90,7 @@ import presignedUrls from "!!raw-loader!../../../examples/elixir/examples/presig
 
 You can also use a
 [presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+by replacing the bucket host with your custom domain:
 
 ```elixir
 branded_url = String.replace(

--- a/docs/sdks/s3/aws-elixir-sdk.mdx
+++ b/docs/sdks/s3/aws-elixir-sdk.mdx
@@ -88,10 +88,9 @@ import presignedUrls from "!!raw-loader!../../../examples/elixir/examples/presig
 
 ### Presigned URLs with custom domains
 
-SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
-URLs with clients. Replace the host with your
-[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
-before distributing them:
+You can also use a
+[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
+by replacing the Tigris domain name with your custom domain name:
 
 ```elixir
 branded_url = String.replace(

--- a/docs/sdks/s3/aws-go-sdk.mdx
+++ b/docs/sdks/s3/aws-go-sdk.mdx
@@ -95,7 +95,8 @@ You can also use a
 by replacing the Tigris domain name with your custom domain name:
 
 ```go
-brandedURL := strings.ReplaceAll(presignedGetReq.URL, "tigris-example.t3.storage.dev", "your-domain.example.com")
+brandedURL := strings.ReplaceAll(
+    presignedGetReq.URL, "foo-bucket.t3.storage.dev", "your-domain.example.com")
 fmt.Printf("Presigned URL for GET (custom domain): %s\n", brandedURL)
 ```
 

--- a/docs/sdks/s3/aws-go-sdk.mdx
+++ b/docs/sdks/s3/aws-go-sdk.mdx
@@ -96,7 +96,7 @@ by replacing the bucket host with your custom domain:
 
 ```go
 brandedURL := strings.ReplaceAll(
-    presignedGetReq.URL, "foo-bucket.t3.storage.dev", "your-domain.example.com")
+    presignedGetReq.URL, bucketName+".t3.storage.dev", "your-domain.example.com")
 fmt.Printf("Presigned URL for GET (custom domain): %s\n", brandedURL)
 ```
 

--- a/docs/sdks/s3/aws-go-sdk.mdx
+++ b/docs/sdks/s3/aws-go-sdk.mdx
@@ -92,7 +92,7 @@ This will generate a virtual-hosted-style URL that is compatible with Tigris.
 
 You can also use a
 [presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+by replacing the bucket host with your custom domain:
 
 ```go
 brandedURL := strings.ReplaceAll(

--- a/docs/sdks/s3/aws-java-sdk.md
+++ b/docs/sdks/s3/aws-java-sdk.md
@@ -128,11 +128,13 @@ public class AWSS3PresignedURLs {
 
 ### Presigned URLs with custom domains
 
-You can also use a
-[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
+URLs with clients. Replace the host with your
+[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
+before distributing them:
 
 ```java
-String brandedUrl = url.replace("t3.storage.dev", "your-domain.example.com");
+String brandedUrl = url.replace(
+    "foo-bucket.t3.storage.dev", "your-domain.example.com");
 System.out.println("Presigned URL for GET (custom domain): " + brandedUrl);
 ```

--- a/docs/sdks/s3/aws-java-sdk.md
+++ b/docs/sdks/s3/aws-java-sdk.md
@@ -128,10 +128,9 @@ public class AWSS3PresignedURLs {
 
 ### Presigned URLs with custom domains
 
-SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
-URLs with clients. Replace the host with your
-[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
-before distributing them:
+You can also use a
+[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
+by replacing the Tigris domain name with your custom domain name:
 
 ```java
 String brandedUrl = url.replace(

--- a/docs/sdks/s3/aws-java-sdk.md
+++ b/docs/sdks/s3/aws-java-sdk.md
@@ -130,7 +130,7 @@ public class AWSS3PresignedURLs {
 
 You can also use a
 [presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+by replacing the bucket host with your custom domain:
 
 ```java
 String brandedUrl = url.replace(

--- a/docs/sdks/s3/aws-js-sdk.mdx
+++ b/docs/sdks/s3/aws-js-sdk.mdx
@@ -46,13 +46,16 @@ upload objects to the bucket using the `https` package.
 
 ### Presigned URLs with custom domains
 
-You can also use a
-[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+### Presigned URLs with custom domains
+
+SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
+URLs with clients. Replace the host with your
+[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
+before distributing them:
 
 ```js
 const brandedURL = presignedUrl.replace(
-  "t3.storage.dev",
+  "foo-bucket.t3.storage.dev",
   "your-domain.example.com",
 );
 console.log("Presigned URL for GET (custom domain):", brandedURL);

--- a/docs/sdks/s3/aws-js-sdk.mdx
+++ b/docs/sdks/s3/aws-js-sdk.mdx
@@ -46,12 +46,9 @@ upload objects to the bucket using the `https` package.
 
 ### Presigned URLs with custom domains
 
-### Presigned URLs with custom domains
-
-SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
-URLs with clients. Replace the host with your
-[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
-before distributing them:
+You can also use a
+[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
+by replacing the Tigris domain name with your custom domain name:
 
 ```js
 const brandedURL = presignedUrl.replace(

--- a/docs/sdks/s3/aws-js-sdk.mdx
+++ b/docs/sdks/s3/aws-js-sdk.mdx
@@ -48,7 +48,7 @@ upload objects to the bucket using the `https` package.
 
 You can also use a
 [presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+by replacing the bucket host with your custom domain:
 
 ```js
 const brandedURL = presignedUrl.replace(

--- a/docs/sdks/s3/aws-net-sdk.mdx
+++ b/docs/sdks/s3/aws-net-sdk.mdx
@@ -60,11 +60,13 @@ import presignedUrl from "!!raw-loader!../../../examples/dotnet/PresignedURL.csx
 
 ### Presigned URLs with custom domains
 
-You can also use a
-[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
+URLs with clients. Replace the host with your
+[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
+before distributing them:
 
 ```csharp
-string brandedURL = presignedUrl.Replace("t3.storage.dev", "your-domain.example.com");
+string brandedURL = presignedUrl.Replace(
+    "foo-bucket.t3.storage.dev", "your-domain.example.com");
 Console.WriteLine($"Presigned URL for GET (custom domain): {brandedURL}");
 ```

--- a/docs/sdks/s3/aws-net-sdk.mdx
+++ b/docs/sdks/s3/aws-net-sdk.mdx
@@ -62,7 +62,7 @@ import presignedUrl from "!!raw-loader!../../../examples/dotnet/PresignedURL.csx
 
 You can also use a
 [presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+by replacing the bucket host with your custom domain:
 
 ```csharp
 string brandedURL = presignedUrl.Replace(

--- a/docs/sdks/s3/aws-net-sdk.mdx
+++ b/docs/sdks/s3/aws-net-sdk.mdx
@@ -60,10 +60,9 @@ import presignedUrl from "!!raw-loader!../../../examples/dotnet/PresignedURL.csx
 
 ### Presigned URLs with custom domains
 
-SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
-URLs with clients. Replace the host with your
-[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
-before distributing them:
+You can also use a
+[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
+by replacing the Tigris domain name with your custom domain name:
 
 ```csharp
 string brandedURL = presignedUrl.Replace(

--- a/docs/sdks/s3/aws-php-sdk.md
+++ b/docs/sdks/s3/aws-php-sdk.md
@@ -122,11 +122,13 @@ download objects.
 
 ### Presigned URLs with custom domains
 
-You can also use a
-[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
+URLs with clients. Replace the host with your
+[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
+before distributing them:
 
 ```php
-$brandedURL = str_replace("t3.storage.dev", "your-domain.example.com", $presignedUrl);
+$brandedURL = str_replace(
+    "foo-bucket.t3.storage.dev", "your-domain.example.com", $presignedUrl);
 echo "Presigned URL for GET (custom domain): " . $brandedURL . "\n";
 ```

--- a/docs/sdks/s3/aws-php-sdk.md
+++ b/docs/sdks/s3/aws-php-sdk.md
@@ -122,10 +122,9 @@ download objects.
 
 ### Presigned URLs with custom domains
 
-SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
-URLs with clients. Replace the host with your
-[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
-before distributing them:
+You can also use a
+[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
+by replacing the Tigris domain name with your custom domain name:
 
 ```php
 $brandedURL = str_replace(

--- a/docs/sdks/s3/aws-php-sdk.md
+++ b/docs/sdks/s3/aws-php-sdk.md
@@ -124,7 +124,7 @@ download objects.
 
 You can also use a
 [presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+by replacing the bucket host with your custom domain:
 
 ```php
 $brandedURL = str_replace(

--- a/docs/sdks/s3/aws-python-sdk.mdx
+++ b/docs/sdks/s3/aws-python-sdk.mdx
@@ -82,7 +82,7 @@ import presignedURLs from "!!raw-loader!../../../examples/python/presigned-urls.
 
 You can also use a
 [presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+by replacing the bucket host with your custom domain:
 
 ```python
 branded_url = presigned_url.replace(

--- a/docs/sdks/s3/aws-python-sdk.mdx
+++ b/docs/sdks/s3/aws-python-sdk.mdx
@@ -80,12 +80,15 @@ import presignedURLs from "!!raw-loader!../../../examples/python/presigned-urls.
 
 ### Presigned URLs with custom domains
 
-You can also use a
-[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
+URLs with clients. Replace the host with your
+[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
+before distributing them:
 
 ```python
-branded_url = presigned_url.replace("t3.storage.dev", "your-domain.example.com")
+branded_url = presigned_url.replace(
+    "foo-bucket.t3.storage.dev", "your-domain.example.com"
+)
 print(f"Presigned URL for GET (custom domain): {branded_url}")
 ```
 

--- a/docs/sdks/s3/aws-python-sdk.mdx
+++ b/docs/sdks/s3/aws-python-sdk.mdx
@@ -80,10 +80,9 @@ import presignedURLs from "!!raw-loader!../../../examples/python/presigned-urls.
 
 ### Presigned URLs with custom domains
 
-SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
-URLs with clients. Replace the host with your
-[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
-before distributing them:
+You can also use a
+[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
+by replacing the Tigris domain name with your custom domain name:
 
 ```python
 branded_url = presigned_url.replace(

--- a/docs/sdks/s3/aws-ruby-sdk.mdx
+++ b/docs/sdks/s3/aws-ruby-sdk.mdx
@@ -46,10 +46,9 @@ import presignedUrls from "!!raw-loader!../../../examples/ruby/presigned_urls.rb
 
 ### Presigned URLs with custom domains
 
-SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
-URLs with clients. Replace the host with your
-[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
-before distributing them:
+You can also use a
+[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
+by replacing the Tigris domain name with your custom domain name:
 
 ```ruby
 branded_url = presigned_url.gsub(

--- a/docs/sdks/s3/aws-ruby-sdk.mdx
+++ b/docs/sdks/s3/aws-ruby-sdk.mdx
@@ -46,11 +46,13 @@ import presignedUrls from "!!raw-loader!../../../examples/ruby/presigned_urls.rb
 
 ### Presigned URLs with custom domains
 
-You can also use a
-[presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+SDKs sign presigned URLs against `https://t3.storage.dev`. Do not share these
+URLs with clients. Replace the host with your
+[custom domain](../../objects/presigned.md#sharing-presigned-urls-with-clients)
+before distributing them:
 
 ```ruby
-branded_url = presigned_url.gsub("t3.storage.dev", "your-domain.example.com")
+branded_url = presigned_url.gsub(
+  "foo-bucket.t3.storage.dev", "your-domain.example.com")
 puts "Presigned URL for GET (custom domain): #{branded_url}"
 ```

--- a/docs/sdks/s3/aws-ruby-sdk.mdx
+++ b/docs/sdks/s3/aws-ruby-sdk.mdx
@@ -48,7 +48,7 @@ import presignedUrls from "!!raw-loader!../../../examples/ruby/presigned_urls.rb
 
 You can also use a
 [presigned URL with a custom domain](../../objects/presigned.md#presigned-url-with-custom-domain)
-by replacing the Tigris domain name with your custom domain name:
+by replacing the bucket host with your custom domain:
 
 ```ruby
 branded_url = presigned_url.gsub(

--- a/examples/go/cmd/presigned-urls/main.go
+++ b/examples/go/cmd/presigned-urls/main.go
@@ -118,7 +118,7 @@ func main() {
 	}
 
 	// Use a custom domain for presigned URLs
-	brandedURL := strings.ReplaceAll(presignedGetReq.URL, "tigris-example.t3.storage.dev", "your-domain.example.com")
+	brandedURL := strings.ReplaceAll(presignedGetReq.URL, bucketName+".t3.storage.dev", "your-domain.example.com")
 	fmt.Printf("Presigned URL for GET (custom domain): %s\n", brandedURL)
 
 	// Presigned URL to delete an object from the bucket

--- a/examples/go/cmd/presigned-urls/main.go
+++ b/examples/go/cmd/presigned-urls/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -76,7 +77,7 @@ func (p *Client) DeleteObject(ctx context.Context, bucket string, object string,
 func main() {
 	flag.Parse()
 	if flag.NArg() != 1 {
-		log.Fatalf("usage: %s <bucket>", flag.Arg(0))
+		log.Fatalf("usage: %s <bucket>", os.Args[0])
 	}
 
 	bucketName := flag.Arg(0)
@@ -118,7 +119,7 @@ func main() {
 
 	fmt.Printf("Presigned URL for GET: %s\n", presignedGetReq.URL)
 
-	// Use a custom domain for presigned URLs
+	// Replace the bucket host with your custom domain before sharing
 	brandedURL := strings.ReplaceAll(presignedGetReq.URL, bucketName+".t3.storage.dev", "your-domain.example.com")
 	fmt.Printf("Presigned URL for GET (custom domain): %s\n", brandedURL)
 

--- a/examples/go/cmd/presigned-urls/main.go
+++ b/examples/go/cmd/presigned-urls/main.go
@@ -113,9 +113,10 @@ func main() {
 	presignedGetReq, err := presigner.GetObject(ctx, bucketName, "bar.txt", 60*time.Minute)
 	if err != nil {
 		log.Printf("Couldn't get a presigned request to get bar.txt. Here's why: %v\n", err)
-	} else {
-		fmt.Printf("Presigned URL for GET: %s\n", presignedGetReq.URL)
+		return
 	}
+
+	fmt.Printf("Presigned URL for GET: %s\n", presignedGetReq.URL)
 
 	// Use a custom domain for presigned URLs
 	brandedURL := strings.ReplaceAll(presignedGetReq.URL, bucketName+".t3.storage.dev", "your-domain.example.com")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and a small Go example fix only; no production service or auth logic changes.
> 
> **Overview**
> Clarifies that **`https://t3.storage.dev`** is for authenticated API/SDK/CLI traffic only, while **public reads** should use **public bucket hosts** (e.g. `https://bucket.t3.tigrisbucket.io`) or a custom domain — with explicit warnings not to serve public content from `t3.storage.dev`.
> 
> Updates bucket naming, ACL, Vercel, and public-bucket docs to match, and rewrites the **presigned URL + custom domain** flow so examples presign against the API endpoint then **swap the virtual-hosted bucket host** (`foo-bucket.t3.storage.dev` → `cdn.example.com`) instead of stripping a path segment from the endpoint URL.
> 
> Aligns the same host-replacement pattern across **all S3 SDK doc snippets** and fixes the **Go presigned-urls** sample (usage string, GET error handling, dynamic `bucketName` in the branded URL replace).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53846c69c100804393d12a6315a2bad86eaea896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->