### PR TITLE
Mention that presigned URLs can be used with object versions

### DIFF
--- a/docs/buckets/snapshots-and-forks.mdx
+++ b/docs/buckets/snapshots-and-forks.mdx
@@ -606,6 +606,10 @@ operation is available to users with read-only (or higher) access to the bucket.
 However, note that this is a separate operation, and some IAM policies may need
 to be updated to allow it.
 
+Versioned object operations support the same authentication mechanisms as
+non-versioned operations. Presigned URLs can target a specific object version by
+including `versionId` in presigned URL requests, matching S3 behavior.
+
 ## Using a forked bucket
 
 Forked buckets behave the same as regular buckets, and you can use the usual


### PR DESCRIPTION
We've already been supporting this for some time — this just makes it more explicit and clearer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior changes.
> 
> **Overview**
> Documents that **versioned object operations** use the same auth as non-versioned calls, and that **presigned URLs** can address a specific object version by including `versionId` in the request (aligned with S3).
> 
> The addition sits in the object versioning section of `snapshots-and-forks.mdx`; behavior is described as already supported—this PR only clarifies it for readers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c34e65521448b8150681456311805381af5763c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->