### PR TITLE
Remove an old announcement about bucket names and custom domains

### DIFF
--- a/docs/buckets/custom-domain.md
+++ b/docs/buckets/custom-domain.md
@@ -3,15 +3,9 @@
 You can also use a custom domain with your bucket. To do this, the following
 requirements must be met first:
 
-1. The custom domain name must be a valid domain or subdomain. For example,
-   `images.example.com`, `example.com`.
-
-   :::note[Update]
-
-   Starting 7 April 2025, bucket names no longer need to match custom domain
-   names.
-
-   :::
+1. The custom domain name must be a valid domain or subdomain — for example,
+   `images.example.com` or `example.com`. The bucket name does not need to match
+   the custom domain name.
 
 2. The custom domain must have a CNAME record that points to the bucket URL. For
    example, if you own the domain `images.example.com` and bucket `foo-bucket`,


### PR DESCRIPTION
The fact that custom domain names do not need to match bucket names is no longer something new, so removing announcement styling for that info.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or security impact.
> 
> **Overview**
> Updates **`docs/buckets/custom-domain.md`** so the custom-domain requirement is stated plainly instead of inside a dated “Update” callout.
> 
> The first requirement now says the bucket name **does not need to match** the custom domain, with example domains on one line. The **7 April 2025** note and `:::note[Update]` block are removed because that behavior is no longer newsworthy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e00b31f7917574d405c88d91d5cb2bbebacf98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->