### PR TITLE
docs: list all object notification event types

### DIFF
--- a/docs/buckets/object-notifications.md
+++ b/docs/buckets/object-notifications.md
@@ -42,16 +42,15 @@ For token authentication, the header will set as follows:
 
 ## Notification Types
 
-Tigris currently supports the following notification types:
+Tigris supports the following notification types:
 
-- `OBJECT_CREATED_PUT`: When an object is created or updated.
-- `OBJECT_DELETED`: When an object is deleted.
-
-:::note
-
-More events will be supported in the future.
-
-:::
+- `OBJECT_CREATED_PUT`: An object was created via a PUT request.
+- `OBJECT_CREATED_MULTIPART`: An object was created via a multipart upload.
+- `OBJECT_CREATED_COPY`: An object was created by copying an existing object.
+- `OBJECT_DELETED`: An object was deleted.
+- `OBJECT_TRANSITIONED`: An object was transitioned to a different storage class
+  (for example, via a lifecycle rule).
+- `OBJECT_RENAME`: An object was renamed.
 
 ## Notification Format
 


### PR DESCRIPTION
Update the object notifications docs to list the full set of supported event types instead of just `OBJECT_CREATED_PUT` and `OBJECT_DELETED`.

The `eventName` field is set from the change event type, which can be one of:

- `OBJECT_CREATED_PUT` — created via PUT
- `OBJECT_CREATED_MULTIPART` — created via multipart upload
- `OBJECT_CREATED_COPY` — created by copy
- `OBJECT_DELETED` — deleted
- `OBJECT_TRANSITIONED` — transitioned to a different storage class (e.g. lifecycle rule)
- `OBJECT_RENAME` — renamed

Also removed the "more events will be supported in the future" note since the list is now complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Updates **object notifications** documentation so the **Notification Types** section lists the full supported `eventName` set instead of only `OBJECT_CREATED_PUT` and `OBJECT_DELETED`.
> 
> Adds **`OBJECT_CREATED_MULTIPART`**, **`OBJECT_CREATED_COPY`**, **`OBJECT_TRANSITIONED`**, and **`OBJECT_RENAME`**, with clearer one-line descriptions for each type. Removes the admonition that more event types are coming later, since the doc now presents a complete catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4a8445e102827d17f283f9a6457343b95ce4f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->