### PR TITLE
Document changing bucket type between Regular and Snapshot

### DIFF
--- a/docs/agents-use-cases.mdx
+++ b/docs/agents-use-cases.mdx
@@ -124,8 +124,9 @@ For more information, see the docs:
 
 :::note
 
-`X-Tigris-Enable-Snapshot: true` must be set at bucket creation and cannot be
-changed afterward.
+`X-Tigris-Enable-Snapshot: true` enables snapshots at bucket creation. You can
+also switch a bucket between Regular and Snapshot later under **Bucket
+Settings** in the Tigris Dashboard.
 
 :::
 

--- a/docs/buckets/settings/index.mdx
+++ b/docs/buckets/settings/index.mdx
@@ -76,8 +76,12 @@ Some restrictions apply for bucket type changes:
   supported on snapshot-enabled buckets.
 - **Snapshot to Regular**: the bucket must not be a fork parent or a fork child.
 
-Note: If a Snapshot bucket is converted to Regular, all object versions are
-still kept in the bucket.
+:::note
+
+If a Snapshot bucket is converted to Regular, all object versions are still
+kept in the bucket.
+
+:::
 
 For more information, see
 [Bucket Snapshots and Forks](/docs/buckets/snapshots-and-forks/).

--- a/docs/buckets/settings/index.mdx
+++ b/docs/buckets/settings/index.mdx
@@ -9,6 +9,8 @@ Here's an overview of the settings you can configure:
 - Bucket Location: Set the location type for a bucket to control where your data
   is stored.
 - Storage Tier: Set the storage tier for a bucket.
+- Bucket Type: Switch a bucket between Regular and Snapshot to enable or disable
+  snapshots and forks.
 - Cache Control: Set the default _Cache-Control_ header for objects in the
   bucket.
 - Data Migration: Migrate data from one bucket to another (also known as shadow
@@ -60,6 +62,25 @@ please see the storage tiers page: [Storage Tiers](/docs/objects/tiers/).
 You can set the storage tier for individual objects when you upload them. For
 more information, please see the storage tiers page:
 [Storage Tiers: Setting object tier](/docs/objects/tiers/#setting-object-tier)
+
+## Bucket Type
+
+A bucket is either **Regular** or **Snapshot**. Snapshot buckets support
+whole-bucket point-in-time [snapshots](/docs/snapshots/) and zero-copy
+[forks](/docs/forks/).
+
+Some restrictions apply for bucket type changes:
+
+- **Regular to Snapshot**: the bucket must not use the GLACIER storage tier,
+  object lifecycle rules, or object expiration (TTL) rules, since these are not
+  supported on snapshot-enabled buckets.
+- **Snapshot to Regular**: the bucket must not be a fork parent or a fork child.
+
+Note: If a Snapshot bucket is converted to Regular, all object versions are
+still kept in the bucket.
+
+For more information, see
+[Bucket Snapshots and Forks](/docs/buckets/snapshots-and-forks/).
 
 ## Cache Control
 

--- a/docs/buckets/settings/index.mdx
+++ b/docs/buckets/settings/index.mdx
@@ -78,8 +78,8 @@ Some restrictions apply for bucket type changes:
 
 :::note
 
-If a Snapshot bucket is converted to Regular, all object versions are still
-kept in the bucket.
+If a Snapshot bucket is converted to Regular, all object versions are still kept
+in the bucket.
 
 :::
 

--- a/docs/buckets/snapshots-and-forks.mdx
+++ b/docs/buckets/snapshots-and-forks.mdx
@@ -13,9 +13,14 @@ To enable snapshots and forks at creation, set the
 `X-Tigris-Enable-Snapshot: true` header when creating the bucket.
 
 You can also switch an existing bucket between Regular and Snapshot under
-**Bucket Settings → Storage Settings** in the Tigris Dashboard. Note: to convert
-a Regular bucket to Snapshot, it must not use the GLACIER storage tier,
-lifecycle rules, or object expiration (TTL) rules.
+**Bucket Settings → Storage Settings** in the Tigris Dashboard.
+
+:::note
+
+To convert a Regular bucket to Snapshot, it must not use the GLACIER storage
+tier, lifecycle rules, or object expiration (TTL) rules.
+
+:::
 
 <Tabs groupId="languages">
 <TabItem value="go" label="Go">

--- a/docs/buckets/snapshots-and-forks.mdx
+++ b/docs/buckets/snapshots-and-forks.mdx
@@ -7,13 +7,15 @@ This page covers how to enable and use snapshots, forks, and object versioning
 on your Tigris buckets. For an overview of the concepts, see
 [Snapshots and Forks](/docs/snapshots-and-forks).
 
-Snapshots and forks are opt-in features. To enable them on a bucket, you must
-set a special header at creation time.
-
 ## Enabling snapshots and forks
 
-To enable snapshots and forks, set the `X-Tigris-Enable-Snapshot: true` header
-when creating the bucket.
+To enable snapshots and forks at creation, set the
+`X-Tigris-Enable-Snapshot: true` header when creating the bucket.
+
+You can also switch an existing bucket between Regular and Snapshot under
+**Bucket Settings → Storage Settings** in the Tigris Dashboard. Note: to convert
+a Regular bucket to Snapshot, it must not use the GLACIER storage tier,
+lifecycle rules, or object expiration (TTL) rules.
 
 <Tabs groupId="languages">
 <TabItem value="go" label="Go">

--- a/docs/forks/index.mdx
+++ b/docs/forks/index.mdx
@@ -169,7 +169,9 @@ forks first before deleting the source bucket.
 
 ### Do I need to enable snapshots to use forks?
 
-Yes. Snapshot support must be enabled at bucket creation to use forks.
+Yes. Forks require a snapshot-enabled bucket. Enable snapshots when you create
+the bucket, or switch an existing bucket to Snapshot under **Bucket Settings**
+in the Tigris Dashboard.
 
 ### Do forks affect performance?
 

--- a/docs/snapshots/index.mdx
+++ b/docs/snapshots/index.mdx
@@ -164,16 +164,15 @@ No. Snapshots are metadata-only and don't slow down reads or writes.
 
 ### Can I enable snapshots on an existing bucket?
 
-Snapshot support can be enabled for existing buckets; however, this
-functionality is not yet exposed to users. If you would like to change the type
-of your bucket, please contact us at
-[help@tigrisdata.com](mailto:help@tigrisdata.com).
+Yes. Change the bucket type from Regular to Snapshot under **Bucket Settings →
+Storage Settings** in the Tigris Dashboard. See
+[Bucket Type](/docs/buckets/settings/#bucket-type) for more details.
 
 ### Can I disable snapshots after enabling them?
 
-Snapshots can be disabled for buckets; however, this functionality is not yet
-exposed to users. If you would like to change the type of your bucket, please
-contact us at [help@tigrisdata.com](mailto:help@tigrisdata.com).
+Yes. Change the bucket type from Snapshot back to Regular under **Bucket
+Settings → Storage Settings** in the Tigris Dashboard. See
+[Bucket Type](/docs/buckets/settings/#bucket-type) for more details.
 
 ### Can I restore a bucket to a previous snapshot?
 

--- a/docs/training-use-cases.mdx
+++ b/docs/training-use-cases.mdx
@@ -182,8 +182,9 @@ Scope each training job's credentials with a
 [fine-grained IAM policy](/docs/iam/policies/examples/training-job): read-only
 to the dataset bucket, read-only to the base model, write-only to the output
 bucket, with optional time-window and IP restrictions.
-`X-Tigris-Enable-Snapshot: true` must be set at bucket creation and cannot be
-changed afterward.
+`X-Tigris-Enable-Snapshot: true` enables snapshots at bucket creation. You can
+also switch a bucket between Regular and Snapshot later under **Bucket
+Settings** in the Tigris Dashboard.
 
 :::
 

--- a/docs/use-cases/checkpoint-restore-fork.mdx
+++ b/docs/use-cases/checkpoint-restore-fork.mdx
@@ -71,14 +71,15 @@ bucket, with optional time-window and IP restrictions.
 
 ### How it works
 
-Create the bucket with `X-Tigris-Enable-Snapshot: true` at creation time (this
-must be set at creation and cannot be changed afterward). Have your training
-loop write checkpoints on a fixed cadence — every N steps or at epoch
-boundaries.
+Create the bucket with `X-Tigris-Enable-Snapshot: true`, or enable snapshots
+later by switching the bucket type under **Bucket Settings** in the Tigris
+Dashboard.
 
-Store the snapshot version ID alongside run metadata in your experiment tracker.
-To resume, pass the version to the new job. To sweep hyperparameters, fork the
-snapshot once per configuration and let each fork write independently.
+Have your training loop write checkpoints on a fixed cadence — every N steps or
+at epoch boundaries. Store the snapshot version ID alongside run metadata in
+your experiment tracker. To resume, pass the version to the new job. To sweep
+hyperparameters, fork the snapshot once per configuration and let each fork
+write independently.
 
 ```bash
 # Take a snapshot after checkpoint write

--- a/docs/web-console/index.mdx
+++ b/docs/web-console/index.mdx
@@ -61,8 +61,9 @@ Open a bucket and click **Settings** to configure:
   [Public Buckets](/docs/buckets/public-bucket/) and
   [Object ACLs](/docs/objects/acl/).
 - **Snapshots and Forks** — capture **whole-bucket point-in-time snapshots** and
-  create zero-copy forks of them. Must be enabled at **bucket creation time** —
-  can't be turned on for an existing bucket. See
+  create zero-copy forks of them. Enable snapshots when you create a bucket, or
+  switch an existing bucket between Regular and Snapshot under **Storage
+  Settings**. See
   [Bucket Snapshots and Forks](/docs/buckets/snapshots-and-forks/).
 - **Bucket Sharing** — share a bucket with other organization members or outside
   collaborators. See [Bucket Sharing](/docs/buckets/sharing/).

--- a/static/api/extensions/v1/api.yaml
+++ b/static/api/extensions/v1/api.yaml
@@ -1227,7 +1227,9 @@ components:
         enable_snapshots:
           type: boolean
           description: |
-            Enable snapshots on the bucket. Create-time only. See
+            Enable snapshots on the bucket at creation. Snapshots can also be
+            enabled or disabled on an existing bucket from the Storage Settings
+            page in the Tigris Dashboard. See
             https://www.tigrisdata.com/docs/snapshots/.
         object_notifications:
           $ref: "#/components/schemas/ObjectNotifications"
@@ -1791,7 +1793,7 @@ components:
             If true, anonymous users can list objects in this public bucket
         snapshots_enabled:
           type: boolean
-          description: True if the bucket was created with snapshots enabled.
+          description: True if snapshots are enabled on the bucket.
         fork_info:
           $ref: "#/components/schemas/ForkInfo"
         website:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI description-only updates; no application or runtime behavior changes in this diff.
> 
> **Overview**
> Documents that **Regular** and **Snapshot** bucket types can be changed after creation via the Tigris Dashboard (**Bucket Settings → Storage Settings**), replacing guidance that snapshots were create-time only or required contacting support.
> 
> Adds a **Bucket Type** section under bucket settings with conversion rules (e.g. no GLACIER/lifecycle/TTL when enabling snapshots; no fork parent/child when disabling) and notes that object versions remain when switching Snapshot → Regular. The same dashboard path is wired through snapshots/forks guides, agent and training use cases, web console docs, and snapshot/fork FAQs.
> 
> **OpenAPI** (`enable_snapshots`, `snapshots_enabled`) now states snapshots can be toggled on existing buckets from Storage Settings, not only at provision time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6bb399843d78f5e142a6c5414ffd0b25d0bacfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->