### PR TITLE
Add details on managing teams and sharing buckets with them

### DIFF
--- a/docs/account-management/organizations.md
+++ b/docs/account-management/organizations.md
@@ -121,10 +121,10 @@ To share a bucket with all users in your organization:
 
 - Click on the `Share` button.
 
-- Modify the "Organization Access" settings to your desired permissions (Editor
-  or Read Only).
+- Find your organization in the Access search bar and assign the desired
+  permission.
 
-- Click on the `Save` button.
+- Click on the `Save changes` button.
 
 Once the bucket is shared, all users in the organization will be able to see it
 in their dashboard and access its content based on the role you assigned. Users

--- a/docs/account-management/teams.md
+++ b/docs/account-management/teams.md
@@ -1,0 +1,69 @@
+# Teams
+
+Teams let you group members of an Organization so you can grant bucket access to
+several people at once instead of sharing with each user individually. A Team
+belongs to a single Organization, and its members are users who already belong
+to that Organization. Only Admins in an organization can create and manage
+teams.
+
+A Team does not carry an access level of its own. You choose the role
+(`Read Only` or `Editor`) each time you
+[share a bucket with the Team](../buckets/sharing.md#sharing-with-a-team).
+
+:::note
+
+Teams are available for Tigris native accounts only. If you log in with a Fly
+account, manage access through Fly Organizations instead — see
+[Manage Organizations in Fly](./organizations.md#manage-organizations-in-fly).
+
+:::
+
+## Create a Team
+
+- Go to the [Tigris Dashboard](https://console.storage.dev).
+- Click on your account name in the upper right corner and select `Teams`.
+- Click `+ Create Team`.
+- Enter a name for the Team, choose members, and save.
+
+## Add or remove members
+
+- Go to the [Tigris Dashboard](https://console.storage.dev).
+- Click on your account name in the upper right corner and select `Teams`.
+- Select the Team.
+- Add members by selecting users from your Organization, or remove members from
+  the member list.
+
+When you remove a member from a Team, that member immediately loses access to
+any buckets shared with the Team. The remaining members keep their access. Any
+access keys the removed member created for those buckets will no longer work.
+
+## Delete a Team
+
+- Go to the [Tigris Dashboard](https://console.storage.dev).
+- Click on your account name in the upper right corner and select `Teams`.
+- Select the Team.
+- Delete the Team.
+
+Deleting a Team revokes every bucket share granted to it. All members lose the
+access they had through the Team, and access keys they created for those buckets
+will no longer work.
+
+## Share a bucket with a Team
+
+To share a bucket with a Team:
+
+- Go to the [Tigris Dashboard](https://console.storage.dev).
+- Click on the bucket you want to share.
+- Click on the `Share` button.
+- Find the Team in the Access search bar and assign the desired permission.
+- Click on the `Save changes` button.
+
+Once the bucket is shared, all members of the Team — including members added
+later — will be able to see it in their dashboard and access its content based
+on the role you assigned. Team members can also create access keys for the
+shared bucket to access it programmatically.
+
+When you remove a member from the Team, that member immediately loses access to
+the bucket. When you revoke the Team's share entirely, all members lose access.
+In both cases, the access keys those users created for the bucket will no longer
+work.

--- a/docs/buckets/sharing.md
+++ b/docs/buckets/sharing.md
@@ -20,7 +20,7 @@ To share a bucket with another user in your organization:
 - Click on the `Share` button.
 - Select the users you want to share the bucket with and the role you want to
   assign to them.
-- Click on the `Save` button.
+- Click on the `Save changes` button.
 
 The roles you can assign to the users are:
 
@@ -35,6 +35,31 @@ that bucket programmatically.
 When the share is revoked, the access keys created by the shared users will no
 longer have access to the bucket.
 
+## Sharing with a team
+
+If you have grouped members of your organization into a
+[Team](../account-management/teams.md), you can share a bucket with the whole
+Team at once instead of adding each user individually.
+
+To share a bucket with a Team:
+
+- Go to the [Tigris Dashboard](https://console.storage.dev).
+- Click on the bucket you want to share.
+- Click on the `Share` button.
+- Select the Team you want to share the bucket with and the role you want to
+  assign (`Read Only` or `Editor`).
+- Click on the `Save changes` button.
+
+Once the bucket is shared, all members of the Team — including members added
+later — will be able to see it in their dashboard and access its content based
+on the role you assigned. Team members can also create access keys for the
+shared bucket to access it programmatically.
+
+When you remove a member from the Team, that member immediately loses access to
+the bucket. When you revoke the Team's share entirely, all members lose access.
+In both cases, the access keys those users created for the bucket will no longer
+work.
+
 ## Sharing with your entire organization
 
 You can also share your buckets with your entire organization.
@@ -46,7 +71,7 @@ To share a bucket with all users in your organization:
 - Click on the `Share` button.
 - Modify the "Organization Access" settings to your desired permissions (Editor
   or Read Only).
-- Click on the `Save` button.
+- Click on the `Save changes` button.
 
 Once the bucket is shared, all users in the organization will be able to see it
 in their dashboard and access its content based on the role you assigned. Users
@@ -73,7 +98,7 @@ To share a bucket with users from another organization:
 - Enter the access key (starts with `tid_`) in the text box.
 - Click "Add External ID" to add the access key ID to the list. It should have
   the role `External`.
-- Click on the `Save` button at the top of the dialogue.
+- Click on the `Save changes` button at the top of the dialogue.
 
 Once the bucket is shared, the user from the other organization will be able to
 access the bucket using the access key.

--- a/sidebars.js
+++ b/sidebars.js
@@ -533,6 +533,7 @@ const sidebars = {
           items: [
             "account-management/accounts",
             "account-management/organizations",
+            "account-management/teams",
             "account-management/billing",
           ],
         },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no product code or access-control behavior changes.
> 
> **Overview**
> Adds **Teams** documentation under Account Management and wires it into the docs sidebar, covering how admins create teams, manage membership, and what happens to bucket access when members leave or a team is deleted.
> 
> **Bucket sharing** docs now describe sharing with a **Team** (bulk access vs. per-user) and link to the new teams page. Several console flows are aligned with the current UI: **Save** → **Save changes**, and org-wide sharing steps now point users to the **Access** search bar instead of legacy **Organization Access** wording in `organizations.md` and related sharing sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa83adc4708dd924d62a3c177fbb49b488d6a78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->