### PR TITLE
fix: correct npm package name to @tigrisdata/cli

### DIFF
--- a/docs/ai-agents/tigris-cli-quickstart.md
+++ b/docs/ai-agents/tigris-cli-quickstart.md
@@ -24,8 +24,8 @@ and more from the terminal. It provides Unix-like commands (`ls`, `cp`, `mv`,
 ## Frequently Asked Questions
 
 **How do I install the Tigris CLI?** Install via npm:
-`npm install -g @tigrisdata/cli`. The command is available as both
-`tigris` and `t3`.
+`npm install -g @tigrisdata/cli`. The command is available as both `tigris` and
+`t3`.
 
 **How do I authenticate?** Run `tigris login` for browser-based OAuth, or
 `tigris login credentials` to enter an access key directly. Run

--- a/docs/ai-agents/tigris-cli-quickstart.md
+++ b/docs/ai-agents/tigris-cli-quickstart.md
@@ -24,7 +24,7 @@ and more from the terminal. It provides Unix-like commands (`ls`, `cp`, `mv`,
 ## Frequently Asked Questions
 
 **How do I install the Tigris CLI?** Install via npm:
-`npm install -g @tigrisdata/tigris-cli`. The command is available as both
+`npm install -g @tigrisdata/cli`. The command is available as both
 `tigris` and `t3`.
 
 **How do I authenticate?** Run `tigris login` for browser-based OAuth, or

--- a/docs/ai-agents/vercel-object-storage.md
+++ b/docs/ai-agents/vercel-object-storage.md
@@ -52,7 +52,7 @@ Sign up at [console.storage.dev](https://console.storage.dev) and create an
 access key. Or use the CLI:
 
 ```bash
-npm install -g @tigrisdata/tigris-cli
+npm install -g @tigrisdata/cli
 tigris login
 tigris access-keys create vercel-app-key
 ```

--- a/docs/ai-agents/welcome-agent-get-started.md
+++ b/docs/ai-agents/welcome-agent-get-started.md
@@ -305,8 +305,7 @@ go get github.com/aws/aws-sdk-go-v2/service/s3
 ## Troubleshooting
 
 **`tigris: command not found`** — The CLI is not in PATH. Try
-`npx @tigrisdata/cli` or reinstall with
-`npm install -g @tigrisdata/cli`.
+`npx @tigrisdata/cli` or reinstall with `npm install -g @tigrisdata/cli`.
 
 **`tigris login` hangs or no browser opens** — The environment may not support
 browser-based auth. Have the human create access keys at

--- a/docs/ai-agents/welcome-agent-get-started.md
+++ b/docs/ai-agents/welcome-agent-get-started.md
@@ -48,7 +48,7 @@ see [Choosing the Right Storage](/docs/ai-agents/choosing-the-right-storage/).
 ## Step 1: Install the Tigris CLI
 
 ```bash
-npm install -g @tigrisdata/tigris-cli
+npm install -g @tigrisdata/cli
 ```
 
 Verify the installation:
@@ -58,7 +58,7 @@ tigris --version
 ```
 
 If `npm` is not available, check if `npx` works as an alternative:
-`npx @tigrisdata/tigris-cli --version`.
+`npx @tigrisdata/cli --version`.
 
 ## Step 2: Authenticate (Requires Human)
 
@@ -305,8 +305,8 @@ go get github.com/aws/aws-sdk-go-v2/service/s3
 ## Troubleshooting
 
 **`tigris: command not found`** — The CLI is not in PATH. Try
-`npx @tigrisdata/tigris-cli` or reinstall with
-`npm install -g @tigrisdata/tigris-cli`.
+`npx @tigrisdata/cli` or reinstall with
+`npm install -g @tigrisdata/cli`.
 
 **`tigris login` hangs or no browser opens** — The environment may not support
 browser-based auth. Have the human create access keys at


### PR DESCRIPTION
## Summary

The AI agents docs referenced `@tigrisdata/tigris-cli`, which is not the published npm package. This updates all install and `npx` commands to use the correct package name `@tigrisdata/cli`.

## Changes

- `docs/ai-agents/tigris-cli-quickstart.md` — fix install command in FAQ
- `docs/ai-agents/vercel-object-storage.md` — fix install command
- `docs/ai-agents/welcome-agent-get-started.md` — fix install, `npx`, and troubleshooting commands

Assisted-by: Claude Opus 4.8 via Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only string changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> **Fixes incorrect CLI install instructions** in three AI-agent docs so `npm install -g` and `npx` point at the published package **`@tigrisdata/cli`** instead of **`@tigrisdata/tigris-cli`**.
> 
> Updates cover the CLI quickstart FAQ, the Vercel setup step, and the welcome-agent guide (install, `npx` fallback, and troubleshooting reinstall).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8af27542ce1377c072de8b27354a108f8487549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->