### PR TITLE
docs: add Cloud Disk (overview + architecture) under Product

### DIFF
--- a/docs/cloud-disk/architecture.mdx
+++ b/docs/cloud-disk/architecture.mdx
@@ -10,11 +10,9 @@ import CloudDiskArchitectureDiagram from "@site/src/components/diagrams/CloudDis
 
 # Architecture & Design
 
-:::info Cloud Disk is in beta
+:::info Beta
 
-The design described here is current as of this release. Internal details such
-as the chunk layout and the write log format may change before general
-availability.
+Cloud Disk is in beta and under active development.
 
 :::
 

--- a/docs/cloud-disk/architecture.mdx
+++ b/docs/cloud-disk/architecture.mdx
@@ -6,6 +6,8 @@ description:
   caching, write-through and write-back durability, snapshots, and leasing.
 ---
 
+import CloudDiskArchitectureDiagram from "@site/src/components/diagrams/CloudDiskArchitectureDiagram";
+
 # Architecture & Design
 
 An infinitely-scalable block device backed by Tigris.
@@ -41,16 +43,7 @@ replication jobs, no data movement.
 
 ## Architecture at a glance
 
-```mermaid
-graph TD
-    A[application · filesystem · database] --> B[Linux block device]
-    B --> C[cloud-disk]
-    subgraph C [cloud-disk]
-        D[memory cache<br/>hot reads + write coalescing]
-        E[local disk cache<br/>warm reads, survives remounts]
-    end
-    C -->|flush commits to the bucket| F[(your Tigris bucket<br/>source of truth)]
-```
+<CloudDiskArchitectureDiagram />
 
 The volume is divided into fixed-size chunks stored as individual objects.
 Unwritten regions are simply never stored — a 10 TB volume holding 50 GB of data

--- a/docs/cloud-disk/architecture.mdx
+++ b/docs/cloud-disk/architecture.mdx
@@ -1,0 +1,125 @@
+---
+title: cloud-disk Architecture
+sidebar_label: Architecture
+description:
+  How cloud-disk turns a Tigris bucket into a Linux block device — chunks,
+  caching, write-through and write-back durability, snapshots, and leasing.
+---
+
+# Architecture & Design
+
+An infinitely-scalable block device backed by Tigris.
+
+## What it is
+
+cloud-disk presents a Linux block device backed by a Tigris bucket. You format
+it with any filesystem (ext4, XFS, btrfs), run any application on it — databases
+included. Capacity is effectively unlimited, you pay only for the data you
+actually store, and the volume inherits the durability, replication, and access
+controls of the object store underneath.
+
+A disk is just a name. With a single command you get a formatted, mounted,
+ready-to-use disk:
+
+```bash
+cloud-disk create data1 --size 100G
+```
+
+Everything that defines the disk — its geometry, its tuning, its contents —
+lives in the bucket, so the disk you unmount on one machine is byte-for-byte the
+disk you `cloud-disk mount` on the next.
+
+## Why
+
+Traditional cloud block storage is capacity-provisioned and locked to a single
+availability zone. Object storage is elastic and durable — but it isn't a disk.
+cloud-disk closes that gap: applications get an ordinary block device, while the
+data lives in Tigris and inherits its elastic capacity and global data
+distribution. Because Tigris is global, every disk lives in a global namespace:
+moving it between machines — or regions — is just unmount and mount. No
+replication jobs, no data movement.
+
+## Architecture at a glance
+
+```mermaid
+graph TD
+    A[application · filesystem · database] --> B[Linux block device]
+    B --> C[cloud-disk]
+    subgraph C [cloud-disk]
+        D[memory cache<br/>hot reads + write coalescing]
+        E[local disk cache<br/>warm reads, survives remounts]
+    end
+    C -->|flush commits to the bucket| F[(your Tigris bucket<br/>source of truth)]
+```
+
+The volume is divided into fixed-size chunks stored as individual objects.
+Unwritten regions are simply never stored — a 10 TB volume holding 50 GB of data
+stores only 50 GB.
+
+## Durability: the bucket is the disk
+
+By default cloud-disk operates **write-through**: when the application calls
+`fsync`, the acknowledged data is in the bucket. There is no local state that
+matters — the host can vanish the moment a flush returns and the disk is
+complete, current, and mountable elsewhere. Durability is exactly the durability
+of Tigris, which means surviving not just machine failure but region failure as
+well.
+
+This is the strongest possible guarantee, and it's the default because most
+workloads never notice the cost: writes land in the memory cache and are
+coalesced, so sequential and bursty workloads stream to the bucket at full
+bandwidth. What write-through cannot hide is flush latency — an `fsync` costs an
+object-store round trip.
+
+### Optional: write-back mode for latency-sensitive workloads
+
+For workloads that `fsync` constantly — OLTP databases, message queues — a disk
+can opt into **write-back** mode. Flushes then commit to a local write log at
+NVMe latency (milliseconds instead of an object-store round trip), and a
+background uploader drains to the bucket continuously, in strictly the order the
+application's flush barriers created. That ordering is the key safety property:
+
+- A process crash or host reboot loses nothing — the local log replays on the
+  next mount.
+- Losing the entire host rolls the disk back to a crash-consistent recent point
+  in time — exactly as if power had been cut at that moment. Filesystems and
+  databases recover with their normal journal replay; the bucket never holds a
+  state that reorders writes across an `fsync`, the failure mode that corrupts
+  data.
+
+The window of recent writes at risk is bounded — cloud-disk throttles new writes
+rather than letting the not-yet-uploaded backlog grow without limit — and a
+planned unmount always drains fully before detaching.
+
+Write-through when you want the bucket current at every `fsync`; write-back when
+you want local-disk latency and can tolerate seconds of rollback on sudden host
+loss. It's one setting, per disk.
+
+## Snapshots and forks
+
+A disk can be snapshotted at a point in time, and new disks can be created as
+instant forks of a snapshot — copy-on-write, no data copied, regardless of size.
+Cloning a multi-terabyte production database for a staging environment takes
+seconds. Forked disks are full first-class disks: mount them anywhere and tune
+them independently of their parent.
+
+## Operating it
+
+- **Config travels with the disk.** Tuning is stored in the bucket alongside the
+  data and applied wherever the disk is next mounted —
+  `cloud-disk config data1 set ...` from any machine with access.
+- **One writer at a time, enforced.** A lease in the bucket fences out
+  concurrent writers, so two hosts can never corrupt a disk by mounting it
+  read-write simultaneously. Mounting elsewhere after a host dies is safe as
+  soon as the lease expires — 30 seconds by default.
+
+## Operational properties
+
+- **Pay for what you store** — sparse volumes; deleted and never-written ranges
+  occupy no objects.
+- **Portable** — unmount on one host, mount on another; the bucket is the
+  volume.
+- **Your bucket, your controls** — data is stored in a bucket you own; access
+  policy is governed by your object-store configuration.
+- **Tunable per disk** — cache sizes and durability mode are per-disk settings,
+  so a scratch disk and a database disk can make different trade-offs.

--- a/docs/cloud-disk/architecture.mdx
+++ b/docs/cloud-disk/architecture.mdx
@@ -1,8 +1,8 @@
 ---
-title: cloud-disk Architecture
+title: Cloud Disk Architecture
 sidebar_label: Architecture
 description:
-  How cloud-disk turns a Tigris bucket into a Linux block device — chunks,
+  How Cloud Disk turns a Tigris bucket into a Linux block device — chunks,
   caching, write-through and write-back durability, snapshots, and leasing.
 ---
 
@@ -10,36 +10,40 @@ import CloudDiskArchitectureDiagram from "@site/src/components/diagrams/CloudDis
 
 # Architecture & Design
 
-An infinitely-scalable block device backed by Tigris.
+:::info Cloud Disk is in beta
+
+The design described here is current as of this release. Internal details such
+as the chunk layout and the write log format may change before general
+availability.
+
+:::
 
 ## What it is
 
-cloud-disk presents a Linux block device backed by a Tigris bucket. You format
-it with any filesystem (ext4, XFS, btrfs), run any application on it — databases
-included. Capacity is effectively unlimited, you pay only for the data you
-actually store, and the volume inherits the durability, replication, and access
+Cloud Disk presents a Linux block device backed by a Tigris bucket. You format
+it with any filesystem (ext4, XFS, btrfs) and run any application on it,
+databases included. Capacity is effectively unlimited, you pay only for the data
+you store, and the volume inherits the durability, replication, and access
 controls of the object store underneath.
 
-A disk is just a name. With a single command you get a formatted, mounted,
-ready-to-use disk:
+A single command gives you a formatted, mounted, ready-to-use disk:
 
 ```bash
 cloud-disk create data1 -size 100G
 ```
 
 Everything that defines the disk — its geometry, its tuning, its contents —
-lives in the bucket, so the disk you unmount on one machine is byte-for-byte the
-disk you `cloud-disk mount` on the next.
+lives in the bucket, so the disk you unmount on one machine is the disk you
+`cloud-disk mount` on the next.
 
 ## Why
 
-Traditional cloud block storage is capacity-provisioned and locked to a single
-availability zone. Object storage is elastic and durable — but it isn't a disk.
-cloud-disk closes that gap: applications get an ordinary block device, while the
-data lives in Tigris and inherits its elastic capacity and global data
-distribution. Because Tigris is global, every disk lives in a global namespace:
-moving it between machines — or regions — is just unmount and mount. No
-replication jobs, no data movement.
+Traditional cloud block storage is capacity-provisioned and tied to a single
+availability zone. Object storage is elastic and durable, but it isn't a disk.
+Cloud Disk bridges the two: applications see an ordinary block device while the
+data lives in Tigris, inheriting its elastic capacity and global distribution.
+Because Tigris is global, moving a disk between machines or regions is just an
+unmount and a mount. There are no replication jobs and no data to copy.
 
 ## Architecture at a glance
 
@@ -49,61 +53,60 @@ The volume is divided into fixed-size chunks stored as individual objects.
 Unwritten regions are simply never stored — a 10 TB volume holding 50 GB of data
 stores only 50 GB.
 
-## Durability: the bucket is the disk
+## Durability
 
-By default cloud-disk operates **write-through**: when the application calls
-`fsync`, the acknowledged data is in the bucket. There is no local state that
-matters — the host can vanish the moment a flush returns and the disk is
-complete, current, and mountable elsewhere. Durability is exactly the durability
-of Tigris, which means surviving not just machine failure but region failure as
-well.
+By default Cloud Disk runs **write-through**: when the application calls
+`fsync`, the acknowledged data is already in the bucket. No local state matters,
+so the host can disappear the moment a flush returns and the disk stays
+complete, current, and mountable elsewhere. Its durability is the durability of
+Tigris, which survives machine failure and region failure alike.
 
-This is the strongest possible guarantee, and it's the default because most
-workloads never notice the cost: writes land in the memory cache and are
-coalesced, so sequential and bursty workloads stream to the bucket at full
-bandwidth. What write-through cannot hide is flush latency — an `fsync` costs an
-object-store round trip.
+This is the default because most workloads never feel the cost. Writes land in
+the memory cache and are coalesced, so sequential and bursty workloads stream to
+the bucket at full bandwidth. The cost write-through can't hide is flush
+latency: an `fsync` pays for an object-store round trip.
 
-### Optional: write-back mode for latency-sensitive workloads
+### Write-back mode for latency-sensitive workloads
 
-For workloads that `fsync` constantly — OLTP databases, message queues — a disk
-can opt into **write-back** mode. Flushes then commit to a local write log at
-NVMe latency (milliseconds instead of an object-store round trip), and a
-background uploader drains to the bucket continuously, in strictly the order the
-application's flush barriers created. That ordering is the key safety property:
+Workloads that `fsync` constantly, such as OLTP databases and message queues,
+can opt a disk into **write-back** mode. Flushes then commit to a local write
+log at NVMe latency, milliseconds rather than an object-store round trip, and a
+background uploader drains to the bucket continuously. It uploads in exactly the
+order the application's flush barriers created, which is what keeps the disk
+safe:
 
-- A process crash or host reboot loses nothing — the local log replays on the
+- A process crash or host reboot loses nothing. The local log replays on the
   next mount.
-- Losing the entire host rolls the disk back to a crash-consistent recent point
-  in time — exactly as if power had been cut at that moment. Filesystems and
-  databases recover with their normal journal replay; the bucket never holds a
-  state that reorders writes across an `fsync`, the failure mode that corrupts
-  data.
+- Losing the entire host rolls the disk back to a recent crash-consistent point,
+  the same state you'd get if power had been cut at that moment. Filesystems and
+  databases recover with their normal journal replay, because the bucket never
+  holds a state that reorders writes across an `fsync` — the failure mode that
+  corrupts data.
 
-The window of recent writes at risk is bounded — cloud-disk throttles new writes
-rather than letting the not-yet-uploaded backlog grow without limit — and a
-planned unmount always drains fully before detaching.
+The amount of recent writes at risk is bounded: Cloud Disk throttles new writes
+rather than let the not-yet-uploaded backlog grow without limit, and a planned
+unmount drains fully before detaching.
 
-:::warning
+:::warning Write-back trades durability for latency
 
-Write-back trades durability for latency: losing the entire host suddenly can
-roll the disk back by the seconds of writes not yet uploaded (crash-consistent,
-not corrupt). Use it only where that rollback is acceptable; keep the default
-write-through when every `fsync` must be on Tigris.
+Losing the entire host suddenly can roll the disk back by the seconds of writes
+not yet uploaded. The result is crash-consistent, not corrupt, but use
+write-back only where that rollback is acceptable. Keep the default
+write-through when every `fsync` must be on Tigris before it returns.
 
 :::
 
-Write-through when you want the bucket current at every `fsync`; write-back when
-you want local-disk latency and can tolerate seconds of rollback on sudden host
-loss. It's one setting, per disk.
+It's one setting per disk: write-through keeps the bucket current at every
+`fsync`; write-back gives you local-disk latency in exchange for a few seconds
+of possible rollback on sudden host loss.
 
 ## Snapshots and forks
 
 A disk can be snapshotted at a point in time, and new disks can be created as
-instant forks of a snapshot — copy-on-write, no data copied, regardless of size.
-Cloning a multi-terabyte production database for a staging environment takes
-seconds. Forked disks are full first-class disks: mount them anywhere and tune
-them independently of their parent.
+instant forks of a snapshot. Forks are copy-on-write, so no data is copied
+regardless of disk size, and cloning a multi-terabyte database for a staging
+environment takes seconds. A fork is a first-class disk in its own right: mount
+it anywhere and tune it independently of its parent.
 
 ## Operating it
 
@@ -125,3 +128,9 @@ them independently of their parent.
   policy is governed by your object-store configuration.
 - **Tunable per disk** — cache sizes and durability mode are per-disk settings,
   so a scratch disk and a database disk can make different trade-offs.
+
+## Next steps
+
+- [Configuration & Tuning](./tuning.mdx) — the cache, write-back, and durability
+  settings, and when to change them.
+- [Kubernetes (CSI)](./kubernetes.mdx) — run Cloud Disk as PersistentVolumes.

--- a/docs/cloud-disk/architecture.mdx
+++ b/docs/cloud-disk/architecture.mdx
@@ -24,7 +24,7 @@ A disk is just a name. With a single command you get a formatted, mounted,
 ready-to-use disk:
 
 ```bash
-cloud-disk create data1 --size 100G
+cloud-disk create data1 -size 100G
 ```
 
 Everything that defines the disk — its geometry, its tuning, its contents —
@@ -83,6 +83,15 @@ application's flush barriers created. That ordering is the key safety property:
 The window of recent writes at risk is bounded — cloud-disk throttles new writes
 rather than letting the not-yet-uploaded backlog grow without limit — and a
 planned unmount always drains fully before detaching.
+
+:::warning
+
+Write-back trades durability for latency: losing the entire host suddenly can
+roll the disk back by the seconds of writes not yet uploaded (crash-consistent,
+not corrupt). Use it only where that rollback is acceptable; keep the default
+write-through when every `fsync` must be on Tigris.
+
+:::
 
 Write-through when you want the bucket current at every `fsync`; write-back when
 you want local-disk latency and can tolerate seconds of rollback on sudden host

--- a/docs/cloud-disk/index.mdx
+++ b/docs/cloud-disk/index.mdx
@@ -77,8 +77,7 @@ cloud-disk config mydata set max-cache-size=8G flush-workers=16
 cloud-disk config mydata show
 ```
 
-See [Configuration & Tuning](https://cloud-disk.t3.tigrisfiles.io/tuning.html)
-for the settings worth knowing.
+See [Configuration & Tuning](./tuning.mdx) for the settings worth knowing.
 
 ## Status
 

--- a/docs/cloud-disk/index.mdx
+++ b/docs/cloud-disk/index.mdx
@@ -1,27 +1,35 @@
 ---
-title: cloud-disk
+title: Tigris Cloud Disk
 sidebar_label: Overview
 description:
-  cloud-disk presents a Tigris bucket as a Linux block device — format it with
-  any filesystem, run any application, and pay only for the data you store.
+  Tigris Cloud Disk presents a Tigris bucket as a Linux block device. Format it
+  with any filesystem, run any application, and pay only for the data you store.
 ---
 
 # Cloud Disk
 
-High-performance Tigris-backed block device.
-
-cloud-disk presents a Linux block device backed by a Tigris bucket. Format it
-with any filesystem (ext4, XFS, btrfs), run any application on it — databases
-included. Capacity is effectively unlimited, you pay only for the data you
-actually store, and the volume inherits the durability, replication, and access
+Tigris Cloud Disk presents a Tigris bucket as a Linux block device. You format
+it with any filesystem (ext4, XFS, btrfs) and run any application on it,
+databases included. Capacity is effectively unlimited, you pay only for the data
+you store, and the volume inherits the durability, replication, and access
 controls of the bucket underneath.
 
-A disk is just a name. Everything that defines it — geometry, tuning, contents —
-lives in the bucket, so the disk you unmount on one machine is byte-for-byte the
-disk you mount on the next.
+:::info Cloud Disk is in beta
 
-See [Architecture](./architecture.mdx) for how it works, or
-[Kubernetes (CSI)](./kubernetes.mdx) to provision disks as PersistentVolumes.
+The `cloud-disk` CLI, its defaults, and its on-disk format may change between
+releases. Don't yet depend on it for production data you can't reproduce, and
+pin a known version if you need stability.
+
+:::
+
+Everything that defines a disk — its geometry, its settings, its contents —
+lives in the bucket. The disk you unmount on one machine is the disk you mount
+on the next, including on another machine or in another region.
+
+To work with disks, install the CLI below. The
+[Architecture](./architecture.mdx) page covers how it works, and
+[Kubernetes (CSI)](./kubernetes.mdx) covers provisioning disks as
+PersistentVolumes.
 
 ## Install
 
@@ -56,7 +64,7 @@ the first command; after that they're remembered there as well.
 
 ## Snapshots & forks
 
-Snapshot a disk — even while it's mounted and in use — then fork the snapshot
+You can snapshot a disk while it's mounted and in use, then fork the snapshot
 into an independent copy. Everything is uploaded to Tigris before the snapshot
 is taken:
 
@@ -93,3 +101,11 @@ Deletes the disk and all its data, after asking for confirmation:
 ```bash
 cloud-disk delete mydata
 ```
+
+## Next steps
+
+- [Architecture](./architecture.mdx) — how a bucket becomes a block device, and
+  the durability trade-offs behind write-through and write-back.
+- [Kubernetes (CSI)](./kubernetes.mdx) — provision disks as PersistentVolumes.
+- [Configuration & Tuning](./tuning.mdx) — the settings worth knowing and when
+  to change them.

--- a/docs/cloud-disk/index.mdx
+++ b/docs/cloud-disk/index.mdx
@@ -1,0 +1,95 @@
+---
+title: cloud-disk
+sidebar_label: Overview
+description:
+  cloud-disk presents a Tigris bucket as a Linux block device — format it with
+  any filesystem, run any application, and pay only for the data you store.
+---
+
+# cloud-disk
+
+High-performance Tigris-backed block device.
+
+cloud-disk presents a Linux block device backed by a Tigris bucket. Format it
+with any filesystem (ext4, XFS, btrfs), run any application on it — databases
+included. Capacity is effectively unlimited, you pay only for the data you
+actually store, and the volume inherits the durability, replication, and access
+controls of the bucket underneath.
+
+A disk is just a name. Everything that defines it — geometry, tuning, contents —
+lives in the bucket, so the disk you unmount on one machine is byte-for-byte the
+disk you mount on the next.
+
+See [Architecture](./architecture.mdx) for how it works.
+
+## Install
+
+Auto-detects CPU arch and package manager (Linux, amd64/arm64):
+
+```bash
+curl -fsSL https://cloud-disk.t3.tigrisfiles.io/install.sh | sh
+```
+
+## Quick start
+
+One command creates the disk, formats it, and mounts it at
+`/mnt/cloud-disk/<name>`. Get your access keys from the
+[Tigris console](https://console.storage.dev). Credentials are remembered, so
+it's the only time they're needed:
+
+```bash
+export AWS_ACCESS_KEY_ID=tid_... AWS_SECRET_ACCESS_KEY=tsec_...
+sudo -E cloud-disk create mydata -size 100G
+```
+
+From then on:
+
+```bash
+sudo cloud-disk umount mydata     # flushes everything to Tigris, unmounts
+sudo cloud-disk mount mydata      # mount again — here or on another machine
+```
+
+Different object-store endpoint or bucket name? Pass `-endpoint` / `-bucket` to
+`create` — they're remembered too. On a new machine, export the credentials for
+the first command; after that they're remembered there as well.
+
+## Snapshots & forks
+
+Snapshot a disk — even while it's mounted and in use — then fork the snapshot
+into an independent copy. Everything is uploaded to Tigris before the snapshot
+is taken:
+
+```bash
+cloud-disk snapshot mydata create --name nightly    # prints the snapshot version
+cloud-disk create mydata-test --parent mydata --snapshot <version> \
+    --set mount-point=/mnt/cloud-disk/mydata-test
+```
+
+The fork starts with the parent's data and settings at that snapshot; the two
+disks are fully independent afterwards.
+
+## Settings
+
+Settings are stored with the disk — set once, they apply wherever it's mounted:
+
+```bash
+cloud-disk config mydata set max-cache-size=8G flush-workers=16
+cloud-disk config mydata show
+```
+
+See [Configuration & Tuning](https://cloud-disk.t3.tigrisfiles.io/tuning.html)
+for the settings worth knowing.
+
+## Status
+
+```bash
+cloud-disk status mydata
+```
+
+## Delete
+
+Deletes the disk and all its data, after asking for confirmation:
+
+```bash
+cloud-disk delete mydata
+```

--- a/docs/cloud-disk/index.mdx
+++ b/docs/cloud-disk/index.mdx
@@ -14,11 +14,9 @@ databases included. Capacity is effectively unlimited, you pay only for the data
 you store, and the volume inherits the durability, replication, and access
 controls of the bucket underneath.
 
-:::info Cloud Disk is in beta
+:::info Beta
 
-The `cloud-disk` CLI, its defaults, and its on-disk format may change between
-releases. Don't yet depend on it for production data you can't reproduce, and
-pin a known version if you need stability.
+Cloud Disk is in beta and under active development.
 
 :::
 

--- a/docs/cloud-disk/index.mdx
+++ b/docs/cloud-disk/index.mdx
@@ -20,7 +20,8 @@ A disk is just a name. Everything that defines it — geometry, tuning, contents
 lives in the bucket, so the disk you unmount on one machine is byte-for-byte the
 disk you mount on the next.
 
-See [Architecture](./architecture.mdx) for how it works.
+See [Architecture](./architecture.mdx) for how it works, or
+[Kubernetes (CSI)](./kubernetes.mdx) to provision disks as PersistentVolumes.
 
 ## Install
 

--- a/docs/cloud-disk/index.mdx
+++ b/docs/cloud-disk/index.mdx
@@ -6,7 +6,7 @@ description:
   any filesystem, run any application, and pay only for the data you store.
 ---
 
-# cloud-disk
+# Cloud Disk
 
 High-performance Tigris-backed block device.
 

--- a/docs/cloud-disk/kubernetes.mdx
+++ b/docs/cloud-disk/kubernetes.mdx
@@ -32,9 +32,11 @@ Nodes need the `nbd` kernel module, which isn't present on some minimal images
 ```bash
 kubectl create secret generic tigris-csi-aws -n kube-system \
   --from-literal=AWS_ACCESS_KEY_ID=tid_... \
-  --from-literal=AWS_SECRET_ACCESS_KEY=tsec_... \
-  --from-literal=AWS_ENDPOINT_URL=https://t3.storage.dev
+  --from-literal=AWS_SECRET_ACCESS_KEY=tsec_...
 ```
+
+The endpoint defaults to Tigris. To use AWS, MinIO, or another endpoint, add
+`--from-literal=AWS_ENDPOINT_URL=<url>` and set `endpoint` on the StorageClass.
 
 ## 2. Deploy the driver
 
@@ -44,15 +46,15 @@ kubectl apply -f https://cloud-disk.t3.tigrisfiles.io/csi-driver.yaml
 
 ## 3. Create a StorageClass
 
+No parameters are required — a disk's bucket is derived from the PVC name and
+the endpoint defaults to Tigris:
+
 ```yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: cloud-disk
 provisioner: csi.tigris.dev
-parameters:
-  bucket: my-volumes
-  endpoint: https://t3.storage.dev
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 ```
@@ -90,23 +92,61 @@ spec:
 
 ## StorageClass parameters
 
+All parameters are optional — the defaults target Tigris.
+
 | Parameter        | Default                  | Description                         |
 | ---------------- | ------------------------ | ----------------------------------- |
-| `bucket`         | _(required)_             | Tigris bucket name                  |
-| `endpoint`       | `https://t3.storage.dev` | Tigris endpoint                     |
+| `endpoint`       | `https://t3.storage.dev` | Endpoint (AWS / MinIO / other)      |
 | `region`         | `us-east-1`              | Region                              |
 | `fstype`         | `ext4`                   | Filesystem (`ext4`, `xfs`, `btrfs`) |
 | `chunk-size`     | `1M`                     | Object size                         |
 | `max-cache-size` | `1G`                     | Local cache size                    |
 | `flush-workers`  | `8`                      | Concurrent upload workers to Tigris |
 
-Any disk setting can be a StorageClass parameter — see
+A disk's bucket is **not** a parameter — it's derived from the PVC name, so each
+PVC is its own disk. Any other disk setting can be a StorageClass parameter; see
 [Configuration & Tuning](./tuning.mdx) for the full list.
 
 ## How it works
 
-A PVC writes a metadata marker into the bucket at `<bucket>/csi-vol-<name>/`.
-When a pod is scheduled, the node's DaemonSet starts a `cloud-disk` process for
-the volume, attaches it to a free `/dev/nbdN`, formats it on first use (`fsck`
+A PVC creates its own bucket (`csi-vol-<pvc-name>`) with a metadata marker. When
+a pod is scheduled, the node's DaemonSet starts a `cloud-disk` process for the
+volume, attaches it to a free `/dev/nbdN`, formats it on first use (`fsck`
 thereafter), and mounts it into the pod. Deleting the pod flushes the cache to
-Tigris and detaches; deleting the PVC removes the volume's objects.
+Tigris and detaches; deleting the PVC removes the bucket and its objects.
+
+## Raw block volumes
+
+For applications that manage their own storage (some databases), request a raw
+device with `volumeMode: Block` — no filesystem is created, and the device is
+exposed via `volumeDevices` instead of `volumeMounts`:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-block
+spec:
+  volumeMode: Block
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: cloud-disk
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-block-app
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep 3600"]
+      volumeDevices:
+        - { name: data, devicePath: /dev/xvda }
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: my-block
+```

--- a/docs/cloud-disk/kubernetes.mdx
+++ b/docs/cloud-disk/kubernetes.mdx
@@ -1,0 +1,112 @@
+---
+title: cloud-disk on Kubernetes (CSI)
+sidebar_label: Kubernetes (CSI)
+description:
+  Provision Tigris-backed block storage as Kubernetes PersistentVolumes with the
+  cloud-disk CSI driver.
+---
+
+# cloud-disk on Kubernetes
+
+The cloud-disk CSI driver provisions PersistentVolumes backed by Tigris — each
+PVC becomes a Tigris-backed NBD block device, formatted with the filesystem of
+your choice and mounted into your pod.
+
+## Prerequisites
+
+- Kubernetes 1.26+
+- Linux worker nodes with the `nbd` kernel module available
+- A Tigris bucket and access keys from the
+  [Tigris console](https://console.storage.dev)
+
+:::note
+
+Nodes need the `nbd` kernel module, which isn't present on some minimal images
+(e.g. GKE Container-Optimized OS). Volumes are single-node — `ReadWriteOnce` or
+`ReadOnlyMany`.
+
+:::
+
+## 1. Create the credentials secret
+
+```bash
+kubectl create secret generic tigris-csi-aws -n kube-system \
+  --from-literal=AWS_ACCESS_KEY_ID=tid_... \
+  --from-literal=AWS_SECRET_ACCESS_KEY=tsec_... \
+  --from-literal=AWS_ENDPOINT_URL=https://t3.storage.dev
+```
+
+## 2. Deploy the driver
+
+```bash
+kubectl apply -f https://cloud-disk.t3.tigrisfiles.io/csi-driver.yaml
+```
+
+## 3. Create a StorageClass
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cloud-disk
+provisioner: csi.tigris.dev
+parameters:
+  bucket: my-volumes
+  endpoint: https://t3.storage.dev
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+```
+
+## 4. Claim it from a pod
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: cloud-disk
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-app
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep 3600"]
+      volumeMounts:
+        - { name: data, mountPath: /data }
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: my-data
+```
+
+## StorageClass parameters
+
+| Parameter        | Default                  | Description                         |
+| ---------------- | ------------------------ | ----------------------------------- |
+| `bucket`         | _(required)_             | Tigris bucket name                  |
+| `endpoint`       | `https://t3.storage.dev` | Tigris endpoint                     |
+| `region`         | `us-east-1`              | Region                              |
+| `fstype`         | `ext4`                   | Filesystem (`ext4`, `xfs`, `btrfs`) |
+| `chunk-size`     | `1M`                     | Object size                         |
+| `max-cache-size` | `1G`                     | Local cache size                    |
+| `flush-workers`  | `8`                      | Concurrent upload workers to Tigris |
+
+Any disk setting can be a StorageClass parameter — see
+[Configuration & Tuning](./tuning.mdx) for the full list.
+
+## How it works
+
+A PVC writes a metadata marker into the bucket at `<bucket>/csi-vol-<name>/`.
+When a pod is scheduled, the node's DaemonSet starts a `cloud-disk` process for
+the volume, attaches it to a free `/dev/nbdN`, formats it on first use (`fsck`
+thereafter), and mounts it into the pod. Deleting the pod flushes the cache to
+Tigris and detaches; deleting the PVC removes the volume's objects.

--- a/docs/cloud-disk/kubernetes.mdx
+++ b/docs/cloud-disk/kubernetes.mdx
@@ -1,16 +1,24 @@
 ---
-title: cloud-disk on Kubernetes (CSI)
+title: Cloud Disk on Kubernetes (CSI)
 sidebar_label: Kubernetes (CSI)
 description:
   Provision Tigris-backed block storage as Kubernetes PersistentVolumes with the
-  cloud-disk CSI driver.
+  Cloud Disk CSI driver.
 ---
 
-# cloud-disk on Kubernetes
+# Cloud Disk on Kubernetes
 
-The cloud-disk CSI driver provisions PersistentVolumes backed by Tigris — each
+The Cloud Disk CSI driver provisions PersistentVolumes backed by Tigris. Each
 PVC becomes a Tigris-backed NBD block device, formatted with the filesystem of
 your choice and mounted into your pod.
+
+:::info Cloud Disk is in beta
+
+The CSI driver and its StorageClass parameters may change between releases. Pin
+the driver manifest to a known version for anything you don't want to re-test on
+upgrade.
+
+:::
 
 ## Prerequisites
 

--- a/docs/cloud-disk/kubernetes.mdx
+++ b/docs/cloud-disk/kubernetes.mdx
@@ -12,11 +12,9 @@ The Cloud Disk CSI driver provisions PersistentVolumes backed by Tigris. Each
 PVC becomes a Tigris-backed NBD block device, formatted with the filesystem of
 your choice and mounted into your pod.
 
-:::info Cloud Disk is in beta
+:::info Beta
 
-The CSI driver and its StorageClass parameters may change between releases. Pin
-the driver manifest to a known version for anything you don't want to re-test on
-upgrade.
+Cloud Disk is in beta and under active development.
 
 :::
 

--- a/docs/cloud-disk/tuning.mdx
+++ b/docs/cloud-disk/tuning.mdx
@@ -10,10 +10,9 @@ description:
 
 This page covers the settings most worth knowing and when to change them.
 
-:::info Cloud Disk is in beta
+:::info Beta
 
-Setting names and defaults may change between releases. Run
-`cloud-disk config <disk> show` to see what a given build actually applies.
+Cloud Disk is in beta and under active development.
 
 :::
 

--- a/docs/cloud-disk/tuning.mdx
+++ b/docs/cloud-disk/tuning.mdx
@@ -1,0 +1,114 @@
+---
+title: cloud-disk Configuration & Tuning
+sidebar_label: Configuration & Tuning
+description:
+  The cloud-disk settings most worth knowing — cache sizes, write-back,
+  durability, reliability — and when to change them.
+---
+
+# Configuration & Tuning
+
+_The settings most worth knowing, and when to change them._
+
+Settings are stored with the disk and apply wherever it's mounted. Change them
+any time:
+
+```bash
+cloud-disk config mydata set flush-workers=16
+cloud-disk config mydata show
+cloud-disk config mydata unset flush-workers
+```
+
+While a disk is mounted, performance settings apply immediately — `config set`
+tells you which; the rest take effect on the next mount. Defaults are sensible —
+most deployments only change a few.
+
+## At create time
+
+| Option            | Example | Description                                                               |
+| ----------------- | ------- | ------------------------------------------------------------------------- |
+| `-size`           | `100G`  | Disk size (`500M`, `1G`, `2T`). Sparse — only written data costs storage. |
+| `-fstype`         | `xfs`   | Filesystem for the disk: `ext4` (default), `xfs`, `btrfs`.                |
+| `--set key=value` |         | Apply any setting below at create time (repeatable).                      |
+| `--no-mount`      |         | Create only; don't mount.                                                 |
+
+## Performance — the high-impact knobs
+
+| Setting                                       | Default    | When to raise it                                                                                                                                      |
+| --------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max-cache-size`                              | `1G`       | The in-RAM cache. Raise it so your working set fits — fewer reads go to Tigris. For read-heavy workloads, a meaningful fraction of RAM (`4G`, `16G`). |
+| `flush-workers`                               | `8`        | Concurrent uploads to Tigris. Raise (`16`–`32`) for **write-heavy** workloads.                                                                        |
+| `read-ahead-workers`, `read-ahead-max-window` | `4` / auto | Prefetching for sequential reads. Raise the window for **streaming / scan-heavy** workloads; set workers to `-1` to disable prefetching.              |
+| `connections`                                 | CPU count  | Parallel device connections. Usually leave alone; lower it on small machines sharing many disks.                                                      |
+
+## Local disk cache
+
+A cache on local disk (SSD) between RAM and Tigris: reads that miss the RAM
+cache are served from local disk instead of Tigris, and write-back uses it to
+buffer writes.
+
+| Setting           | Default   | Description                                                                                                                                                                          |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `disk-cache-path` | —         | Local directory for the cache, e.g. `/var/lib/cloud-disk`. Each disk uses its own subdirectory, so one path is safe to share (and to inherit on forks). Required for write-back.     |
+| `disk-cache-size` | unlimited | How much local disk the cache may use, e.g. `4G`, `100G`. Size it to your working set for the biggest read speedup. `0` turns the read cache off while keeping write-back buffering. |
+
+## Write-back
+
+Write-back buffers writes locally and uploads in the background — much faster.
+Everything is flushed to Tigris on unmount.
+
+| Setting                | Default | Effect                                                                                |
+| ---------------------- | ------- | ------------------------------------------------------------------------------------- |
+| `write-back`           | off     | `true` enables write-back caching. Needs `disk-cache-path`.                           |
+| `max-staging-bytes`    | `1G`    | Write buffer budget. Raise (`16G`) for bursty write-heavy workloads.                  |
+| `max-dirty-ratio`      | `0.5`   | How full the cache gets before background uploading starts. Lower = upload sooner.    |
+| `sync-writeback-ratio` | `0.8`   | How full the cache gets before writes pause for the upload to catch up. `0` disables. |
+
+## Unmount durability
+
+What a clean unmount does with buffered data before finishing, via
+`shutdown-mode`:
+
+| Mode       | Behavior                                                                                              |
+| ---------- | ----------------------------------------------------------------------------------------------------- |
+| `remote`   | **(default)** Upload everything to Tigris — the bucket is the complete disk. Safest; slowest unmount. |
+| `local`    | Save to local disk only; the next mount finishes the upload. Faster unmount.                          |
+| `dirty`    | Exit fast. For quick restarts on the same machine.                                                    |
+| `ship-wal` | Like `remote`, plus uploads the recovery log for another machine to take over.                        |
+
+## Reliability
+
+| Setting               | Default               | When to change                                                                                                               |
+| --------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `retry-max-retries`   | `30`                  | How many times object-store operations retry before reporting an error. The default rides out ~2 minutes of unavailability.  |
+| `nbd-request-timeout` | kernel default (~30s) | How long a single disk I/O may take before the kernel gives up on it. Raise (`600s`) for slow links or heavily loaded disks. |
+
+## Filesystem & mount
+
+| Setting       | Default                  | Description                                                                             |
+| ------------- | ------------------------ | --------------------------------------------------------------------------------------- |
+| `fstype`      | `ext4`                   | Filesystem created on first mount (ext4, xfs, btrfs).                                   |
+| `mount-point` | `/mnt/cloud-disk/<disk>` | Where the disk is mounted. Set it on a fork so parent and fork can be mounted together. |
+| `mount-opts`  | —                        | Extra mount options, e.g. `noatime`.                                                    |
+| `readonly`    | off                      | `true` mounts the disk read-only.                                                       |
+
+## Observability
+
+| Setting                  | Default                                      | Description                                        |
+| ------------------------ | -------------------------------------------- | -------------------------------------------------- |
+| `metrics-addr`           | —                                            | Expose Prometheus metrics, e.g. `:9090`.           |
+| `stats-interval`         | —                                            | Log periodic throughput/latency stats, e.g. `10s`. |
+| `log-file`, `log-format` | `/var/log/cloud-disk-<disk>.log` / `console` | Log destination and format (`console` or `json`).  |
+
+## Example: tuned for a database
+
+```bash
+sudo -E cloud-disk create pg-data -size 200G \
+    --set write-back=true \
+    --set disk-cache-path=/var/lib/cloud-disk \
+    --set disk-cache-size=100G \
+    --set max-cache-size=16G \
+    --set flush-workers=16 \
+    --set max-staging-bytes=16G \
+    --set metrics-addr=:9090
+```

--- a/docs/cloud-disk/tuning.mdx
+++ b/docs/cloud-disk/tuning.mdx
@@ -1,14 +1,21 @@
 ---
-title: cloud-disk Configuration & Tuning
+title: Cloud Disk Configuration & Tuning
 sidebar_label: Configuration & Tuning
 description:
-  The cloud-disk settings most worth knowing — cache sizes, write-back,
+  The Cloud Disk settings most worth knowing — cache sizes, write-back,
   durability, reliability — and when to change them.
 ---
 
 # Configuration & Tuning
 
-_The settings most worth knowing, and when to change them._
+This page covers the settings most worth knowing and when to change them.
+
+:::info Cloud Disk is in beta
+
+Setting names and defaults may change between releases. Run
+`cloud-disk config <disk> show` to see what a given build actually applies.
+
+:::
 
 Settings are stored with the disk and apply wherever it's mounted. Change them
 any time:
@@ -19,9 +26,9 @@ cloud-disk config mydata show
 cloud-disk config mydata unset flush-workers
 ```
 
-While a disk is mounted, performance settings apply immediately — `config set`
-tells you which; the rest take effect on the next mount. Defaults are sensible —
-most deployments only change a few.
+While a disk is mounted, performance settings apply immediately, and
+`config set` tells you which ones; the rest take effect on the next mount. The
+defaults cover most deployments, so you'll usually change only a few of these.
 
 ## At create time
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -737,11 +737,6 @@ const sidebars = {
             },
             {
               type: "doc",
-              label: "Kubernetes (CSI)",
-              id: "cloud-disk/kubernetes",
-            },
-            {
-              type: "doc",
               label: "Architecture",
               id: "cloud-disk/architecture",
             },

--- a/sidebars.js
+++ b/sidebars.js
@@ -740,6 +740,16 @@ const sidebars = {
               label: "Architecture",
               id: "cloud-disk/architecture",
             },
+            {
+              type: "doc",
+              label: "Kubernetes (CSI)",
+              id: "cloud-disk/kubernetes",
+            },
+            {
+              type: "doc",
+              label: "Configuration & Tuning",
+              id: "cloud-disk/tuning",
+            },
           ],
         },
         "training/tigrisfs",

--- a/sidebars.js
+++ b/sidebars.js
@@ -737,6 +737,11 @@ const sidebars = {
             },
             {
               type: "doc",
+              label: "Kubernetes (CSI)",
+              id: "cloud-disk/kubernetes",
+            },
+            {
+              type: "doc",
               label: "Architecture",
               id: "cloud-disk/architecture",
             },

--- a/sidebars.js
+++ b/sidebars.js
@@ -724,6 +724,24 @@ const sidebars = {
             },
           ],
         },
+        {
+          type: "category",
+          label: "Cloud Disk",
+          collapsible: true,
+          collapsed: true,
+          items: [
+            {
+              type: "doc",
+              label: "Overview",
+              id: "cloud-disk/index",
+            },
+            {
+              type: "doc",
+              label: "Architecture",
+              id: "cloud-disk/architecture",
+            },
+          ],
+        },
         "training/tigrisfs",
       ],
     },

--- a/src/components/diagrams/CloudDiskArchitectureDiagram.tsx
+++ b/src/components/diagrams/CloudDiskArchitectureDiagram.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+
+// Faithful port of the cloud-disk site's "architecture at a glance" diagram:
+// a vertical stack of boxes (app → block device → cloud-disk engine with its
+// cache layers → bucket) joined by labeled arrows. Styled with Infima theme
+// variables so it tracks light/dark like the rest of the docs.
+
+const C = {
+  border: "var(--ifm-color-emphasis-300)",
+  box: "var(--ifm-color-emphasis-100)",
+  accent: "var(--ifm-color-primary)",
+  surface: "var(--ifm-background-surface-color)",
+  muted: "var(--ifm-color-emphasis-700)",
+};
+
+const node: React.CSSProperties = {
+  border: `1px solid ${C.border}`,
+  borderRadius: 10,
+  padding: ".55rem .9rem",
+  textAlign: "center",
+  background: C.box,
+  fontSize: ".92rem",
+};
+
+const plain: React.CSSProperties = {
+  ...node,
+  background: "transparent",
+  borderStyle: "dashed",
+  color: C.muted,
+};
+
+const engine: React.CSSProperties = {
+  ...node,
+  padding: ".7rem .8rem .8rem",
+  borderColor: C.accent,
+};
+
+const engineTitle: React.CSSProperties = {
+  fontWeight: 600,
+  color: C.accent,
+  marginBottom: ".55rem",
+  fontFamily: "var(--ifm-font-family-monospace)",
+};
+
+const layer: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "1rem",
+  alignItems: "baseline",
+  border: `1px solid ${C.border}`,
+  borderRadius: 7,
+  background: C.surface,
+  padding: ".4rem .7rem",
+  marginTop: ".45rem",
+  fontSize: ".88rem",
+  textAlign: "left",
+};
+
+const bucket: React.CSSProperties = {
+  ...node,
+  borderColor: C.accent,
+  fontWeight: 600,
+};
+
+function Layer({ name, note }: { name: string; note: string }) {
+  return (
+    <div style={layer}>
+      <b style={{ fontWeight: 600, whiteSpace: "nowrap" }}>{name}</b>
+      <span style={{ color: C.muted, fontSize: ".84rem", textAlign: "right" }}>
+        {note}
+      </span>
+    </div>
+  );
+}
+
+function Arrow({ label }: { label?: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        color: C.muted,
+        lineHeight: 1,
+        padding: ".15rem 0",
+      }}
+    >
+      {label && (
+        <span style={{ fontSize: ".8rem", padding: ".15rem 0 .1rem" }}>
+          {label}
+        </span>
+      )}
+      <span style={{ width: 2, height: 14, background: C.border }} />
+      <span style={{ fontSize: ".6rem", marginTop: 1 }}>▼</span>
+    </div>
+  );
+}
+
+export default function CloudDiskArchitectureDiagram() {
+  return (
+    <div
+      style={{
+        margin: "1.5rem auto",
+        maxWidth: 480,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "stretch",
+      }}
+    >
+      <div style={plain}>application · filesystem · database</div>
+      <Arrow />
+      <div style={node}>Linux block device</div>
+      <Arrow />
+      <div style={engine}>
+        <div style={engineTitle}>cloud-disk</div>
+        <Layer name="memory cache" note="hot reads + write coalescing" />
+        <Layer name="local disk cache" note="warm reads, survives remounts" />
+      </div>
+      <Arrow label="flush commits to the bucket" />
+      <div style={bucket}>
+        your Tigris bucket
+        <span
+          style={{
+            display: "block",
+            fontWeight: 400,
+            color: C.muted,
+            fontSize: ".84rem",
+          }}
+        >
+          source of truth
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds **Cloud Disk** documentation under the Product section — cloud-disk presents a Tigris bucket as a Linux block device (format with any filesystem, run any app, pay only for stored data).

Two pages in a new "Cloud Disk" category (placed after Tigris Acceleration Gateway, mirroring its layout):

- **Overview** (`cloud-disk/index`) — what it is, install, quick start, snapshots & forks, settings, status, delete. Sourced from the cloud-disk site's landing page.
- **Architecture** (`cloud-disk/architecture`) — high-level design: what it is / why / architecture at a glance (mermaid diagram) / write-through & write-back durability / snapshots & forks / leasing / operational properties. Sourced from the site's `design.html` (the conceptual page, not the deep internals).

## Verification

- `docusaurus build` succeeds, both pages render, mermaid diagram compiles, **no broken-link warnings**.
- `prettier --check` clean.

A couple of links (tuning, install one-liner) point to the cloud-disk site for now; a Tuning page could follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a presentational React component only; no runtime product or auth changes.
> 
> **Overview**
> Adds a **Cloud Disk** section under Product (after Tigris Acceleration Gateway) with four new pages: **Overview** (install, quick start, snapshots/forks, config), **Architecture** (chunks, write-through vs write-back, snapshots, leasing), **Kubernetes (CSI)** (driver deploy, StorageClass, PVC/pod examples, raw block volumes), and **Configuration & Tuning** (performance, disk cache, write-back, shutdown modes, observability).
> 
> The architecture page embeds a new **React diagram** (`CloudDiskArchitectureDiagram`) themed with Infima variables instead of an external/mermaid diagram. Cross-links tie the pages together so tuning and CSI are first-class in the docs site rather than only on the cloud-disk marketing site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98273f84ecd8ebbdca0665abd9ba989451add676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->