### PR TITLE
docs: trim cloud disk endpoint note and storageclass region row

### DIFF
--- a/docs/cloud-disk/index.mdx
+++ b/docs/cloud-disk/index.mdx
@@ -56,8 +56,8 @@ sudo cloud-disk umount mydata     # flushes everything to Tigris, unmounts
 sudo cloud-disk mount mydata      # mount again — here or on another machine
 ```
 
-On a new machine, export the credentials for
-the first command; after that they're remembered there as well.
+On a new machine, export the credentials for the first command; after that
+they're remembered there as well.
 
 ## Snapshots & forks
 

--- a/docs/cloud-disk/index.mdx
+++ b/docs/cloud-disk/index.mdx
@@ -56,8 +56,7 @@ sudo cloud-disk umount mydata     # flushes everything to Tigris, unmounts
 sudo cloud-disk mount mydata      # mount again — here or on another machine
 ```
 
-Different object-store endpoint or bucket name? Pass `-endpoint` / `-bucket` to
-`create` — they're remembered too. On a new machine, export the credentials for
+On a new machine, export the credentials for
 the first command; after that they're remembered there as well.
 
 ## Snapshots & forks

--- a/docs/cloud-disk/kubernetes.mdx
+++ b/docs/cloud-disk/kubernetes.mdx
@@ -103,7 +103,6 @@ All parameters are optional — the defaults target Tigris.
 | Parameter        | Default                  | Description                         |
 | ---------------- | ------------------------ | ----------------------------------- |
 | `endpoint`       | `https://t3.storage.dev` | Endpoint (AWS / MinIO / other)      |
-| `region`         | `us-east-1`              | Region                              |
 | `fstype`         | `ext4`                   | Filesystem (`ext4`, `xfs`, `btrfs`) |
 | `chunk-size`     | `1M`                     | Object size                         |
 | `max-cache-size` | `1G`                     | Local cache size                    |

--- a/docs/cloud-disk/kubernetes.mdx
+++ b/docs/cloud-disk/kubernetes.mdx
@@ -102,7 +102,7 @@ All parameters are optional — the defaults target Tigris.
 
 | Parameter        | Default                  | Description                         |
 | ---------------- | ------------------------ | ----------------------------------- |
-| `endpoint`       | `https://t3.storage.dev` | Endpoint (AWS / MinIO / other)      |
+| `endpoint`       | `https://t3.storage.dev` | Endpoint                            |
 | `fstype`         | `ext4`                   | Filesystem (`ext4`, `xfs`, `btrfs`) |
 | `chunk-size`     | `1M`                     | Object size                         |
 | `max-cache-size` | `1G`                     | Local cache size                    |


### PR DESCRIPTION
Two small cleanups to the Cloud Disk docs:

- **Overview** (`docs/cloud-disk/index.mdx`): remove the "Different object-store endpoint or bucket name? Pass `-endpoint` / `-bucket` to `create` — they're remembered too." sentence. The remaining note about exporting credentials on a new machine is kept.
- **Kubernetes (CSI)** (`docs/cloud-disk/kubernetes.mdx`): drop the `region` row from the StorageClass parameters table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no product or code behavior changes.
> 
> **Overview**
> **Cloud Disk overview** drops the quick-start sentence about passing `-endpoint` / `-bucket` to `create` (and that those values are remembered). The note about exporting credentials on a new machine is unchanged.
> 
> **Kubernetes (CSI)** removes the `region` row from the StorageClass parameters table and narrows the `endpoint` description (no longer “AWS / MinIO / other”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75d1266b6a60371d73f264c3902870120cda1a8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->