### PR TITLE
docs(cloud-disk): write-back is the default mode (1.7.0)

### DIFF
--- a/docs/cloud-disk/architecture.mdx
+++ b/docs/cloud-disk/architecture.mdx
@@ -53,24 +53,10 @@ stores only 50 GB.
 
 ## Durability
 
-By default Cloud Disk runs **write-through**: when the application calls
-`fsync`, the acknowledged data is already in the bucket. No local state matters,
-so the host can disappear the moment a flush returns and the disk stays
-complete, current, and mountable elsewhere. Its durability is the durability of
-Tigris, which survives machine failure and region failure alike.
-
-This is the default because most workloads never feel the cost. Writes land in
-the memory cache and are coalesced, so sequential and bursty workloads stream to
-the bucket at full bandwidth. The cost write-through can't hide is flush
-latency: an `fsync` pays for an object-store round trip.
-
-### Write-back mode for latency-sensitive workloads
-
-Workloads that `fsync` constantly, such as OLTP databases and message queues,
-can opt a disk into **write-back** mode. Flushes then commit to a local write
-log at NVMe latency, milliseconds rather than an object-store round trip, and a
-background uploader drains to the bucket continuously. It uploads in exactly the
-order the application's flush barriers created, which is what keeps the disk
+By default Cloud Disk runs **write-back**: when the application calls `fsync`,
+the acknowledged data commits to a local write log at NVMe latency, and a
+background uploader drains it to the bucket continuously. It uploads in exactly
+the order the application's flush barriers created, which is what keeps the disk
 safe:
 
 - A process crash or host reboot loses nothing. The local log replays on the
@@ -83,20 +69,32 @@ safe:
 
 The amount of recent writes at risk is bounded: Cloud Disk throttles new writes
 rather than let the not-yet-uploaded backlog grow without limit, and a planned
-unmount drains fully before detaching.
+unmount drains fully before detaching. This is the default because it gives
+local-disk flush latency while staying crash-consistent — what OLTP databases,
+message queues, and most `fsync`-heavy workloads want.
 
-:::warning Write-back trades durability for latency
+### Write-through mode for strict durability
+
+Workloads that need every acknowledged write already in the bucket can opt a
+disk into **write-through** mode. An `fsync` then returns only once the data is
+in Tigris: no local state matters, so the host can disappear the moment a flush
+returns and the disk stays complete, current, and mountable elsewhere. Its
+durability is the durability of Tigris, which survives machine failure and
+region failure alike. The cost write-through can't hide is flush latency: an
+`fsync` pays for an object-store round trip.
+
+:::warning Write-back can roll back a few seconds on sudden host loss
 
 Losing the entire host suddenly can roll the disk back by the seconds of writes
-not yet uploaded. The result is crash-consistent, not corrupt, but use
-write-back only where that rollback is acceptable. Keep the default
-write-through when every `fsync` must be on Tigris before it returns.
+not yet uploaded. The result is crash-consistent, not corrupt — but opt into
+write-through (`--set write-back=false`) when every `fsync` must be on Tigris
+before it returns.
 
 :::
 
-It's one setting per disk: write-through keeps the bucket current at every
-`fsync`; write-back gives you local-disk latency in exchange for a few seconds
-of possible rollback on sudden host loss.
+It's one setting per disk: write-back gives you local-disk latency in exchange
+for a few seconds of possible rollback on sudden host loss; write-through keeps
+the bucket current at every `fsync`.
 
 ## Snapshots and forks
 

--- a/docs/cloud-disk/tuning.mdx
+++ b/docs/cloud-disk/tuning.mdx
@@ -53,22 +53,22 @@ A cache on local disk (SSD) between RAM and Tigris: reads that miss the RAM
 cache are served from local disk instead of Tigris, and write-back uses it to
 buffer writes.
 
-| Setting           | Default   | Description                                                                                                                                                                          |
-| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `disk-cache-path` | —         | Local directory for the cache, e.g. `/var/lib/cloud-disk`. Each disk uses its own subdirectory, so one path is safe to share (and to inherit on forks). Required for write-back.     |
-| `disk-cache-size` | unlimited | How much local disk the cache may use, e.g. `4G`, `100G`. Size it to your working set for the biggest read speedup. `0` turns the read cache off while keeping write-back buffering. |
+| Setting           | Default               | Description                                                                                                                                                                                             |
+| ----------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disk-cache-path` | `/var/lib/cloud-disk` | Local directory for the cache and write-back buffer. Each disk uses its own subdirectory, so one path is safe to share (and to inherit on forks).                                                       |
+| `disk-cache-size` | `0`                   | How much local disk the read cache may use, e.g. `4G`, `100G`. `0` (the default) turns the read cache off while keeping write-back buffering; size it to your working set for the biggest read speedup. |
 
 ## Write-back
 
 Write-back buffers writes locally and uploads in the background — much faster.
 Everything is flushed to Tigris on unmount.
 
-| Setting                | Default | Effect                                                                                |
-| ---------------------- | ------- | ------------------------------------------------------------------------------------- |
-| `write-back`           | off     | `true` enables write-back caching. Needs `disk-cache-path`.                           |
-| `max-staging-bytes`    | `1G`    | Write buffer budget. Raise (`16G`) for bursty write-heavy workloads.                  |
-| `max-dirty-ratio`      | `0.5`   | How full the cache gets before background uploading starts. Lower = upload sooner.    |
-| `sync-writeback-ratio` | `0.8`   | How full the cache gets before writes pause for the upload to catch up. `0` disables. |
+| Setting                | Default | Effect                                                                                         |
+| ---------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `write-back`           | `true`  | On by default. Set `false` for write-through (every `fsync` lands in Tigris before returning). |
+| `max-staging-bytes`    | `1G`    | Write buffer budget. Raise (`16G`) for bursty write-heavy workloads.                           |
+| `max-dirty-ratio`      | `0.5`   | How full the cache gets before background uploading starts. Lower = upload sooner.             |
+| `sync-writeback-ratio` | `0.8`   | How full the cache gets before writes pause for the upload to catch up. `0` disables.          |
 
 ## Unmount durability
 
@@ -110,8 +110,6 @@ What a clean unmount does with buffered data before finishing, via
 
 ```bash
 sudo -E cloud-disk create pg-data -size 200G \
-    --set write-back=true \
-    --set disk-cache-path=/var/lib/cloud-disk \
     --set disk-cache-size=100G \
     --set max-cache-size=16G \
     --set flush-workers=16 \


### PR DESCRIPTION
1.7.0 made write-back the default mode (write-through is now opt-in) and changed
the disk-cache defaults. The docs still described the old world. This inverts them.

**architecture.mdx — Durability**
- Write-back is now the default (NVMe-latency flushes, crash-consistent, bounded backlog).
- Write-through is the opt-in for strict every-`fsync`-durable workloads (`--set write-back=false`).

**tuning.mdx — corrected defaults**
- `write-back`: off → **on**
- `disk-cache-path`: — / "required" → **`/var/lib/cloud-disk`** (auto, per-bucket scoped)
- `disk-cache-size`: unlimited → **`0`** (read cache off, write-back buffering kept)
- Dropped the now-redundant `write-back=true` / `disk-cache-path` lines from the database tuning example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-path impact.
> 
> **Overview**
> Updates Cloud Disk docs to match **1.7.0**, where **write-back** is the default durability mode and **write-through** is opt-in via `--set write-back=false`.
> 
> In **architecture.mdx**, the Durability section is reordered: write-back (NVMe-latency `fsync`, crash consistency, bounded backlog) is described first as the default; write-through is a separate subsection for strict bucket durability. The warning callout now targets write-back rollback risk and points readers to write-through when every `fsync` must land in Tigris.
> 
> In **tuning.mdx**, default tables reflect the new product defaults: `write-back` **on**, `disk-cache-path` **`/var/lib/cloud-disk`**, `disk-cache-size` **`0`** (read cache off, write-back buffering unchanged). The database tuning example drops redundant `write-back=true` and `disk-cache-path` flags that are no longer needed at create time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cc3a12c33bb97b98928fd2afff1264a810784e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->