### PR TITLE
docs: add static website hosting section to public buckets

### DIFF
--- a/docs/buckets/public-bucket.md
+++ b/docs/buckets/public-bucket.md
@@ -190,3 +190,35 @@ To set up a custom domain, create a CNAME record pointing your domain to
 `foo-public-bucket.t3.tigrisbucket.io` and then configure the domain in your
 bucket settings. See the [Custom Domains](./custom-domain.md) guide for full
 instructions.
+
+## Hosting a static website
+
+A public bucket can serve a static website directly, with no separate web server
+or CDN. Files are served over the
+[public bucket domains](#public-bucket-domains) or a
+[custom domain](#custom-domain), cached at the edge, with no egress charge.
+
+1. Make the bucket public, as shown above.
+2. Upload your files, setting `Content-Type` on each object so browsers render
+   them correctly. For example, use `text/html` for `.html` files.
+3. Link to each file by its full key, such as
+   `https://foo-public-bucket.t3.tigrisfiles.io/index.html`.
+
+:::warning[No default index document]
+
+Tigris serves objects by their exact key. A request to the bucket root (`/`)
+returns a directory listing (when [directory listing](#directory-listing) is
+enabled) or `403 AccessDenied`. It never serves `index.html`, and the same
+applies to subpaths: `/app/` returns `404 NoSuchKey` even when `app/index.html`
+exists. Link to each page by its full key, such as `/index.html` or
+`/app/index.html`.
+
+This shapes how single-page apps work. Load the app from an explicit key like
+`/index.html`, not the bare domain, which does not serve it. From there,
+hash-based routing (`/index.html#/dashboard`) works, because every route is
+served by the same `index.html` object. Path-based routing (`/dashboard`) does
+not: a direct request or refresh returns `404 NoSuchKey` before the app loads,
+which cannot be fixed in app code. It needs a CDN or edge layer in front of the
+bucket to rewrite unknown paths to `index.html`.
+
+:::


### PR DESCRIPTION
Adds a "Hosting a static website" section to the public bucket page.

You can host a static site on a public bucket today, but the docs don't explain how, so you end up piecing it together from the public bucket and custom domain pages. The thing most likely to catch people out, especially anyone coming from S3 website endpoints or GitHub Pages, is that there is no default index document, and that isn't written down anywhere.

The new section lists the steps and adds a warning covering it:

- a request to `/` returns a directory listing (when enabled) or `403`, not `index.html`
- a missing key returns `404 NoSuchKey` with no fallback to `index.html`, so single-page apps that rely on client-side routing need their own handling

I checked the behaviour against a live public bucket on the `t3.tigrisfiles.io` domain. Formatted with the repo's Prettier config (`prettier --check` passes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security impact.
> 
> **Overview**
> Documents how to host a static site on a **public bucket** (public ACL, correct `Content-Type`, URLs by full object key) and clarifies that serving is via public bucket domains or a custom domain with edge caching and no egress charge.
> 
> Adds a **warning** that Tigris has **no default index document**: `/` is a listing or `403`, not `index.html`; subpaths like `/app/` do not map to `app/index.html`. The doc spells out SPA implications—use explicit keys (e.g. `/index.html`), hash routing works on one object, path-based client routes need a CDN/edge rewrite for direct loads/refreshes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4537a24079378acf3e54b57f27b49b69da163a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->