### PR TITLE
feat: update sdk and cli docs

### DIFF
--- a/docs/cli/buckets/create.mdx
+++ b/docs/cli/buckets/create.mdx
@@ -13,15 +13,17 @@ t3 b c [name] [flags]
 
 ## Flags
 
-| Name                       | Required | Default    | Description                                                                                                                                                                                                                                      |
-| -------------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--access`, `-a`           | No       | `private`  | Access level. Options: `public`, `private`                                                                                                                                                                                                       |
-| `--public`                 | No       | —          | Shorthand for `--access public`                                                                                                                                                                                                                  |
-| `--enable-snapshots`, `-s` | No       | `false`    | Enable snapshots for the bucket                                                                                                                                                                                                                  |
-| `--default-tier`, `-t`     | No       | `STANDARD` | Default storage tier. Options: `STANDARD` (Standard), `STANDARD_IA` (Infrequent Access), `GLACIER` (Archive), `GLACIER_IR` (Instant Retrieval Archive)                                                                                           |
-| `--locations`, `-l`        | No       | `global`   | Bucket location. Options: `global`, `usa`, `eur`, `ams`, `fra`, `gru`, `iad`, `jnb`, `lhr`, `nrt`, `ord`, `sin`, `sjc`, `syd`. Supports comma-separated values for dual region (e.g. `ams,fra`). See [locations docs](/docs/buckets/locations/). |
-| `--consistency`, `-c`      | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
-| `--region`, `-r`           | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
+| Name                         | Required | Default    | Description                                                                                                                                                                                                                                      |
+| ---------------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--access`, `-a`             | No       | `private`  | Access level. Options: `public`, `private`                                                                                                                                                                                                       |
+| `--public`                   | No       | —          | Shorthand for `--access public`                                                                                                                                                                                                                  |
+| `--enable-snapshots`, `-s`   | No       | `false`    | Enable snapshots for the bucket                                                                                                                                                                                                                  |
+| `--allow-object-acl`         | No       | `false`    | Allow per-object ACLs on the bucket                                                                                                                                                                                                              |
+| `--enable-directory-listing` | No       | `false`    | Enable directory listing, relevant for public buckets                                                                                                                                                                                            |
+| `--default-tier`, `-t`       | No       | `STANDARD` | Default storage tier. Options: `STANDARD` (Standard), `STANDARD_IA` (Infrequent Access), `GLACIER` (Archive), `GLACIER_IR` (Instant Retrieval Archive)                                                                                           |
+| `--locations`, `-l`          | No       | `global`   | Bucket location. Options: `global`, `usa`, `eur`, `ams`, `fra`, `gru`, `iad`, `jnb`, `lhr`, `nrt`, `ord`, `sin`, `sjc`, `syd`. Supports comma-separated values for dual region (e.g. `ams,fra`). See [locations docs](/docs/buckets/locations/). |
+| `--consistency`, `-c`        | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
+| `--region`, `-r`             | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
 
 ## Examples
 
@@ -34,4 +36,10 @@ tigris buckets create my-bucket --access public --locations iad
 
 # Create with snapshots and infrequent access tier
 tigris buckets create my-bucket --enable-snapshots --default-tier STANDARD_IA
+
+# Create a bucket that allows per-object ACLs
+tigris buckets create my-bucket --allow-object-acl
+
+# Create a public bucket with directory listing enabled
+tigris buckets create my-bucket --public --enable-directory-listing
 ```

--- a/docs/cli/cp.mdx
+++ b/docs/cli/cp.mdx
@@ -17,15 +17,19 @@ treated as local files. At least one side must be remote.
 
 ## Flags
 
-| Name                | Required | Default | Description                  |
-| ------------------- | -------- | ------- | ---------------------------- |
-| `--recursive`, `-r` | No       | —       | Copy directories recursively |
+| Name                | Required | Default | Description                                                                                              |
+| ------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| `--recursive`, `-r` | No       | —       | Copy directories recursively                                                                             |
+| `--access`, `-a`    | No       | —       | Access level for uploaded objects. Only applies to local-to-remote uploads. Options: `public`, `private` |
 
 ## Examples
 
 ```bash
 # Upload a local file to remote
 tigris cp ./file.txt t3://my-bucket/file.txt
+
+# Upload a local file and make it public
+tigris cp ./logo.png t3://my-bucket/logo.png --access public
 
 # Download a remote object to local
 tigris cp t3://my-bucket/file.txt ./local-copy.txt

--- a/docs/cli/iam.mdx
+++ b/docs/cli/iam.mdx
@@ -14,6 +14,7 @@ t3 iam <resource> <operation> [flags]
 - [`tigris iam policies`](/docs/cli/iam/policies) - Manage IAM policies
 - [`tigris iam users`](/docs/cli/iam/users) - Manage organization users and
   invitations
+- [`tigris iam teams`](/docs/cli/iam/teams) - Manage organization teams
 
 ## Examples
 
@@ -22,4 +23,6 @@ tigris iam policies list
 tigris iam policies create my-policy --document policy.json
 tigris iam users list
 tigris iam users invite user@example.com --role member
+tigris iam teams list
+tigris iam teams create engineering --members user@example.com
 ```

--- a/docs/cli/iam/teams.mdx
+++ b/docs/cli/iam/teams.mdx
@@ -1,0 +1,23 @@
+# tigris iam teams
+
+Manage organization teams.
+
+**Alias:** `t`
+
+## Usage
+
+```bash
+tigris iam teams <operation> [flags]
+t3 iam t <operation> [flags]
+```
+
+Team management requires OAuth login (`tigris login oauth`).
+
+## Examples
+
+```bash
+tigris iam teams list
+tigris iam teams create engineering --description "Engineering team"
+tigris iam teams create engineering --members user@example.com
+tigris iam teams edit team_id --name platform
+```

--- a/docs/cli/iam/teams/create.mdx
+++ b/docs/cli/iam/teams/create.mdx
@@ -1,0 +1,38 @@
+# tigris iam teams create
+
+Create a new team in the organization.
+
+**Alias:** `c`
+
+## Usage
+
+```bash
+tigris iam teams create <name> [flags]
+t3 iam t c <name> [flags]
+```
+
+## Arguments
+
+| Name   | Required | Description      |
+| ------ | -------- | ---------------- |
+| `name` | Yes      | Name of the team |
+
+## Flags
+
+| Name                  | Required | Default | Description                                                    |
+| --------------------- | -------- | ------- | -------------------------------------------------------------- |
+| `--description`, `-d` | No       | —       | Description for the team                                       |
+| `--members`, `-m`     | No       | —       | Member email address(es) to add (comma-separated for multiple) |
+
+## Examples
+
+```bash
+# Create a team
+tigris iam teams create engineering
+
+# Create a team with a description
+tigris iam teams create engineering --description "Engineering team"
+
+# Create a team with members
+tigris iam teams create engineering --members a@example.com,b@example.com
+```

--- a/docs/cli/iam/teams/edit.mdx
+++ b/docs/cli/iam/teams/edit.mdx
@@ -1,0 +1,42 @@
+# tigris iam teams edit
+
+Update a team's name, description, or members. Members are replaced with the
+provided list.
+
+**Alias:** `e`
+
+## Usage
+
+```bash
+tigris iam teams edit <id> [flags]
+t3 iam t e <id> [flags]
+```
+
+Provide at least one of `--name`, `--description`, or `--members` to update.
+
+## Arguments
+
+| Name | Required | Description            |
+| ---- | -------- | ---------------------- |
+| `id` | Yes      | ID of the team to edit |
+
+## Flags
+
+| Name                  | Required | Default | Description                                                                            |
+| --------------------- | -------- | ------- | -------------------------------------------------------------------------------------- |
+| `--name`, `-n`        | No       | —       | New name for the team                                                                  |
+| `--description`, `-d` | No       | —       | New description for the team                                                           |
+| `--members`, `-m`     | No       | —       | Replace the team's members with these email address(es) (comma-separated for multiple) |
+
+## Examples
+
+```bash
+# Rename a team
+tigris iam teams edit team_id --name platform
+
+# Update the description
+tigris iam teams edit team_id --description "Platform team"
+
+# Replace the member list
+tigris iam teams edit team_id --members a@example.com,b@example.com
+```

--- a/docs/cli/iam/teams/list.mdx
+++ b/docs/cli/iam/teams/list.mdx
@@ -1,0 +1,25 @@
+# tigris iam teams list
+
+List all teams in the organization.
+
+**Alias:** `l`
+
+## Usage
+
+```bash
+tigris iam teams list [flags]
+t3 iam t l [flags]
+```
+
+## Flags
+
+| Name             | Required | Default | Description                                    |
+| ---------------- | -------- | ------- | ---------------------------------------------- |
+| `--format`, `-f` | No       | `table` | Output format. Options: `json`, `table`, `xml` |
+
+## Examples
+
+```bash
+tigris iam teams list
+tigris iam teams list --format json
+```

--- a/docs/cli/mk.mdx
+++ b/docs/cli/mk.mdx
@@ -20,15 +20,17 @@ folder inside the bucket.
 
 Flags only apply when creating a bucket (not folders).
 
-| Name                       | Required | Default    | Description                                                                                                                                                                                                                                      |
-| -------------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--access`, `-a`           | No       | `private`  | Access level. Options: `public`, `private`                                                                                                                                                                                                       |
-| `--public`                 | No       | —          | Shorthand for `--access public`                                                                                                                                                                                                                  |
-| `--enable-snapshots`, `-s` | No       | `false`    | Enable snapshots for the bucket                                                                                                                                                                                                                  |
-| `--default-tier`, `-t`     | No       | `STANDARD` | Default storage tier. Options: `STANDARD`, `STANDARD_IA`, `GLACIER`, `GLACIER_IR`                                                                                                                                                                |
-| `--locations`, `-l`        | No       | `global`   | Bucket location. Options: `global`, `usa`, `eur`, `ams`, `fra`, `gru`, `iad`, `jnb`, `lhr`, `nrt`, `ord`, `sin`, `sjc`, `syd`. Supports comma-separated values for dual region (e.g. `ams,fra`). See [locations docs](/docs/buckets/locations/). |
-| `--consistency`, `-c`      | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
-| `--region`, `-r`           | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
+| Name                         | Required | Default    | Description                                                                                                                                                                                                                                      |
+| ---------------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--access`, `-a`             | No       | `private`  | Access level. Options: `public`, `private`                                                                                                                                                                                                       |
+| `--public`                   | No       | —          | Shorthand for `--access public`                                                                                                                                                                                                                  |
+| `--enable-snapshots`, `-s`   | No       | `false`    | Enable snapshots for the bucket                                                                                                                                                                                                                  |
+| `--allow-object-acl`         | No       | `false`    | Allow per-object ACLs on the bucket                                                                                                                                                                                                              |
+| `--enable-directory-listing` | No       | `false`    | Enable directory listing, relevant for public buckets                                                                                                                                                                                            |
+| `--default-tier`, `-t`       | No       | `STANDARD` | Default storage tier. Options: `STANDARD`, `STANDARD_IA`, `GLACIER`, `GLACIER_IR`                                                                                                                                                                |
+| `--locations`, `-l`          | No       | `global`   | Bucket location. Options: `global`, `usa`, `eur`, `ams`, `fra`, `gru`, `iad`, `jnb`, `lhr`, `nrt`, `ord`, `sin`, `sjc`, `syd`. Supports comma-separated values for dual region (e.g. `ams,fra`). See [locations docs](/docs/buckets/locations/). |
+| `--consistency`, `-c`        | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
+| `--region`, `-r`             | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
 
 ## Examples
 
@@ -38,6 +40,12 @@ tigris mk my-bucket
 
 # Create a public bucket in a specific region
 tigris mk my-bucket --access public --locations iad
+
+# Create a bucket that allows per-object ACLs
+tigris mk my-bucket --allow-object-acl
+
+# Create a public bucket with directory listing enabled
+tigris mk my-bucket --public --enable-directory-listing
 
 # Create a folder in a bucket
 tigris mk my-bucket/images/

--- a/docs/cli/objects.mdx
+++ b/docs/cli/objects.mdx
@@ -23,6 +23,8 @@ t3 o <operation> [flags]
 | [`delete`](delete)               | Delete one or more objects by key                                    |
 | [`set-access`](set-access)       | Set the access level (public or private) on an existing object       |
 | [`info`](info)                   | Show metadata for an object (content type, size, modified date)      |
+| [`restore`](restore)             | Restore an archived object (e.g. GLACIER tier) for a number of days  |
+| [`restore-info`](restore-info)   | Show the restore state of an archived object                         |
 
 `tigris objects set` is deprecated. Use [`set-access`](set-access) to change
 ACLs and [`tigris mv`](/docs/cli/mv) to rename objects.
@@ -37,4 +39,6 @@ tigris objects put my-bucket report.pdf ./report.pdf
 tigris objects delete my-bucket report.pdf
 tigris objects set-access my-bucket report.pdf public
 tigris objects info my-bucket report.pdf
+tigris objects restore my-bucket archived.bin --days 3
+tigris objects restore-info my-bucket archived.bin
 ```

--- a/docs/cli/objects/restore-info.mdx
+++ b/docs/cli/objects/restore-info.mdx
@@ -1,0 +1,43 @@
+# tigris objects restore-info
+
+Show the restore state of an archived object (`archived`, `in-progress`, or
+`restored`).
+
+**Alias:** `ri`
+
+## Usage
+
+```bash
+tigris objects restore-info <bucket> [key] [flags]
+t3 o ri <bucket> [key] [flags]
+```
+
+If the bucket argument contains the full path (e.g.
+`t3://my-bucket/archived.bin`), the `key` argument can be omitted. Objects that
+are not archived report no restore information.
+
+## Arguments
+
+| Name     | Required | Description                                          |
+| -------- | -------- | ---------------------------------------------------- |
+| `bucket` | Yes      | Bucket name, or a full path (`t3://bucket/key`)      |
+| `key`    | No       | Object key. Omit if `bucket` contains the full path. |
+
+## Flags
+
+| Name           | Required | Default | Description                                                                                      |
+| -------------- | -------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `--version-id` | No       | —       | Inspect a specific object version (requires bucket versioning). Omit to read the current version |
+| `--format`     | No       | `table` | Output format. Options: `json`, `table`, `xml`                                                   |
+
+## Examples
+
+```bash
+# Show restore state
+tigris objects restore-info my-bucket archived.bin
+
+# Show restore state as JSON using a t3:// path
+tigris objects restore-info t3://my-bucket/archived.bin --format json
+```
+
+Use [`tigris objects restore`](restore) to request a restore.

--- a/docs/cli/objects/restore-info.mdx
+++ b/docs/cli/objects/restore-info.mdx
@@ -40,4 +40,4 @@ tigris objects restore-info my-bucket archived.bin
 tigris objects restore-info t3://my-bucket/archived.bin --format json
 ```
 
-Use [`tigris objects restore`](restore) to request a restore.
+Use [`tigris objects restore`](/docs/cli/objects/restore) to request a restore.

--- a/docs/cli/objects/restore.mdx
+++ b/docs/cli/objects/restore.mdx
@@ -43,5 +43,5 @@ tigris objects restore my-bucket archived.bin --days 3
 tigris objects restore t3://my-bucket/archived.bin --days 7
 ```
 
-Use [`tigris objects restore-info`](restore-info) to check the restore state of
-an object.
+Use [`tigris objects restore-info`](/docs/cli/objects/restore-info) to check the
+restore state of an object.

--- a/docs/cli/objects/restore.mdx
+++ b/docs/cli/objects/restore.mdx
@@ -1,0 +1,47 @@
+# tigris objects restore
+
+Restore an archived object (e.g. one in the `GLACIER` tier) into an
+actively-readable copy for a number of days.
+
+**Alias:** `rs`
+
+## Usage
+
+```bash
+tigris objects restore <bucket> [key] [flags]
+t3 o rs <bucket> [key] [flags]
+```
+
+If the bucket argument contains the full path (e.g.
+`t3://my-bucket/archived.bin`), the `key` argument can be omitted.
+
+## Arguments
+
+| Name     | Required | Description                                          |
+| -------- | -------- | ---------------------------------------------------- |
+| `bucket` | Yes      | Bucket name, or a full path (`t3://bucket/key`)      |
+| `key`    | No       | Object key. Omit if `bucket` contains the full path. |
+
+## Flags
+
+| Name           | Required | Default | Description                                                                                         |
+| -------------- | -------- | ------- | --------------------------------------------------------------------------------------------------- |
+| `--days`, `-d` | No       | `1`     | How many days the restored copy stays available before reverting to its archived tier               |
+| `--version-id` | No       | —       | Restore a specific object version (requires bucket versioning). Omit to restore the current version |
+| `--format`     | No       | `table` | Output format. Options: `json`, `table`, `xml`                                                      |
+
+## Examples
+
+```bash
+# Restore for the default 1 day
+tigris objects restore my-bucket archived.bin
+
+# Restore for 3 days
+tigris objects restore my-bucket archived.bin --days 3
+
+# Restore using a t3:// path
+tigris objects restore t3://my-bucket/archived.bin --days 7
+```
+
+Use [`tigris objects restore-info`](restore-info) to check the restore state of
+an object.

--- a/docs/sdks/tigris/api.mdx
+++ b/docs/sdks/tigris/api.mdx
@@ -9,7 +9,7 @@ sidebar_label: API Reference
 
 API reference for
 [`@tigrisdata/storage`](https://www.npmjs.com/package/@tigrisdata/storage)
-v3.0.0.
+v3.16.0.
 
 For usage examples and guides, see [Using the SDK](/docs/sdks/tigris/using-sdk).
 
@@ -149,6 +149,38 @@ function put(
 function get(
   path: string,
   format: "string",
+  options: GetOptions & {
+    includeMetadata: true;
+  },
+): Promise<TigrisStorageResponse<GetResponseWithMetadata<string>, Error>>;
+```
+
+```ts
+function get(
+  path: string,
+  format: "file",
+  options: GetOptions & {
+    includeMetadata: true;
+  },
+): Promise<TigrisStorageResponse<GetResponseWithMetadata<File>, Error>>;
+```
+
+```ts
+function get(
+  path: string,
+  format: "stream",
+  options: GetOptions & {
+    includeMetadata: true;
+  },
+): Promise<
+  TigrisStorageResponse<GetResponseWithMetadata<ReadableStream>, Error>
+>;
+```
+
+```ts
+function get(
+  path: string,
+  format: "string",
   options?: GetOptions,
 ): Promise<TigrisStorageResponse<string, Error>>;
 ```
@@ -175,7 +207,7 @@ function get(
 function head(
   path: string,
   options?: HeadOptions,
-): Promise<TigrisStorageResponse<HeadResponse | void, Error>>;
+): Promise<TigrisStorageResponse<HeadResponse | undefined, Error>>;
 ```
 
 ### `list`
@@ -197,6 +229,10 @@ function remove(
 
 ### `updateObject`
 
+> **Deprecated** Use `setObjectAccess` to change object ACLs, or the dedicated
+> rename helper to change an object's key. `updateObject` will be removed in a
+> future major version.
+
 ```ts
 function updateObject(
   path: string,
@@ -215,6 +251,7 @@ type PutOptions = {
   allowOverwrite?: boolean;
   contentType?: string;
   contentDisposition?: "attachment" | "inline";
+  metadata?: Record<string, string>;
   multipart?: boolean;
   partSize?: number;
   queueSize?: number;
@@ -224,19 +261,20 @@ type PutOptions = {
 };
 ```
 
-| Property             | Type                       | Required | Description |
-| -------------------- | -------------------------- | -------- | ----------- |
-| `access`             | `'public' \| 'private'`    | No       |             |
-| `addRandomSuffix`    | `boolean`                  | No       |             |
-| `allowOverwrite`     | `boolean`                  | No       |             |
-| `contentType`        | `string`                   | No       |             |
-| `contentDisposition` | `'attachment' \| 'inline'` | No       |             |
-| `multipart`          | `boolean`                  | No       |             |
-| `partSize`           | `number`                   | No       |             |
-| `queueSize`          | `number`                   | No       |             |
-| `abortController`    | `AbortController`          | No       |             |
-| `onUploadProgress`   | `PutOnUploadProgress`      | No       |             |
-| `config`             | `TigrisStorageConfig`      | No       |             |
+| Property             | Type                           | Required | Description |
+| -------------------- | ------------------------------ | -------- | ----------- |
+| `access`             | `'public' \| 'private'`        | No       |             |
+| `addRandomSuffix`    | `boolean`                      | No       |             |
+| `allowOverwrite`     | `boolean`                      | No       |             |
+| `contentType`        | `string`                       | No       |             |
+| `contentDisposition` | `'attachment' \| 'inline'`     | No       |             |
+| `metadata`           | `Record&lt;string, string&gt;` | No       |             |
+| `multipart`          | `boolean`                      | No       |             |
+| `partSize`           | `number`                       | No       |             |
+| `queueSize`          | `number`                       | No       |             |
+| `abortController`    | `AbortController`              | No       |             |
+| `onUploadProgress`   | `PutOnUploadProgress`          | No       |             |
+| `config`             | `TigrisStorageConfig`          | No       |             |
 
 ### `PutResponse`
 
@@ -244,6 +282,8 @@ type PutOptions = {
 type PutResponse = {
   contentDisposition: string | undefined;
   contentType: string | undefined;
+  etag: string;
+  metadata: Record<string, string> | undefined;
   modified: Date;
   path: string;
   size: number;
@@ -251,14 +291,16 @@ type PutResponse = {
 };
 ```
 
-| Property             | Type                  | Required | Description |
-| -------------------- | --------------------- | -------- | ----------- |
-| `contentDisposition` | `string \| undefined` | Yes      |             |
-| `contentType`        | `string \| undefined` | Yes      |             |
-| `modified`           | `Date`                | Yes      |             |
-| `path`               | `string`              | Yes      |             |
-| `size`               | `number`              | Yes      |             |
-| `url`                | `string`              | Yes      |             |
+| Property             | Type                                        | Required | Description |
+| -------------------- | ------------------------------------------- | -------- | ----------- |
+| `contentDisposition` | `string \| undefined`                       | Yes      |             |
+| `contentType`        | `string \| undefined`                       | Yes      |             |
+| `etag`               | `string`                                    | Yes      |             |
+| `metadata`           | `Record&lt;string, string&gt; \| undefined` | Yes      |             |
+| `modified`           | `Date`                                      | Yes      |             |
+| `path`               | `string`                                    | Yes      |             |
+| `size`               | `number`                                    | Yes      |             |
+| `url`                | `string`                                    | Yes      |             |
 
 ### `PutOnUploadProgress`
 
@@ -282,17 +324,45 @@ type GetOptions = {
   contentDisposition?: "attachment" | "inline";
   contentType?: string;
   encoding?: string;
+  /**
+   * When true, `get` returns `{ body, metadata }` instead of the bare
+   * body, surfacing the object's etag, content metadata, user metadata,
+   * and (when `range` is used) `Content-Range` — all read from the same
+   * S3 response, no extra round-trip.
+   */
+  includeMetadata?: boolean;
+  /**
+   * Byte range to read. Both bounds are inclusive and 0-based, matching
+   * the HTTP `Range: bytes=…` semantics. Omit `end` to read from `start`
+   * to the end of the object. A range that falls entirely outside the
+   * object returns an error (HTTP 416). The returned body is the partial
+   * content only.
+   */
+  range?: {
+    start: number;
+    end?: number;
+  };
   snapshotVersion?: string;
+  versionId?: string;
 };
 ```
 
-| Property             | Type                       | Required | Description |
-| -------------------- | -------------------------- | -------- | ----------- |
-| `config`             | `TigrisStorageConfig`      | No       |             |
-| `contentDisposition` | `'attachment' \| 'inline'` | No       |             |
-| `contentType`        | `string`                   | No       |             |
-| `encoding`           | `string`                   | No       |             |
-| `snapshotVersion`    | `string`                   | No       |             |
+| Property             | Type                       | Required | Description                                                       |
+| -------------------- | -------------------------- | -------- | ----------------------------------------------------------------- |
+| `config`             | `TigrisStorageConfig`      | No       |                                                                   |
+| `contentDisposition` | `'attachment' \| 'inline'` | No       |                                                                   |
+| `contentType`        | `string`                   | No       |                                                                   |
+| `encoding`           | `string`                   | No       |                                                                   |
+| `includeMetadata`    | `boolean`                  | No       | When true, `get` returns `{ body, metadata }` instead of the bare |
+
+body, surfacing the object's etag, content metadata, user metadata, and (when
+`range` is used) `Content-Range` — all read from the same S3 response, no extra
+round-trip. | | `range` | `\{ start: number; end?: number; \}` | No | Byte range
+to read. Both bounds are inclusive and 0-based, matching the HTTP
+`Range: bytes=…` semantics. Omit `end` to read from `start` to the end of the
+object. A range that falls entirely outside the object returns an error (HTTP
+416). The returned body is the partial content only. | | `snapshotVersion` |
+`string` | No | | | `versionId` | `string` | No | |
 
 ### `GetResponse`
 
@@ -305,6 +375,7 @@ type GetResponse = string | File | ReadableStream;
 ```ts
 type HeadOptions = {
   snapshotVersion?: string;
+  versionId?: string;
   config?: TigrisStorageConfig;
 };
 ```
@@ -312,6 +383,7 @@ type HeadOptions = {
 | Property          | Type                  | Required | Description |
 | ----------------- | --------------------- | -------- | ----------- |
 | `snapshotVersion` | `string`              | No       |             |
+| `versionId`       | `string`              | No       |             |
 | `config`          | `TigrisStorageConfig` | No       |             |
 
 ### `HeadResponse`
@@ -320,6 +392,8 @@ type HeadOptions = {
 type HeadResponse = {
   contentDisposition: string;
   contentType: string;
+  etag: string;
+  metadata: Record<string, string>;
   modified: Date;
   path: string;
   size: number;
@@ -327,14 +401,16 @@ type HeadResponse = {
 };
 ```
 
-| Property             | Type     | Required | Description |
-| -------------------- | -------- | -------- | ----------- |
-| `contentDisposition` | `string` | Yes      |             |
-| `contentType`        | `string` | Yes      |             |
-| `modified`           | `Date`   | Yes      |             |
-| `path`               | `string` | Yes      |             |
-| `size`               | `number` | Yes      |             |
-| `url`                | `string` | Yes      |             |
+| Property             | Type                           | Required | Description |
+| -------------------- | ------------------------------ | -------- | ----------- |
+| `contentDisposition` | `string`                       | Yes      |             |
+| `contentType`        | `string`                       | Yes      |             |
+| `etag`               | `string`                       | Yes      |             |
+| `metadata`           | `Record&lt;string, string&gt;` | Yes      |             |
+| `modified`           | `Date`                         | Yes      |             |
+| `path`               | `string`                       | Yes      |             |
+| `size`               | `number`                       | Yes      |             |
+| `url`                | `string`                       | Yes      |             |
 
 ### `ListOptions`
 
@@ -345,18 +421,20 @@ type ListOptions = {
   limit?: number;
   paginationToken?: string;
   snapshotVersion?: string;
+  source?: "tigris" | "shadow";
   config?: TigrisStorageConfig;
 };
 ```
 
-| Property          | Type                  | Required | Description |
-| ----------------- | --------------------- | -------- | ----------- |
-| `delimiter`       | `string`              | No       |             |
-| `prefix`          | `string`              | No       |             |
-| `limit`           | `number`              | No       |             |
-| `paginationToken` | `string`              | No       |             |
-| `snapshotVersion` | `string`              | No       |             |
-| `config`          | `TigrisStorageConfig` | No       |             |
+| Property          | Type                   | Required | Description |
+| ----------------- | ---------------------- | -------- | ----------- |
+| `delimiter`       | `string`               | No       |             |
+| `prefix`          | `string`               | No       |             |
+| `limit`           | `number`               | No       |             |
+| `paginationToken` | `string`               | No       |             |
+| `snapshotVersion` | `string`               | No       |             |
+| `source`          | `'tigris' \| 'shadow'` | No       |             |
+| `config`          | `TigrisStorageConfig`  | No       |             |
 
 ### `ListItem`
 
@@ -366,6 +444,7 @@ type ListItem = {
   name: string;
   size: number;
   lastModified: Date;
+  etag: string;
 };
 ```
 
@@ -375,12 +454,14 @@ type ListItem = {
 | `name`         | `string` | Yes      |             |
 | `size`         | `number` | Yes      |             |
 | `lastModified` | `Date`   | Yes      |             |
+| `etag`         | `string` | Yes      |             |
 
 ### `ListResponse`
 
 ```ts
 type ListResponse = {
   items: ListItem[];
+  commonPrefixes: string[];
   paginationToken: string | undefined;
   hasMore: boolean;
 };
@@ -389,6 +470,7 @@ type ListResponse = {
 | Property          | Type                  | Required | Description |
 | ----------------- | --------------------- | -------- | ----------- |
 | `items`           | `ListItem[]`          | Yes      |             |
+| `commonPrefixes`  | `string[]`            | Yes      |             |
 | `paginationToken` | `string \| undefined` | Yes      |             |
 | `hasMore`         | `boolean`             | Yes      |             |
 
@@ -397,12 +479,14 @@ type ListResponse = {
 ```ts
 type RemoveOptions = {
   config?: TigrisStorageConfig;
+  versionId?: string;
 };
 ```
 
-| Property | Type                  | Required | Description |
-| -------- | --------------------- | -------- | ----------- |
-| `config` | `TigrisStorageConfig` | No       |             |
+| Property    | Type                  | Required | Description |
+| ----------- | --------------------- | -------- | ----------- |
+| `config`    | `TigrisStorageConfig` | No       |             |
+| `versionId` | `string`              | No       |             |
 
 ### `UpdateObjectOptions`
 
@@ -461,17 +545,44 @@ type GetPresignedUrlOptions = {
    * Default is 3600 seconds (1 hour).
    */
   expiresIn?: number;
+  /**
+   * Snapshot version to read from. When set, the presigned URL is
+   * pinned to the object version that was current at the time of the
+   * snapshot.
+   *
+   * The gateway's presign endpoint accepts a literal object versionId
+   * (not a snapshot version), so this function resolves the snapshot
+   * to the correct versionId client-side: lists the key's versions
+   * (and delete markers) and selects the newest entry with
+   * `versionId <= snapshotVersion`.
+   *
+   * Only valid with `operation: 'get'`. Returns an error if the object
+   * did not exist at the snapshot time (either never written, or
+   * deleted before the snapshot).
+   */
+  snapshotVersion?: string;
   config?: TigrisStorageConfig;
 } & MethodOrOperation;
 ```
 
-| Property                                                         | Type                  | Required | Description                                          |
-| ---------------------------------------------------------------- | --------------------- | -------- | ---------------------------------------------------- |
-| `accessKeyId`                                                    | `string`              | No       | The access key ID to use for the presigned URL.      |
+| Property                                                         | Type     | Required | Description                                                   |
+| ---------------------------------------------------------------- | -------- | -------- | ------------------------------------------------------------- |
+| `accessKeyId`                                                    | `string` | No       | The access key ID to use for the presigned URL.               |
 | If not provided, the access key ID from the config will be used. |
-| `expiresIn`                                                      | `number`              | No       | The expiration time of the presigned URL in seconds. |
+| `expiresIn`                                                      | `number` | No       | The expiration time of the presigned URL in seconds.          |
 | Default is 3600 seconds (1 hour).                                |
-| `config`                                                         | `TigrisStorageConfig` | No       |                                                      |
+| `snapshotVersion`                                                | `string` | No       | Snapshot version to read from. When set, the presigned URL is |
+
+pinned to the object version that was current at the time of the snapshot.
+
+The gateway's presign endpoint accepts a literal object versionId (not a
+snapshot version), so this function resolves the snapshot to the correct
+versionId client-side: lists the key's versions (and delete markers) and selects
+the newest entry with `versionId <= snapshotVersion`.
+
+Only valid with `operation: 'get'`. Returns an error if the object did not exist
+at the snapshot time (either never written, or deleted before the snapshot). | |
+`config` | `TigrisStorageConfig` | No | |
 
 ### `GetPresignedUrlResponse`
 
@@ -574,19 +685,23 @@ type CreateBucketOptions = {
   access?: "public" | "private";
   defaultTier?: StorageClass;
   locations?: BucketLocations;
+  enableDirectoryListing?: boolean;
+  allowObjectAcl?: boolean;
   config?: Omit<TigrisStorageConfig, "bucket">;
 };
 ```
 
-| Property               | Type                                        | Required | Description |
-| ---------------------- | ------------------------------------------- | -------- | ----------- |
-| `enableSnapshot`       | `boolean`                                   | No       |             |
-| `sourceBucketName`     | `string`                                    | No       |             |
-| `sourceBucketSnapshot` | `string`                                    | No       |             |
-| `access`               | `'public' \| 'private'`                     | No       |             |
-| `defaultTier`          | `StorageClass`                              | No       |             |
-| `locations`            | `BucketLocations`                           | No       |             |
-| `config`               | `Omit&lt;TigrisStorageConfig, 'bucket'&gt;` | No       |             |
+| Property                 | Type                                        | Required | Description |
+| ------------------------ | ------------------------------------------- | -------- | ----------- |
+| `enableSnapshot`         | `boolean`                                   | No       |             |
+| `sourceBucketName`       | `string`                                    | No       |             |
+| `sourceBucketSnapshot`   | `string`                                    | No       |             |
+| `access`                 | `'public' \| 'private'`                     | No       |             |
+| `defaultTier`            | `StorageClass`                              | No       |             |
+| `locations`              | `BucketLocations`                           | No       |             |
+| `enableDirectoryListing` | `boolean`                                   | No       |             |
+| `allowObjectAcl`         | `boolean`                                   | No       |             |
+| `config`                 | `Omit&lt;TigrisStorageConfig, 'bucket'&gt;` | No       |             |
 
 ### `CreateBucketResponse`
 
@@ -622,6 +737,19 @@ type GetBucketInfoOptions = {
 
 ```ts
 type BucketInfoResponse = {
+  /**
+   * @deprecated Use `locations` instead — it carries the same data with
+   * a structured `BucketLocations` shape that distinguishes `global` /
+   * `multi` / `single` / `dual`. `regions` will be removed in the next
+   * major version.
+   *
+   * Note: for region codes the SDK does not recognize, `regions` passes
+   * the raw value through (e.g. `['mars']`) while `locations` falls back
+   * defensively to `{ type: 'global' }`. The two fields can therefore
+   * disagree when the gateway returns a region code newer than the SDK.
+   */
+  regions: string[];
+  locations: BucketLocations;
   isSnapshotEnabled: boolean;
   forkInfo:
     | {
@@ -639,11 +767,27 @@ type BucketInfoResponse = {
     defaultTier: StorageClass;
     lifecycleRules?: BucketLifecycleRule[];
     dataMigration?: Omit<BucketMigration, "enabled">;
+    /**
+     * @deprecated Use `lifecycleRules` instead. This field is no longer
+     * populated — read the rule with only `expiration` (no transition,
+     * no filter) from `lifecycleRules` if you need the bucket-wide TTL.
+     */
     ttlConfig?: BucketTtl;
     customDomain?: string;
+    softDelete:
+      | {
+          enabled: true;
+          retentionDays: number;
+        }
+      | {
+          enabled: false;
+        };
+    /**
+     * @deprecated Use `softDelete` instead.
+     */
     deleteProtection: boolean;
     corsRules: BucketCorsRule[];
-    additionalHeaders?: Record<string, string>;
+    additionalHeaders?: GetBucketInfoApiResponseBody["additional_http_headers"];
     notifications?: BucketNotification;
   };
   sizeInfo: {
@@ -654,12 +798,24 @@ type BucketInfoResponse = {
 };
 ```
 
-| Property            | Type                                                                                                                                                                                                                                                                                                                                                    | Required | Description |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| `isSnapshotEnabled` | `boolean`                                                                                                                                                                                                                                                                                                                                               | Yes      |             |
-| `forkInfo`          | `\{ hasChildren: boolean; parents: Array&lt;\{ bucketName: string; forkCreatedAt: Date; snapshot: string; snapshotCreatedAt: Date; \}&gt;; \} \| undefined`                                                                                                                                                                                             | Yes      |             |
-| `settings`          | `\{ allowObjectAcl: boolean; defaultTier: StorageClass; lifecycleRules?: BucketLifecycleRule[]; dataMigration?: Omit&lt;BucketMigration, 'enabled'&gt;; ttlConfig?: BucketTtl; customDomain?: string; deleteProtection: boolean; corsRules: BucketCorsRule[]; additionalHeaders?: Record&lt;string, string&gt;; notifications?: BucketNotification; \}` | Yes      |             |
-| `sizeInfo`          | `\{ numberOfObjects: number \| undefined; size: number \| undefined; numberOfObjectsAllVersions: number \| undefined; \}`                                                                                                                                                                                                                               | Yes      |             |
+| Property  | Type       | Required | Description                                                             |
+| --------- | ---------- | -------- | ----------------------------------------------------------------------- |
+| `regions` | `string[]` | Yes      | **Deprecated.** Use `locations` instead — it carries the same data with |
+
+a structured `BucketLocations` shape that distinguishes `global` / `multi` /
+`single` / `dual`. `regions` will be removed in the next major version.
+
+Note: for region codes the SDK does not recognize, `regions` passes the raw
+value through (e.g. `['mars']`) while `locations` falls back defensively to
+`{ type: 'global' }`. The two fields can therefore disagree when the gateway
+returns a region code newer than the SDK. | | `locations` | `BucketLocations` |
+Yes | | | `isSnapshotEnabled` | `boolean` | Yes | | | `forkInfo` |
+`\{ hasChildren: boolean; parents: Array&lt;\{ bucketName: string; forkCreatedAt: Date; snapshot: string; snapshotCreatedAt: Date; \}&gt;; \} \| undefined`
+| Yes | | | `settings` |
+`\{ allowObjectAcl: boolean; defaultTier: StorageClass; lifecycleRules?: BucketLifecycleRule[]; dataMigration?: Omit&lt;BucketMigration, 'enabled'&gt;; /** * @deprecated Use `lifecycleRules`instead. This field is no longer * populated — read the rule with only`expiration`(no transition, * no filter) from`lifecycleRules`if you need the bucket-wide TTL. */ ttlConfig?: BucketTtl; customDomain?: string; softDelete: \{ enabled: true; retentionDays: number; \} \| \{ enabled: false; \}; /** * @deprecated Use`softDelete` instead. */ deleteProtection: boolean; corsRules: BucketCorsRule[]; additionalHeaders?: GetBucketInfoApiResponseBody['additional_http_headers']; notifications?: BucketNotification; \}`
+| Yes | | | `sizeInfo` |
+`\{ numberOfObjects: number \| undefined; size: number \| undefined; numberOfObjectsAllVersions: number \| undefined; \}`
+| Yes | |
 
 ### `ListBucketsOptions`
 
@@ -668,6 +824,7 @@ type ListBucketsOptions = {
   config?: TigrisStorageConfig;
   paginationToken?: string;
   limit?: number;
+  deleted?: boolean;
 };
 ```
 
@@ -676,6 +833,7 @@ type ListBucketsOptions = {
 | `config`          | `TigrisStorageConfig` | No       |             |
 | `paginationToken` | `string`              | No       |             |
 | `limit`           | `number`              | No       |             |
+| `deleted`         | `boolean`             | No       |             |
 
 ### `ListBucketsResponse`
 
@@ -699,13 +857,34 @@ type ListBucketsResponse = {
 type Bucket = {
   name: string;
   creationDate: Date;
+  regions?: string[];
+  type?: BucketType;
+  visibility?: BucketVisibility;
+  softDeleteInfo?: {
+    enabled: boolean;
+    retentionDays: number;
+  };
+  forkInfo?: {
+    hasChildren: boolean;
+    parents: Array<{
+      bucketName: string;
+      forkCreatedAt: Date;
+      snapshot: string;
+      snapshotCreatedAt: Date;
+    }>;
+  };
 };
 ```
 
-| Property       | Type     | Required | Description |
-| -------------- | -------- | -------- | ----------- |
-| `name`         | `string` | Yes      |             |
-| `creationDate` | `Date`   | Yes      |             |
+| Property         | Type                                                                                                                                           | Required | Description |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| `name`           | `string`                                                                                                                                       | Yes      |             |
+| `creationDate`   | `Date`                                                                                                                                         | Yes      |             |
+| `regions`        | `string[]`                                                                                                                                     | No       |             |
+| `type`           | `BucketType`                                                                                                                                   | No       |             |
+| `visibility`     | `BucketVisibility`                                                                                                                             | No       |             |
+| `softDeleteInfo` | `\{ enabled: boolean; retentionDays: number; \}`                                                                                               | No       |             |
+| `forkInfo`       | `\{ hasChildren: boolean; parents: Array&lt;\{ bucketName: string; forkCreatedAt: Date; snapshot: string; snapshotCreatedAt: Date; \}&gt;; \}` | No       |             |
 
 ### `BucketOwner`
 
@@ -732,22 +911,34 @@ type UpdateBucketOptions = {
   cacheControl?: string;
   customDomain?: string;
   enableAdditionalHeaders?: boolean;
+  softDelete?:
+    | {
+        enabled: true;
+        retentionDays: number;
+      }
+    | {
+        enabled: false;
+      };
+  /**
+   * @deprecated Use `softDelete` instead.
+   */
   enableDeleteProtection?: boolean;
   config?: Omit<TigrisStorageConfig, "bucket">;
 };
 ```
 
-| Property                  | Type                                        | Required | Description |
-| ------------------------- | ------------------------------------------- | -------- | ----------- |
-| `access`                  | `'public' \| 'private'`                     | No       |             |
-| `allowObjectAcl`          | `boolean`                                   | No       |             |
-| `disableDirectoryListing` | `boolean`                                   | No       |             |
-| `locations`               | `BucketLocations`                           | No       |             |
-| `cacheControl`            | `string`                                    | No       |             |
-| `customDomain`            | `string`                                    | No       |             |
-| `enableAdditionalHeaders` | `boolean`                                   | No       |             |
-| `enableDeleteProtection`  | `boolean`                                   | No       |             |
-| `config`                  | `Omit&lt;TigrisStorageConfig, 'bucket'&gt;` | No       |             |
+| Property                  | Type                                                                   | Required | Description                               |
+| ------------------------- | ---------------------------------------------------------------------- | -------- | ----------------------------------------- |
+| `access`                  | `'public' \| 'private'`                                                | No       |                                           |
+| `allowObjectAcl`          | `boolean`                                                              | No       |                                           |
+| `disableDirectoryListing` | `boolean`                                                              | No       |                                           |
+| `locations`               | `BucketLocations`                                                      | No       |                                           |
+| `cacheControl`            | `string`                                                               | No       |                                           |
+| `customDomain`            | `string`                                                               | No       |                                           |
+| `enableAdditionalHeaders` | `boolean`                                                              | No       |                                           |
+| `softDelete`              | `\{ enabled: true; retentionDays: number; \} \| \{ enabled: false; \}` | No       |                                           |
+| `enableDeleteProtection`  | `boolean`                                                              | No       | **Deprecated.** Use `softDelete` instead. |
+| `config`                  | `Omit&lt;TigrisStorageConfig, 'bucket'&gt;`                            | No       |                                           |
 
 ### `UpdateBucketResponse`
 
@@ -948,13 +1139,26 @@ type BucketCorsRule = {
 
 ### `BucketLifecycleRule`
 
+A bucket lifecycle rule. A rule can have at most one transition (top-level
+`storageClass` + `days`/`date`) and/or one `expiration`, optionally scoped to a
+key prefix via `filter.prefix`. At least one of transition or expiration must be
+present.
+
 ```ts
+/**
+ * A bucket lifecycle rule. A rule can have at most one transition
+ * (top-level `storageClass` + `days`/`date`) and/or one `expiration`,
+ * optionally scoped to a key prefix via `filter.prefix`. At least one
+ * of transition or expiration must be present.
+ */
 type BucketLifecycleRule = {
   id?: string;
   enabled?: boolean;
   storageClass?: Exclude<StorageClass, "STANDARD">;
   days?: number;
   date?: string;
+  expiration?: BucketLifecycleExpiration;
+  filter?: BucketLifecycleFilter;
 };
 ```
 
@@ -965,10 +1169,25 @@ type BucketLifecycleRule = {
 | `storageClass` | `Exclude&lt;StorageClass, 'STANDARD'&gt;` | No       |             |
 | `days`         | `number`                                  | No       |             |
 | `date`         | `string`                                  | No       |             |
+| `expiration`   | `BucketLifecycleExpiration`               | No       |             |
+| `filter`       | `BucketLifecycleFilter`                   | No       |             |
 
 ### `BucketTtl`
 
+Bucket-wide TTL configuration. Kept for back-compat with `setBucketTtl`, which
+manages a lifecycle rule with only `expiration` (no transition, no filter). New
+code should configure expirations via `BucketLifecycleRule.expiration` on
+`setBucketLifecycle` instead. This shape is expected to be removed in the next
+major version.
+
 ```ts
+/**
+ * Bucket-wide TTL configuration. Kept for back-compat with `setBucketTtl`,
+ * which manages a lifecycle rule with only `expiration` (no transition,
+ * no filter). New code should configure expirations via
+ * `BucketLifecycleRule.expiration` on `setBucketLifecycle` instead. This
+ * shape is expected to be removed in the next major version.
+ */
 type BucketTtl = {
   id?: string;
   enabled?: boolean;
@@ -1341,49 +1560,31 @@ function getStats(
 
 ```ts
 type GetStatsOptions = {
+  paginationToken?: string;
   config?: TigrisStorageConfig;
 };
 ```
 
-| Property | Type                  | Required | Description |
-| -------- | --------------------- | -------- | ----------- |
-| `config` | `TigrisStorageConfig` | No       |             |
+| Property          | Type                  | Required | Description |
+| ----------------- | --------------------- | -------- | ----------- |
+| `paginationToken` | `string`              | No       |             |
+| `config`          | `TigrisStorageConfig` | No       |             |
 
 ### `StatsResponse`
 
 ```ts
 type StatsResponse = {
-  stats: {
-    activeBuckets: number;
-    totalObjects: number;
-    totalStorageBytes: number;
-    totalUniqueObjects: number;
-  };
-  buckets: Array<{
-    name: string;
-    creationDate: Date;
-    forkInfo:
-      | {
-          hasChildren: boolean;
-          parents: Array<{
-            bucketName: string;
-            forkCreatedAt: Date;
-            snapshot: string;
-            snapshotCreatedAt: Date;
-          }>;
-        }
-      | undefined;
-    type: BucketType;
-    regions: Array<string>;
-    visibility: BucketVisibility;
-  }>;
+  paginationToken?: string;
+  stats: BucketsStats;
+  buckets: Bucket[];
 };
 ```
 
-| Property  | Type                                                                                                                                                                                                                                                                                                      | Required | Description |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| `stats`   | `\{ activeBuckets: number; totalObjects: number; totalStorageBytes: number; totalUniqueObjects: number; \}`                                                                                                                                                                                               | Yes      |             |
-| `buckets` | `Array&lt;\{ name: string; creationDate: Date; forkInfo: \{ hasChildren: boolean; parents: Array&lt;\{ bucketName: string; forkCreatedAt: Date; snapshot: string; snapshotCreatedAt: Date; \}&gt;; \} \| undefined; type: BucketType; regions: Array&lt;string&gt;; visibility: BucketVisibility; \}&gt;` | Yes      |             |
+| Property          | Type           | Required | Description |
+| ----------------- | -------------- | -------- | ----------- |
+| `paginationToken` | `string`       | No       |             |
+| `stats`           | `BucketsStats` | Yes      |             |
+| `buckets`         | `Bucket[]`     | Yes      |             |
 
 ### `BucketType`
 
@@ -1408,29 +1609,14 @@ Shared configuration and response types used across all API methods.
 ```ts
 type TigrisStorageConfig = {
   bucket?: string;
-  accessKeyId?: string;
-  secretAccessKey?: string;
-  endpoint?: string;
-  sessionToken?: string;
-  organizationId?: string;
-  credentialProvider?: () => Promise<{
-    accessKeyId: string;
-    secretAccessKey: string;
-    sessionToken?: string;
-    expiration?: Date;
-  }>;
-};
+  forcePathStyle?: boolean;
+} & TigrisConfig;
 ```
 
-| Property             | Type                                                                                                                    | Required | Description |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| `bucket`             | `string`                                                                                                                | No       |             |
-| `accessKeyId`        | `string`                                                                                                                | No       |             |
-| `secretAccessKey`    | `string`                                                                                                                | No       |             |
-| `endpoint`           | `string`                                                                                                                | No       |             |
-| `sessionToken`       | `string`                                                                                                                | No       |             |
-| `organizationId`     | `string`                                                                                                                | No       |             |
-| `credentialProvider` | `() =&gt; Promise&lt;\{ accessKeyId: string; secretAccessKey: string; sessionToken?: string; expiration?: Date; \}&gt;` | No       |             |
+| Property         | Type      | Required | Description |
+| ---------------- | --------- | -------- | ----------- |
+| `bucket`         | `string`  | No       |             |
+| `forcePathStyle` | `boolean` | No       |             |
 
 ### `TigrisStorageResponse`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@docusaurus/types": "^3.10.0",
         "@eslint/js": "^9.39.3",
         "@redocly/cli": "^2.19.1",
-        "@tigrisdata/storage": "^3.2.0",
+        "@tigrisdata/storage": "^3.16.0",
         "@types/react": "^19.2.14",
         "@typescript-eslint/eslint-plugin": "^8.56.0",
         "@typescript-eslint/parser": "^8.56.0",
@@ -408,135 +408,66 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.8.tgz",
+      "integrity": "sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1035.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1035.0.tgz",
-      "integrity": "sha512-Bh1h96CjHMpxg6Rn2G4EE30YiiBh9w/7WmSZIfwLB0X/6lblaJcHggcryrq2uNN2Bx1/CNErMjTpGQzqhA7Rhg==",
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1075.0.tgz",
+      "integrity": "sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/credential-provider-node": "^3.972.35",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
-        "@aws-sdk/middleware-expect-continue": "^3.972.10",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.12",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-location-constraint": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.33",
-        "@aws-sdk/middleware-ssec": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.34",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.21",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.20",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.16",
-        "@smithy/eventstream-serde-browser": "^4.2.14",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
-        "@smithy/eventstream-serde-node": "^4.2.14",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-blob-browser": "^4.2.15",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/hash-stream-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/md5-js": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.31",
-        "@smithy/middleware-retry": "^4.5.4",
-        "@smithy/middleware-serde": "^4.2.19",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.0",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.12",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.48",
-        "@smithy/util-defaults-mode-node": "^4.2.53",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.3",
-        "@smithy/util-stream": "^4.5.24",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.16",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.33",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.54",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.4.tgz",
-      "integrity": "sha512-EbVgyzQ83/Lf6oh1O4vYY47tuYw3Aosthh865LNU77KyotKz+uvEBNmsl/bSVS/vG+IU39mCqcOHrnhmhF4lug==",
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.18",
-        "@smithy/core": "^3.23.16",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.12",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.3",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
-      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.31",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -544,16 +475,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.30.tgz",
-      "integrity": "sha512-dHpeqa29a0cBYq/h59IC2EK3AphLY96nKy4F35kBtiz9GuKDc32UYRTgjZaF8uuJCnqgw9omUZKR+9myyDHC2A==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+      "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -561,21 +492,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.32.tgz",
-      "integrity": "sha512-A+ZTT//Mswkf9DFEM6XlngwOtYdD8X4CUcoZ2wdpgI8cCs9mcGeuhgTwbGJvealub/MeONOaUr3FbRPMKmTDjg==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+      "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.0",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.12",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.24",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -583,25 +511,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.34.tgz",
-      "integrity": "sha512-MoRc7tLnx3JpFkV2R826enEfBUVN8o9Cc7y3hnbMwiWzL/VJhgfxRQzHkEL9vWorMWP7tibltsRcLoid9fsVdw==",
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+      "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/credential-provider-env": "^3.972.30",
-        "@aws-sdk/credential-provider-http": "^3.972.32",
-        "@aws-sdk/credential-provider-login": "^3.972.34",
-        "@aws-sdk/credential-provider-process": "^3.972.30",
-        "@aws-sdk/credential-provider-sso": "^3.972.34",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.34",
-        "@aws-sdk/nested-clients": "^3.997.2",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-login": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -609,19 +536,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.34.tgz",
-      "integrity": "sha512-XVSklkRRQ/CQDmv3VVFdZRl5hTFgncFhZrLyi0Ai4LZk5o3jpY5HIfuTK7ad7tixPKa+iQmL9+vg9qNyYZB+nw==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+      "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/nested-clients": "^3.997.2",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -629,23 +554,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.35.tgz",
-      "integrity": "sha512-nVrY7AdGfzYgAa/jd9m06p3ES7QQDaB7zN9c+vXnVXxBRkAs9MjRDPB5AKogWuC6phddltfvHGFqLDJmyU9u/A==",
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+      "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.30",
-        "@aws-sdk/credential-provider-http": "^3.972.32",
-        "@aws-sdk/credential-provider-ini": "^3.972.34",
-        "@aws-sdk/credential-provider-process": "^3.972.30",
-        "@aws-sdk/credential-provider-sso": "^3.972.34",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.34",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-ini": "^3.972.56",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -653,17 +577,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.30.tgz",
-      "integrity": "sha512-McJPomNTSEo+C6UA3Zq6pFrcyTUaVsoPPBOvbOHAoIFPc8Z2CMLndqFJOnB+9bVFiBTWQLutlVGmrocBbvv4MQ==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+      "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -671,19 +594,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.34.tgz",
-      "integrity": "sha512-WngYb2K+/yhkDOmDfAOjoCa9Ja3he0DZiAraboKwgWoVRkajDIcDYBCVbUTxtTUldvQoe7VvHLTrBNxvftN1aQ==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+      "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/nested-clients": "^3.997.2",
-        "@aws-sdk/token-providers": "3.1035.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/token-providers": "3.1074.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -691,18 +613,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.34.tgz",
-      "integrity": "sha512-5KLUH+XmSNRj6amJiJSrPsCxU5l/PYDfxyqPa1MxWhHoQC3sxvGPrSib3IE+HQlfRA4e2kO0bnJy7HJdjvpuuA==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+      "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/nested-clients": "^3.997.2",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -710,16 +631,14 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.1035.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1035.0.tgz",
-      "integrity": "sha512-VkC0kDql0qkv+h6nIZOAxmek3VMCNGsq2v74QT9Zf/WbPlyM5PqyGp1dsPxNSv2iMtoWXzHvqzkZ55ZiJCgq4Q==",
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1075.0.tgz",
+      "integrity": "sha512-Npdac3/Fv994iCdFFeqloPel+95Zv6dRiRUpfey6W/CqpB/QdnYP60U4YBhBgJj6V5020Pm3ad0HV4WzCE5hHQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^4.4.31",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.12",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
@@ -729,141 +648,17 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.1035.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
-      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
-      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "@aws-sdk/client-s3": "^3.1075.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.12.tgz",
-      "integrity": "sha512-v7n0//P95g+UnmyjCpJkDJFB+EP/9Wx/fQJC5BEiK9Y7VHgmhh6RNPVbqDYz9gsz8mXnxzyYt3tCEVJ1kzo01w==",
+      "version": "3.974.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.33.tgz",
+      "integrity": "sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/crc64-nvme": "^3.972.7",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.24",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
-      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/checksums": "^3.1000.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -871,74 +666,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.33.tgz",
-      "integrity": "sha512-n8Eh/+kq3u/EodLr8n6sQupu03QGjf122RHXCTGLaHSkavz/2beSKpRlq2oDgfmJZNkAkWF113xbyaUmyOd+YA==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.54.tgz",
+      "integrity": "sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.16",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.12",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.24",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
-      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.34.tgz",
-      "integrity": "sha512-jrmJHyYlTQocR7H4VhvSFhaoedMb2rmlOTvFWD6tNBQ/EVQhTsrNfQUYFuPiOc2wUGxbm5LgCHtnvVmCPgODHw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@smithy/core": "^3.23.16",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.3",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -946,81 +684,40 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.2.tgz",
-      "integrity": "sha512-uGGQO08YetrqfInOKG5atRMrCDRQWRuZ9gGfKY6svPmuE4K7ac+XcbCkpWpjcA7yCYsBaKB/Nly4XKgPXUO1PA==",
+      "version": "3.997.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.34",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.21",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.20",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.16",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.31",
-        "@smithy/middleware-retry": "^4.5.4",
-        "@smithy/middleware-serde": "^4.2.19",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.0",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.12",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.48",
-        "@smithy/util-defaults-mode-node": "^4.2.53",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.3",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+    "node_modules/@aws-sdk/s3-presigned-post": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.1075.0.tgz",
+      "integrity": "sha512-GtG+DhFxhsQesL8bfZ2HxqeZ8Q2PDAm4DGGJZ8HSy5EgIi4VlwR09Urft8ezu4kwXQTVyuH1sql8oJleiqxQrw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/client-s3": "3.1075.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1028,19 +725,17 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1035.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1035.0.tgz",
-      "integrity": "sha512-zT+ulZy7/4mqSNL0toB5GuJIBm3nbeGyq/sHPOxIKR3g0bVi5CZupxGvt78yzQeBcXVNZz+orXvaw5ejQ0FGPw==",
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1075.0.tgz",
+      "integrity": "sha512-++ftTvAGZSTuzFVHEPk8lLi7mybBD8PzJ9USWBvwnE4kSrXOyqYVJ5Ixd06xUEWS/xsrhpkI07mzCLGIxrRymA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "^3.996.21",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-format-url": "^3.972.10",
-        "@smithy/middleware-endpoint": "^4.4.31",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.12",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1048,17 +743,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.21.tgz",
-      "integrity": "sha512-3EpT+C0QdmTMB5aVeJ5odWSLt9vg2oGzUXl1xvUazKGlkr9OBYnegNWqhhjGgZdv8RmSi5eS8nqqB+euNP2aqA==",
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.33",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1066,18 +759,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1035.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1035.0.tgz",
-      "integrity": "sha512-E6IO3Cn+OzBe6Sb5pnubd5Y8qSUMAsVKkD5QSwFfIx5fV1g5SkYwUDRDyPlm90RuIVcCo28wpMJU6W8wXH46Aw==",
+      "version": "3.1074.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+      "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.4",
-        "@aws-sdk/nested-clients": "^3.997.2",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1085,59 +777,13 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
-      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1145,9 +791,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1155,56 +801,16 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.20.tgz",
-      "integrity": "sha512-owEqyKr0z5hWwk+uHwudwNhyFMZ9f9eSWr/k/XD6yeDCI7hHyc56s4UOY1iBQmoramTbdAY4UCuLLEuKmjVXrg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.34",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
-      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
-        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7687,81 +7293,15 @@
         "micromark-util-symbol": "^1.0.1"
       }
     },
-    "node_modules/@smithy/chunked-blob-reader": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
-      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
-      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/config-resolver": {
-      "version": "4.4.17",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
-      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/core": {
-      "version": "3.23.16",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
-      "integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.24",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/core/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7769,91 +7309,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
-      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
-      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
-      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
-      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
-      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7861,105 +7324,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+      "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
-      "integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/chunked-blob-reader": "^5.2.2",
-        "@smithy/chunked-blob-reader-native": "^4.2.3",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
-      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-stream-node": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
-      "integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-stream-node/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
-      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7967,244 +7339,27 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/md5-js": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
-      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/md5-js/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
-      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.31",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.31.tgz",
-      "integrity": "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.16",
-        "@smithy/middleware-serde": "^4.2.19",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-middleware": "^4.2.14",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.4.tgz",
-      "integrity": "sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.16",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/service-error-classification": "^4.3.0",
-        "@smithy/smithy-client": "^4.12.12",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.3",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.19.tgz",
-      "integrity": "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.16",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
-      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
-      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
-      "integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/property-provider": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
-      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
-      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
-      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
-      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/service-error-classification": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
-      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
-      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8212,52 +7367,14 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.12.tgz",
-      "integrity": "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.16",
-        "@smithy/middleware-endpoint": "^4.4.31",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.24",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8265,79 +7382,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
-      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/url-parser": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
-      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
-      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8348,169 +7395,17 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.48",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.48.tgz",
-      "integrity": "sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.12",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.53",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.53.tgz",
-      "integrity": "sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.12",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
-      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
-      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.3.tgz",
-      "integrity": "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.3.0",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "4.5.24",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.24.tgz",
-      "integrity": "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.0",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
@@ -8525,60 +7420,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-waiter": {
-      "version": "4.2.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
-      "integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/uuid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@social-embed/lib": {
@@ -8885,17 +7726,19 @@
       }
     },
     "node_modules/@tigrisdata/storage": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.2.0.tgz",
-      "integrity": "sha512-sDBloJ+LrHA5+Ni3h545BFv+ZLwbxUvi9q1J6aoaFZEJwLX//RS9JFI5P5J3CT+A7rh8DM5LGj59E1iu5vdfqg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.16.0.tgz",
+      "integrity": "sha512-Tdqh94A8gEj9GUF6fWGibO3Dz3l3BBieNMFh26PXUuBOTOpHEbPitg/zELopboVTRtRzWNsWnUFGymjxHYlpZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-sdk/client-s3": "^3.1030.0",
-        "@aws-sdk/lib-storage": "^3.1030.0",
-        "@aws-sdk/s3-request-presigner": "^3.1030.0",
-        "@smithy/signature-v4": "^5.3.13",
+        "@aws-sdk/client-s3": "^3.1038.0",
+        "@aws-sdk/lib-storage": "^3.1038.0",
+        "@aws-sdk/s3-presigned-post": "^3.1053.0",
+        "@aws-sdk/s3-request-presigner": "^3.1038.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/signature-v4": "^5.3.14",
         "dotenv": "^17.4.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@docusaurus/types": "^3.10.0",
     "@eslint/js": "^9.39.3",
     "@redocly/cli": "^2.19.1",
-    "@tigrisdata/storage": "^3.2.0",
+    "@tigrisdata/storage": "^3.16.0",
     "@types/react": "^19.2.14",
     "@typescript-eslint/eslint-plugin": "^8.56.0",
     "@typescript-eslint/parser": "^8.56.0",

--- a/sidebars.js
+++ b/sidebars.js
@@ -933,6 +933,8 @@ const sidebars = {
             "cli/objects/delete",
             "cli/objects/set-access",
             "cli/objects/info",
+            "cli/objects/restore",
+            "cli/objects/restore-info",
           ],
         },
         {
@@ -981,6 +983,16 @@ const sidebars = {
                 "cli/iam/users/revoke-invitation",
                 "cli/iam/users/update-role",
                 "cli/iam/users/remove",
+              ],
+            },
+            {
+              type: "category",
+              label: "tigris iam teams",
+              link: { type: "doc", id: "cli/iam/teams" },
+              items: [
+                "cli/iam/teams/list",
+                "cli/iam/teams/create",
+                "cli/iam/teams/edit",
               ],
             },
           ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and dev-dependency lockfile updates only; no application runtime or auth logic changes in this repo.
> 
> **Overview**
> Updates the Tigris CLI documentation and regenerates the `@tigrisdata/storage` API reference to match newer product and SDK behavior.
> 
> **CLI:** Documents `tigris iam teams` (list, create, edit) with sidebar navigation and OAuth requirement notes. Adds `tigris objects restore` and `restore-info` for GLACIER-style archives. Extends bucket creation (`buckets create`, `mk`) with `--allow-object-acl` and `--enable-directory-listing`, and documents `tigris cp --access` for public/private uploads.
> 
> **SDK:** Bumps the doc-generation dependency to **v3.16.0** and refreshes `api.mdx` (metadata on get/put, range reads, versioning, soft delete, lifecycle rules, presigned snapshot reads, deprecations, and related types).
> 
> **Tooling:** `package.json` / lockfile align `@tigrisdata/storage` with the regenerated reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb136dccd452c05163e55a9717d92e8b3c7c245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->