### PR TITLE
docs(cloud-disk): add Changelog page

### DIFF
--- a/docs/cloud-disk/changelog.mdx
+++ b/docs/cloud-disk/changelog.mdx
@@ -1,0 +1,61 @@
+---
+title: Cloud Disk Changelog
+sidebar_label: Changelog
+description:
+  Notable user-facing changes to Tigris Cloud Disk — new commands, defaults, and
+  behavior.
+---
+
+# Changelog
+
+Notable changes to Cloud Disk, newest first.
+
+:::info Beta
+
+Cloud Disk is in beta and under active development, so behavior and defaults may
+change between releases.
+
+:::
+
+## 2026-06-24
+
+- Cloud Disk now caps its own memory use automatically, keeping the daemon's
+  footprint predictable without manual tuning.
+
+## 2026-06-22
+
+- **Kubernetes (CSI):** non-root pods can now read and write Cloud Disk volumes.
+- **Kubernetes (CSI):** volume provisioning is now strongly consistent — a newly
+  created volume is immediately usable.
+- Discarding/`TRIM` now reclaims space within partially written chunks, not just
+  whole ones.
+
+## 2026-06-19
+
+- **Write-back caching is now the default**, so writes are acknowledged from the
+  local cache and flushed to Tigris in the background — noticeably faster for
+  write-heavy workloads. Opt into write-through if you need every write durable
+  on Tigris before it's acknowledged. See
+  [Configuration & Tuning](/docs/cloud-disk/tuning).
+- Reads are now strongly consistent: data you just wrote is always reflected,
+  even across mounts.
+
+## 2026-06-17
+
+- **Crash-consistent write-back across hosts:** after an unclean shutdown you
+  can remount the disk — including on a different machine — and it recovers
+  cleanly, without losing acknowledged writes.
+- New `-preset` option to pick a performance profile when creating a disk.
+
+## 2026-06-15
+
+- New `cloud-disk resize` command to grow a disk; the filesystem expands on the
+  next mount.
+
+## 2026-06-12
+
+- **Faster cold starts:** the cache pre-warms and reads ahead automatically, so
+  the disk is responsive sooner after mounting.
+- CLI improvements: mount and unmount show progress, a `status` command reports
+  a disk's state, config defaults are clearer, and a `version` command was
+  added.

--- a/sidebars.js
+++ b/sidebars.js
@@ -750,6 +750,11 @@ const sidebars = {
               label: "Configuration & Tuning",
               id: "cloud-disk/tuning",
             },
+            {
+              type: "doc",
+              label: "Changelog",
+              id: "cloud-disk/changelog",
+            },
           ],
         },
         "training/tigrisfs",


### PR DESCRIPTION
Adds a user-facing **Changelog** page to the Cloud Disk docs, linked in the sidebar right after **Configuration & Tuning**.

- New page: `docs/cloud-disk/changelog.mdx` (matches sibling page frontmatter + the Beta admonition).
- Sidebar: `Changelog` entry added under the Cloud Disk category after Configuration & Tuning.

Entries are written for users (new commands, defaults, behavior — no implementation detail), newest first, with dates from the Cloud Disk release history. The in-review metrics-push feature is intentionally left out until it ships.

Please skim the entries for accuracy/wording. If Cloud Disk has a version scheme (e.g. 1.7.0), we can switch from dates to versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime, API, or security behavior changes.
> 
> **Overview**
> Adds a **Cloud Disk Changelog** doc (`docs/cloud-disk/changelog.mdx`) so users can see notable product changes (commands, defaults, behavior) in one place, newest first, with the same beta admonition as sibling Cloud Disk pages.
> 
> The **Product → Cloud Disk** sidebar now includes a **Changelog** link immediately after **Configuration & Tuning**. Entries span mid–late June 2026 (write-back default, consistency, CSI, `resize`, CLI, memory cap, etc.) and link to tuning where relevant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce56504c9137c45d322fc4feaed27d97b44d75b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->