### PR TITLE
docs(cloud-disk): document mount-time cache warming knobs

### DIFF
--- a/docs/cloud-disk/tuning.mdx
+++ b/docs/cloud-disk/tuning.mdx
@@ -58,6 +58,19 @@ buffer writes.
 | `disk-cache-path` | `/var/lib/cloud-disk` | Local directory for the cache and write-back buffer. Each disk uses its own subdirectory, so one path is safe to share (and to inherit on forks).                                                       |
 | `disk-cache-size` | `0`                   | How much local disk the read cache may use, e.g. `4G`, `100G`. `0` (the default) turns the read cache off while keeping write-back buffering; size it to your working set for the biggest read speedup. |
 
+## Cache warming on mount
+
+On mount the disk preloads its index and recently-stored data into cache, so the
+first reads are fast instead of all going to Tigris. Both are on by default and
+self-limiting — warming never loads more than your cache can hold, counting the
+RAM cache (`max-cache-size`) and the local disk cache (`disk-cache-size`)
+together.
+
+| Setting              | Default | When to change                                                                                                                                                                                      |
+| -------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `warm-start-bytes`   | `1G`    | How much stored data to preload into cache on mount. Capped to the combined RAM + local-disk cache size, so it never evicts what it just loaded. Lower it for a faster mount; `0` preloads nothing. |
+| `prewarm-region-map` | `true`  | Preload the disk's index up front so reads don't pause for lookups. Cheap — leave on. Set `false` on a very large disk to skip it and mount sooner.                                                 |
+
 ## Write-back
 
 Write-back buffers writes locally and uploads in the background — much faster.

--- a/docs/cloud-disk/tuning.mdx
+++ b/docs/cloud-disk/tuning.mdx
@@ -61,13 +61,11 @@ buffer writes.
 ## Cache warming on mount
 
 On mount the disk preloads its index and the data at the start of the disk into
-cache, so the first reads are fast instead of all going to Tigris. (The leading
-bytes are where a filesystem keeps most of its metadata, so this is what early
-reads tend to touch.) This happens in the background — it never delays the
-mount; the disk serves immediately and warming fills the cache as it runs. Both
-are on by default and self-limiting — warming never loads more than your cache
-can hold, counting the RAM cache (`max-cache-size`) and the local disk cache
-(`disk-cache-size`) together.
+cache, so the first reads are fast instead of all going to Tigris. This happens
+in the background — it never delays the mount; the disk serves immediately and
+warming fills the cache as it runs. Both are on by default and self-limiting —
+warming never loads more than your cache can hold, counting the RAM cache
+(`max-cache-size`) and the local disk cache (`disk-cache-size`) together.
 
 | Setting              | Default | When to change                                                                                                                                                                                                                                                                                                            |
 | -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/cloud-disk/tuning.mdx
+++ b/docs/cloud-disk/tuning.mdx
@@ -60,17 +60,19 @@ buffer writes.
 
 ## Cache warming on mount
 
-On mount the disk preloads its index and recently-stored data into cache, so the
-first reads are fast instead of all going to Tigris. This happens in the
-background — it never delays the mount; the disk serves immediately and warming
-fills the cache as it runs. Both are on by default and self-limiting — warming
-never loads more than your cache can hold, counting the RAM cache
-(`max-cache-size`) and the local disk cache (`disk-cache-size`) together.
+On mount the disk preloads its index and the data at the start of the disk into
+cache, so the first reads are fast instead of all going to Tigris. (The leading
+bytes are where a filesystem keeps most of its metadata, so this is what early
+reads tend to touch.) This happens in the background — it never delays the
+mount; the disk serves immediately and warming fills the cache as it runs. Both
+are on by default and self-limiting — warming never loads more than your cache
+can hold, counting the RAM cache (`max-cache-size`) and the local disk cache
+(`disk-cache-size`) together.
 
-| Setting              | Default | When to change                                                                                                                                                                                                                                                               |
-| -------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `warm-start-bytes`   | `1G`    | How much stored data to preload into cache on mount. Capped to the combined RAM + local-disk cache size, so it never evicts what it just loaded. Lower it to reduce background fetching after mount; `0` preloads no stored data (the index is still prewarmed — see below). |
-| `prewarm-region-map` | `true`  | Preload the disk's index up front so reads don't pause for lookups. Cheap — leave on. Set `false` on a very large disk to skip it.                                                                                                                                           |
+| Setting              | Default | When to change                                                                                                                                                                                                                                                                                                            |
+| -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `warm-start-bytes`   | `1G`    | How much data from the start of the disk to preload into cache on mount (unwritten regions are skipped). Capped to the combined RAM + local-disk cache size, so it never evicts what it just loaded. Lower it to reduce background fetching after mount; `0` preloads no data (the index is still prewarmed — see below). |
+| `prewarm-region-map` | `true`  | Preload the disk's index up front so reads don't pause for lookups. Cheap — leave on. Set `false` on a very large disk to skip it.                                                                                                                                                                                        |
 
 ## Write-back
 

--- a/docs/cloud-disk/tuning.mdx
+++ b/docs/cloud-disk/tuning.mdx
@@ -61,15 +61,16 @@ buffer writes.
 ## Cache warming on mount
 
 On mount the disk preloads its index and recently-stored data into cache, so the
-first reads are fast instead of all going to Tigris. Both are on by default and
-self-limiting — warming never loads more than your cache can hold, counting the
-RAM cache (`max-cache-size`) and the local disk cache (`disk-cache-size`)
-together.
+first reads are fast instead of all going to Tigris. This happens in the
+background — it never delays the mount; the disk serves immediately and warming
+fills the cache as it runs. Both are on by default and self-limiting — warming
+never loads more than your cache can hold, counting the RAM cache
+(`max-cache-size`) and the local disk cache (`disk-cache-size`) together.
 
-| Setting              | Default | When to change                                                                                                                                                                                      |
-| -------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `warm-start-bytes`   | `1G`    | How much stored data to preload into cache on mount. Capped to the combined RAM + local-disk cache size, so it never evicts what it just loaded. Lower it for a faster mount; `0` preloads nothing. |
-| `prewarm-region-map` | `true`  | Preload the disk's index up front so reads don't pause for lookups. Cheap — leave on. Set `false` on a very large disk to skip it and mount sooner.                                                 |
+| Setting              | Default | When to change                                                                                                                                                                                                                                                               |
+| -------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `warm-start-bytes`   | `1G`    | How much stored data to preload into cache on mount. Capped to the combined RAM + local-disk cache size, so it never evicts what it just loaded. Lower it to reduce background fetching after mount; `0` preloads no stored data (the index is still prewarmed — see below). |
+| `prewarm-region-map` | `true`  | Preload the disk's index up front so reads don't pause for lookups. Cheap — leave on. Set `false` on a very large disk to skip it.                                                                                                                                           |
 
 ## Write-back
 


### PR DESCRIPTION
## What

Adds a **Cache warming on mount** section to the Cloud Disk tuning page documenting the two prewarm knobs, which are on by default but were missing from the docs:

- `warm-start-bytes` (default `1G`) — how much stored data to preload into cache on mount.
- `prewarm-region-map` (default `true`) — preload the disk's index up front so reads don't pause for lookups.

## Why

The tuning page already documents the related *read-ahead* prefetch (`read-ahead-workers`, `read-ahead-max-window`) but not the *mount-time* prewarm, so users had no documented way to know these defaults exist or how to tune them (e.g. lower `warm-start-bytes` for a faster mount on large volumes).

The copy also makes explicit that the preload budget is **capped to the combined RAM (`max-cache-size`) + local-disk (`disk-cache-size`) cache size**, so warming never evicts what it just loaded.

Kept to the page's existing user-facing style (heading + short prose + Setting/Default/When-to-change table), no implementation detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `docs/cloud-disk/tuning.mdx`; no runtime or configuration behavior is modified.
> 
> **Overview**
> Adds a **Cache warming on mount** section to the Cloud Disk tuning docs, placed after the local disk cache section.
> 
> It explains that on mount the disk **background-preloads** the index and the start of stored data so early reads hit cache instead of Tigris, without blocking mount. The prose states warming is **on by default**, **self-limiting**, and bounded by **combined** `max-cache-size` and `disk-cache-size`.
> 
> A settings table documents **`warm-start-bytes`** (default `1G`, `0` to skip data preload while index prewarm can still apply) and **`prewarm-region-map`** (default `true`, disable on very large disks). This complements the existing read-ahead prefetch knobs that were already documented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2d25ea8c2eee543016b80229ac193fb6c716d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->