### PR TITLE
docs(cli): document fork operations and objects put stdin

### DIFF
--- a/docs/cli/buckets.mdx
+++ b/docs/cli/buckets.mdx
@@ -18,6 +18,8 @@ t3 b <operation> [flags]
 | ---------------------------------------- | ----------------------------------------------------------------- |
 | [`list`](list)                           | List all buckets                                                  |
 | [`create`](create)                       | Create a new bucket                                               |
+| [`rebase`](rebase)                       | Update a fork with the latest changes from its source             |
+| [`merge`](merge)                         | Merge a fork's changes back into its source                       |
 | [`get`](get)                             | Show details for a bucket                                         |
 | [`delete`](delete)                       | Delete a bucket                                                   |
 | [`set`](set)                             | Update bucket settings                                            |

--- a/docs/cli/buckets/create.mdx
+++ b/docs/cli/buckets/create.mdx
@@ -62,7 +62,7 @@ snapshot rather than the source's current state.
 Once you have a fork you can keep it in sync with, or promote it back to, its
 source:
 
-- [`buckets rebase`](rebase) — update a fork with the latest changes from its
-  source
-- [`buckets merge`](merge) — merge a fork's changes back into its source
-- [`buckets list --forks-of`](list) — list the forks of a bucket
+- [`buckets rebase`](./rebase.mdx) — update a fork with the latest changes from
+  its source
+- [`buckets merge`](./merge.mdx) — merge a fork's changes back into its source
+- [`buckets list --forks-of`](./list.mdx) — list the forks of a bucket

--- a/docs/cli/buckets/create.mdx
+++ b/docs/cli/buckets/create.mdx
@@ -13,17 +13,19 @@ t3 b c [name] [flags]
 
 ## Flags
 
-| Name                         | Required | Default    | Description                                                                                                                                                                                                                                      |
-| ---------------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--access`, `-a`             | No       | `private`  | Access level. Options: `public`, `private`                                                                                                                                                                                                       |
-| `--public`                   | No       | —          | Shorthand for `--access public`                                                                                                                                                                                                                  |
-| `--enable-snapshots`, `-s`   | No       | `false`    | Enable snapshots for the bucket                                                                                                                                                                                                                  |
-| `--allow-object-acl`         | No       | `false`    | Allow per-object ACLs on the bucket                                                                                                                                                                                                              |
-| `--enable-directory-listing` | No       | `false`    | Enable directory listing, relevant for public buckets                                                                                                                                                                                            |
-| `--default-tier`, `-t`       | No       | `STANDARD` | Default storage tier. Options: `STANDARD` (Standard), `STANDARD_IA` (Infrequent Access), `GLACIER` (Archive), `GLACIER_IR` (Instant Retrieval Archive)                                                                                           |
-| `--locations`, `-l`          | No       | `global`   | Bucket location. Options: `global`, `usa`, `eur`, `ams`, `fra`, `gru`, `iad`, `jnb`, `lhr`, `nrt`, `ord`, `sin`, `sjc`, `syd`. Supports comma-separated values for dual region (e.g. `ams,fra`). See [locations docs](/docs/buckets/locations/). |
-| `--consistency`, `-c`        | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
-| `--region`, `-r`             | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
+| Name                                 | Required | Default    | Description                                                                                                                                                                                                                                      |
+| ------------------------------------ | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--access`, `-a`                     | No       | `private`  | Access level. Options: `public`, `private`                                                                                                                                                                                                       |
+| `--public`                           | No       | —          | Shorthand for `--access public`                                                                                                                                                                                                                  |
+| `--enable-snapshots`, `-s`           | No       | `false`    | Enable snapshots for the bucket                                                                                                                                                                                                                  |
+| `--allow-object-acl`                 | No       | `false`    | Allow per-object ACLs on the bucket                                                                                                                                                                                                              |
+| `--enable-directory-listing`         | No       | `false`    | Enable directory listing, relevant for public buckets                                                                                                                                                                                            |
+| `--default-tier`, `-t`               | No       | `STANDARD` | Default storage tier. Options: `STANDARD` (Standard), `STANDARD_IA` (Infrequent Access), `GLACIER` (Archive), `GLACIER_IR` (Instant Retrieval Archive)                                                                                           |
+| `--locations`, `-l`                  | No       | `global`   | Bucket location. Options: `global`, `usa`, `eur`, `ams`, `fra`, `gru`, `iad`, `jnb`, `lhr`, `nrt`, `ord`, `sin`, `sjc`, `syd`. Supports comma-separated values for dual region (e.g. `ams,fra`). See [locations docs](/docs/buckets/locations/). |
+| `--fork-of`, `--fork`                | No       | —          | Create this bucket as a fork (copy-on-write clone) of the named source bucket                                                                                                                                                                    |
+| `--source-snapshot`, `--source-snap` | No       | —          | Fork from a specific snapshot of the source bucket. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp. Requires `--fork-of`                                                                                           |
+| `--consistency`, `-c`                | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
+| `--region`, `-r`                     | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
 
 ## Examples
 
@@ -42,4 +44,25 @@ tigris buckets create my-bucket --allow-object-acl
 
 # Create a public bucket with directory listing enabled
 tigris buckets create my-bucket --public --enable-directory-listing
+
+# Create a fork (copy-on-write clone) of an existing bucket
+tigris buckets create my-fork --fork-of my-bucket
+
+# Fork from a specific snapshot of the source bucket
+tigris buckets create my-fork --fork-of my-bucket --source-snapshot 1765889000501544464
 ```
+
+## Forks
+
+A fork is a copy-on-write clone of a source bucket: it starts out sharing the
+source's data and only diverges as you write to it, so creating one is cheap
+regardless of the source's size. Use `--source-snapshot` to fork from a specific
+snapshot rather than the source's current state.
+
+Once you have a fork you can keep it in sync with, or promote it back to, its
+source:
+
+- [`buckets rebase`](rebase) — update a fork with the latest changes from its
+  source
+- [`buckets merge`](merge) — merge a fork's changes back into its source
+- [`buckets list --forks-of`](list) — list the forks of a bucket

--- a/docs/cli/buckets/merge.mdx
+++ b/docs/cli/buckets/merge.mdx
@@ -22,6 +22,8 @@ version.
 | -------------------------------- | -------- | ------------- | ------------------------------------------------------------------------ |
 | `--into`, `--source`             | No       | fork's parent | Source bucket to merge into. Defaults to the fork's parent source bucket |
 | `--from-snapshot`, `--from-snap` | No       | —             | Merge from a specific snapshot of the fork rather than its current state |
+| `--yes`, `-y`                    | No       | —             | Skip the confirmation prompt                                             |
+| `--json`                         | No       | —             | Output as JSON, including the resulting snapshot version                 |
 
 ## Examples
 
@@ -41,7 +43,7 @@ tigris buckets merge my-fork --yes
 
 ## Related
 
-- [`buckets rebase`](rebase) — update a fork with the latest changes from its
-  source
-- [`buckets create --fork-of`](create) — create a fork of a bucket
-- [`buckets list --forks-of`](list) — list the forks of a bucket
+- [`buckets rebase`](./rebase.mdx) — update a fork with the latest changes from
+  its source
+- [`buckets create --fork-of`](./create.mdx) — create a fork of a bucket
+- [`buckets list --forks-of`](./list.mdx) — list the forks of a bucket

--- a/docs/cli/buckets/merge.mdx
+++ b/docs/cli/buckets/merge.mdx
@@ -1,0 +1,47 @@
+# tigris buckets merge
+
+Merge a fork's changes back into its source bucket. By default the source is
+resolved automatically from the fork's parent; use `--into` to target a
+different source bucket.
+
+## Usage
+
+```bash
+tigris buckets merge <fork> [flags]
+t3 b merge <fork> [flags]
+```
+
+You are asked to confirm before the source bucket is written. Pass `--yes`
+(`-y`) to skip the prompt in scripts and other non-interactive shells. Add
+`--json` for machine-readable output, which includes the resulting snapshot
+version.
+
+## Flags
+
+| Name                             | Required | Default       | Description                                                              |
+| -------------------------------- | -------- | ------------- | ------------------------------------------------------------------------ |
+| `--into`, `--source`             | No       | fork's parent | Source bucket to merge into. Defaults to the fork's parent source bucket |
+| `--from-snapshot`, `--from-snap` | No       | —             | Merge from a specific snapshot of the fork rather than its current state |
+
+## Examples
+
+```bash
+# Merge a fork back into its source (parent resolved automatically)
+tigris buckets merge my-fork
+
+# Merge into an explicit source bucket
+tigris buckets merge my-fork --into my-bucket
+
+# Merge from a specific snapshot of the fork
+tigris buckets merge my-fork --from-snapshot 1765889000501544464
+
+# Skip the confirmation prompt (e.g. in scripts)
+tigris buckets merge my-fork --yes
+```
+
+## Related
+
+- [`buckets rebase`](rebase) — update a fork with the latest changes from its
+  source
+- [`buckets create --fork-of`](create) — create a fork of a bucket
+- [`buckets list --forks-of`](list) — list the forks of a bucket

--- a/docs/cli/buckets/rebase.mdx
+++ b/docs/cli/buckets/rebase.mdx
@@ -1,0 +1,34 @@
+# tigris buckets rebase
+
+Update a fork with the latest changes from its source bucket. Rebasing advances
+the fork onto the current state of the bucket it was forked from.
+
+## Usage
+
+```bash
+tigris buckets rebase <fork>
+t3 b rebase <fork>
+```
+
+You are asked to confirm before the fork is updated. Pass `--yes` (`-y`) to skip
+the prompt in scripts and other non-interactive shells. Add `--json` for
+machine-readable output, which includes the resulting snapshot version.
+
+## Examples
+
+```bash
+# Rebase a fork onto its source bucket
+tigris buckets rebase my-fork
+
+# Skip the confirmation prompt (e.g. in scripts)
+tigris buckets rebase my-fork --yes
+
+# Machine-readable output
+tigris buckets rebase my-fork --yes --json
+```
+
+## Related
+
+- [`buckets merge`](merge) — merge a fork's changes back into its source
+- [`buckets create --fork-of`](create) — create a fork of a bucket
+- [`buckets list --forks-of`](list) — list the forks of a bucket

--- a/docs/cli/buckets/rebase.mdx
+++ b/docs/cli/buckets/rebase.mdx
@@ -6,13 +6,20 @@ the fork onto the current state of the bucket it was forked from.
 ## Usage
 
 ```bash
-tigris buckets rebase <fork>
-t3 b rebase <fork>
+tigris buckets rebase <fork> [flags]
+t3 b rebase <fork> [flags]
 ```
 
 You are asked to confirm before the fork is updated. Pass `--yes` (`-y`) to skip
 the prompt in scripts and other non-interactive shells. Add `--json` for
 machine-readable output, which includes the resulting snapshot version.
+
+## Flags
+
+| Name          | Required | Default | Description                                              |
+| ------------- | -------- | ------- | -------------------------------------------------------- |
+| `--yes`, `-y` | No       | —       | Skip the confirmation prompt                             |
+| `--json`      | No       | —       | Output as JSON, including the resulting snapshot version |
 
 ## Examples
 
@@ -29,6 +36,6 @@ tigris buckets rebase my-fork --yes --json
 
 ## Related
 
-- [`buckets merge`](merge) — merge a fork's changes back into its source
-- [`buckets create --fork-of`](create) — create a fork of a bucket
-- [`buckets list --forks-of`](list) — list the forks of a bucket
+- [`buckets merge`](./merge.mdx) — merge a fork's changes back into its source
+- [`buckets create --fork-of`](./create.mdx) — create a fork of a bucket
+- [`buckets list --forks-of`](./list.mdx) — list the forks of a bucket

--- a/docs/cli/mk.mdx
+++ b/docs/cli/mk.mdx
@@ -20,17 +20,19 @@ folder inside the bucket.
 
 Flags only apply when creating a bucket (not folders).
 
-| Name                         | Required | Default    | Description                                                                                                                                                                                                                                      |
-| ---------------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--access`, `-a`             | No       | `private`  | Access level. Options: `public`, `private`                                                                                                                                                                                                       |
-| `--public`                   | No       | —          | Shorthand for `--access public`                                                                                                                                                                                                                  |
-| `--enable-snapshots`, `-s`   | No       | `false`    | Enable snapshots for the bucket                                                                                                                                                                                                                  |
-| `--allow-object-acl`         | No       | `false`    | Allow per-object ACLs on the bucket                                                                                                                                                                                                              |
-| `--enable-directory-listing` | No       | `false`    | Enable directory listing, relevant for public buckets                                                                                                                                                                                            |
-| `--default-tier`, `-t`       | No       | `STANDARD` | Default storage tier. Options: `STANDARD`, `STANDARD_IA`, `GLACIER`, `GLACIER_IR`                                                                                                                                                                |
-| `--locations`, `-l`          | No       | `global`   | Bucket location. Options: `global`, `usa`, `eur`, `ams`, `fra`, `gru`, `iad`, `jnb`, `lhr`, `nrt`, `ord`, `sin`, `sjc`, `syd`. Supports comma-separated values for dual region (e.g. `ams,fra`). See [locations docs](/docs/buckets/locations/). |
-| `--consistency`, `-c`        | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
-| `--region`, `-r`             | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
+| Name                                 | Required | Default    | Description                                                                                                                                                                                                                                      |
+| ------------------------------------ | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--access`, `-a`                     | No       | `private`  | Access level. Options: `public`, `private`                                                                                                                                                                                                       |
+| `--public`                           | No       | —          | Shorthand for `--access public`                                                                                                                                                                                                                  |
+| `--enable-snapshots`, `-s`           | No       | `false`    | Enable snapshots for the bucket                                                                                                                                                                                                                  |
+| `--allow-object-acl`                 | No       | `false`    | Allow per-object ACLs on the bucket                                                                                                                                                                                                              |
+| `--enable-directory-listing`         | No       | `false`    | Enable directory listing, relevant for public buckets                                                                                                                                                                                            |
+| `--default-tier`, `-t`               | No       | `STANDARD` | Default storage tier. Options: `STANDARD`, `STANDARD_IA`, `GLACIER`, `GLACIER_IR`                                                                                                                                                                |
+| `--locations`, `-l`                  | No       | `global`   | Bucket location. Options: `global`, `usa`, `eur`, `ams`, `fra`, `gru`, `iad`, `jnb`, `lhr`, `nrt`, `ord`, `sin`, `sjc`, `syd`. Supports comma-separated values for dual region (e.g. `ams,fra`). See [locations docs](/docs/buckets/locations/). |
+| `--fork-of`, `--fork`                | No       | —          | Create this bucket as a fork (copy-on-write clone) of the named source bucket                                                                                                                                                                    |
+| `--source-snapshot`, `--source-snap` | No       | —          | Fork from a specific snapshot of the source bucket. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp. Requires `--fork-of`                                                                                           |
+| `--consistency`, `-c`                | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
+| `--region`, `-r`                     | No       | —          | **Deprecated.** Use `--locations` instead.                                                                                                                                                                                                       |
 
 ## Examples
 
@@ -52,4 +54,14 @@ tigris mk my-bucket/images/
 
 # Using t3:// prefix
 tigris mk t3://my-bucket
+
+# Create a fork (copy-on-write clone) of an existing bucket
+tigris mk my-fork --fork-of my-bucket
+
+# Fork from a specific snapshot of the source bucket
+tigris mk my-fork --fork-of my-bucket --source-snapshot 1765889000501544464
 ```
+
+Forks are copy-on-write clones. Once created, use
+[`buckets rebase`](buckets/rebase) and [`buckets merge`](buckets/merge) to keep
+a fork in sync with, or promote it back to, its source.

--- a/docs/cli/mk.mdx
+++ b/docs/cli/mk.mdx
@@ -63,5 +63,6 @@ tigris mk my-fork --fork-of my-bucket --source-snapshot 1765889000501544464
 ```
 
 Forks are copy-on-write clones. Once created, use
-[`buckets rebase`](buckets/rebase) and [`buckets merge`](buckets/merge) to keep
-a fork in sync with, or promote it back to, its source.
+[`buckets rebase`](./buckets/rebase.mdx) and
+[`buckets merge`](./buckets/merge.mdx) to keep a fork in sync with, or promote
+it back to, its source.

--- a/docs/cli/objects/put.mdx
+++ b/docs/cli/objects/put.mdx
@@ -1,16 +1,20 @@
 # tigris objects put
 
-Upload a local file as an object. Content-type is auto-detected from extension
-unless overridden.
+Upload a local file — or data piped via stdin — as an object. Content-type is
+auto-detected from the file extension unless overridden.
 
 **Alias:** `p`
 
 ## Usage
 
 ```bash
-tigris objects put <bucket> <key> <file> [flags]
-t3 o p <bucket> <key> <file> [flags]
+tigris objects put <bucket> <key> [file] [flags]
+t3 o p <bucket> <key> [file] [flags]
 ```
+
+Omit the `<file>` argument to read the object data from **stdin** (piped input).
+Since piped data has no file extension to infer from, pass `--content-type` if
+you need a specific type.
 
 ## Flags
 
@@ -28,4 +32,10 @@ tigris objects put my-bucket report.pdf ./report.pdf
 
 # Upload with public access and explicit content type
 tigris objects put my-bucket logo.png ./logo.png --access public --content-type image/png
+
+# Upload piped data from stdin (omit the file argument)
+echo 'hello' | tigris objects put my-bucket hello.txt
+
+# Pipe a command's output straight into an object (t3:// paths work too)
+cat report.pdf | tigris objects put t3://my-bucket/report.pdf --content-type application/pdf
 ```

--- a/sidebars.js
+++ b/sidebars.js
@@ -900,6 +900,8 @@ const sidebars = {
           items: [
             "cli/buckets/list",
             "cli/buckets/create",
+            "cli/buckets/rebase",
+            "cli/buckets/merge",
             "cli/buckets/get",
             "cli/buckets/delete",
             "cli/buckets/set",


### PR DESCRIPTION
## What

Documents the fork lifecycle in the CLI docs, alongside the CLI change in [tigrisdata/cli#119](https://github.com/tigrisdata/cli/pull/119).

**New command pages**

- `cli/buckets/rebase` — update a fork with the latest changes from its source
- `cli/buckets/merge` — merge a fork's changes back into its source (with `--into`/`--from-snapshot` flags)

Both are added to the `buckets` command index and the sidebar nav.

**Fork creation**

- Document `--fork-of`/`--source-snapshot` on `buckets create` and `mk` (previously undocumented), with a **Forks** section covering copy-on-write semantics and the rebase/merge lifecycle.

**`objects put` stdin**

- Reword the description, mark `<file>` optional, and add piped-input examples (`echo 'hi' | tigris objects put …`). Docs-only — the CLI already supports this.

## Notes

- Prettier clean across all changed files; `sidebars.js` parses; relative doc links resolve.
- The `rebase`/`merge` commands ship in cli#119 (depends on `@tigrisdata/storage@3.17.0`), so this is best merged together with / after that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to CLI reference pages and navigation; no runtime or security impact.
> 
> **Overview**
> Documents the **bucket fork** workflow in the CLI reference: new pages for **`buckets rebase`** and **`buckets merge`** (flags, confirmation/`--yes`, `--json`, and merge-specific `--into` / `--from-snapshot`), wired into the **`buckets`** command table and **CLI sidebar**.
> 
> **Fork creation** is documented on **`buckets create`** and **`mk`** via **`--fork-of`** / **`--source-snapshot`**, with a **Forks** section on create explaining copy-on-write behavior and links to rebase, merge, and list.
> 
> **`objects put`** is updated to describe **stdin uploads** (optional `<file>`, piped examples, and when to set **`--content-type`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9686f5f2e9cabd1539f60354a04e94f99a51433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->