### PR TITLE
add Daytona docs guide

### DIFF
--- a/docs/agents/agent-daytona.mdx
+++ b/docs/agents/agent-daytona.mdx
@@ -1,0 +1,229 @@
+---
+id: agent-daytona
+title: "Run Daytona Sandboxes on a Forkable Tigris Bucket"
+---
+
+# Run Daytona Sandboxes on a Forkable Tigris Bucket
+
+[Daytona](https://www.daytona.io) gives your agent a disposable microVM to run
+in. Tigris gives it a durable, forkable world to live in. This guide wires the
+two together end to end: every run gets a private copy-on-write fork of a base
+bucket and an access key scoped to that fork, the sandbox boots already bound to
+its fork, and when the run ends the harness promotes the changes or throws them
+away.
+
+The properties you get from this split:
+
+- **Isolation that is enforced, not conventional.** The sandbox only ever holds
+  credentials for its own fork. A prompt injection or a buggy tool can name the
+  base bucket all it wants; the API will refuse it.
+- **Free experiments.** A fork is a metadata-level, zero-copy clone, so it costs
+  the same whether the base holds megabytes or terabytes. Deleting a fork frees
+  only the deltas the run actually wrote.
+- **One snapshot boundary.** Working files, memory, and run metadata live as
+  keys in one namespace, so "what did the world look like before this run" is a
+  snapshot, not a forensics project.
+
+## Prerequisites
+
+- A Tigris account and the [Tigris CLI](/docs/cli/) installed and authenticated
+  on the machine that runs your harness (`npm install -g @tigrisdata/cli`)
+- A [Daytona](https://app.daytona.io) API key, exported as `DAYTONA_API_KEY`
+- The Daytona Python SDK: `pip install daytona`
+
+## Step 1: Create the base bucket
+
+The base bucket is the agent's world: the one layer you can't rebuild. Enable
+snapshots on it so every promotion below can be preceded by a point-in-time
+marker you can fork from later.
+
+```bash
+tigris buckets create agent-world --enable-snapshots
+```
+
+Seed it with whatever your agent needs to start: a repo under `workspace/`,
+memory under `memory/`, run records under `runs/`.
+
+## Step 2: Write the entrypoint
+
+The entrypoint is baked into the Daytona snapshot and runs before your agent's
+first instruction. It arrives holding fork-scoped credentials and nothing else,
+pulls the working set, and binds every storage tool to the fork.
+
+```bash
+#!/usr/bin/env bash
+# entrypoint.sh
+set -euo pipefail
+
+# 0. The harness set these three at sandbox creation. If any are
+#    missing, fail loudly now rather than partway through a run.
+: "${FORK:?}" "${TIGRIS_ACCESS_KEY_ID:?}" "${TIGRIS_SECRET_ACCESS_KEY:?}"
+
+# 1. The scoped key arrives as TIGRIS_ACCESS_KEY_ID and
+#    TIGRIS_SECRET_ACCESS_KEY (what storagesdk reads); mirror it
+#    to the AWS names the Tigris CLI reads.
+export AWS_ACCESS_KEY_ID="${TIGRIS_ACCESS_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${TIGRIS_SECRET_ACCESS_KEY}"
+
+# 2. Pull the working set only. Memory, run metadata, and artifacts
+#    stay in the fork and are read by key, never copied into the VM.
+tigris cp -r "t3://${FORK}/workspace/" /workspace/
+
+# 3. Bind every storage tool to the fork. Any `storage` command or
+#    MCP tool call the agent makes sees the fork, not the base.
+export STORAGE_ADAPTER=tigris
+export TIGRIS_BUCKET="${FORK}"
+exec "$@"
+```
+
+## Step 3: Bake the Daytona snapshot
+
+Build a snapshot image that contains the Tigris CLI, the
+[storagesdk](https://github.com/storagesdk/storagesdk) MCP server, the
+entrypoint, and an MCP config entry so the agent can reach its world by key. Run
+this once, not per run.
+
+```python
+# build_snapshot.py
+from daytona import CreateSnapshotParams, Daytona, Image
+
+image = (
+    Image.debian_slim("3.13")
+    .run_commands(
+        "apt-get update && apt-get install -y nodejs npm",
+        "npm install -g @tigrisdata/cli @storagesdk/cli",
+    )
+    .add_local_file("entrypoint.sh", "/entrypoint.sh")
+    .add_local_file("mcp.json", "/etc/agent/mcp.json")
+    .run_commands("chmod +x /entrypoint.sh")
+)
+
+daytona = Daytona()  # reads DAYTONA_API_KEY
+daytona.snapshot.create(
+    CreateSnapshotParams(name="agent-runtime", image=image),
+    on_logs=print,
+)
+```
+
+The MCP config is one entry; point your agent framework at wherever it expects
+this file (for Claude Code, a `.mcp.json` in the workspace root):
+
+```json
+{
+  "mcpServers": {
+    "world": { "command": "storage", "args": ["mcp"] }
+  }
+}
+```
+
+Because the entrypoint exported `TIGRIS_BUCKET` as the fork, every tool the
+server offers (`download`, `upload`, `ls`, `snapshot_create`) is already aimed
+at the fork, and the fork-scoped key is what makes the aim binding.
+
+## Step 4: The harness: one fork, one key, one sandbox per run
+
+This is the complete per-run lifecycle: fork the world, mint a key that can see
+only the fork, boot the sandbox with those two facts in its environment, then
+promote or discard from the harness. The sandbox never holds credentials that
+can touch the base.
+
+```python
+# run.py
+import json
+import subprocess
+
+from daytona import CreateSandboxFromSnapshotParams, Daytona
+
+BASE_BUCKET = "agent-world"
+SNAPSHOT = "agent-runtime"
+
+
+def tigris(*args: str) -> str:
+    """Run a Tigris CLI command and return its stdout."""
+    return subprocess.run(
+        ["tigris", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def run_agent(run_id: str, command: str, validate) -> None:
+    fork = f"run-{run_id}"
+
+    # 1. Fork the world. Copy-on-write and metadata-only, so it is
+    #    constant-time at any bucket size.
+    tigris("buckets", "create", fork, "--fork-of", BASE_BUCKET)
+
+    # 2. Mint a key scoped to the fork. The secret is returned
+    #    exactly once, so capture it here.
+    key = json.loads(
+        tigris("access-keys", "create", f"sandbox-{run_id}", "--format", "json")
+    )
+    tigris("access-keys", "assign", key["id"], "-b", fork, "-r", "Editor")
+
+    # 3. Boot the sandbox already bound to its fork. These env vars
+    #    are the only credentials it will ever hold.
+    daytona = Daytona()
+    sandbox = daytona.create(
+        CreateSandboxFromSnapshotParams(
+            snapshot=SNAPSHOT,
+            env_vars={
+                "FORK": fork,
+                "TIGRIS_ACCESS_KEY_ID": key["id"],
+                "TIGRIS_SECRET_ACCESS_KEY": key["secret"],
+            },
+        )
+    )
+
+    try:
+        # 4. Run the agent through the entrypoint.
+        result = sandbox.process.exec(f"/entrypoint.sh {command}", timeout=3600)
+
+        # 5. Decide what the fork was worth, from the harness, never
+        #    the sandbox.
+        if result.exit_code == 0 and validate(fork):
+            # Snapshot the base for provenance, then promote the
+            # prefixes the run actually changed.
+            tigris("snapshots", "take", BASE_BUCKET)
+            tigris(
+                "cp", "-r",
+                f"t3://{fork}/workspace/",
+                f"t3://{BASE_BUCKET}/workspace/",
+            )
+
+        # Either way the fork goes away; deleting it frees only the
+        # deltas the run wrote.
+        tigris("rm", f"t3://{fork}", "-f")
+    finally:
+        # The run's credentials die with the run.
+        tigris("access-keys", "delete", key["id"], "--yes")
+        sandbox.delete()
+
+
+if __name__ == "__main__":
+    run_agent(
+        run_id="4187",
+        command="python -m agent",
+        validate=lambda fork: True,  # your eval suite goes here
+    )
+```
+
+`validate` is where your eval suite runs against the fork before anything
+touches the base: point it at `t3://{fork}` with the same scoped key. Failed
+runs cost you nothing but the deltas they wrote.
+
+## Optional: mount the fork instead of copying
+
+If you'd rather not copy even the working set, Daytona documents
+[mounting a Tigris bucket straight into the sandbox](https://www.daytona.io/docs/mount-external-storage#mount-a-tigris-bucket)
+with `mount-s3` and the `https://t3.storage.dev` endpoint. Bake `mount-s3` into
+the snapshot, replace the `tigris cp` line in the entrypoint with a mount of
+`${FORK}`, and the whole world shows up as a local directory. The fork-scoped
+key works unchanged, because `mount-s3` reads the same `AWS_*` variables the
+entrypoint already exports.
+
+## References
+
+- [Snapshots and forks on Tigris](/docs/buckets/snapshots-and-forks/)
+- [Tigris CLI](/docs/cli/)
+- [Tigris IAM and access keys](/docs/iam/manage-access-key/)
+- [Daytona documentation](https://www.daytona.io/docs)
+- [storagesdk](https://github.com/storagesdk/storagesdk)

--- a/docs/agents/agent-daytona.mdx
+++ b/docs/agents/agent-daytona.mdx
@@ -56,17 +56,24 @@ pulls the working set, and binds every storage tool to the fork.
 set -euo pipefail
 
 # 0. The harness set these three at sandbox creation. If any are
-#    missing, fail loudly now rather than partway through a run.
-: "${FORK:?}" "${TIGRIS_ACCESS_KEY_ID:?}" "${TIGRIS_SECRET_ACCESS_KEY:?}"
+#    missing, print which one and exit nonzero now, rather than
+#    failing partway through a run.
+: "${FORK:?FORK is not set}"
+: "${TIGRIS_ACCESS_KEY_ID:?TIGRIS_ACCESS_KEY_ID is not set}"
+: "${TIGRIS_SECRET_ACCESS_KEY:?TIGRIS_SECRET_ACCESS_KEY is not set}"
 
-# 1. The scoped key arrives as TIGRIS_ACCESS_KEY_ID and
-#    TIGRIS_SECRET_ACCESS_KEY (what storagesdk reads); mirror it
-#    to the AWS names the Tigris CLI reads.
+# 1. Set the AWS credential chain envvars so anything speaking the
+#    S3 API (the Tigris CLI, mount-s3, boto3) can reach Tigris.
+#    storagesdk reads the TIGRIS_* originals directly.
 export AWS_ACCESS_KEY_ID="${TIGRIS_ACCESS_KEY_ID}"
 export AWS_SECRET_ACCESS_KEY="${TIGRIS_SECRET_ACCESS_KEY}"
+export AWS_REGION=auto
+export AWS_ENDPOINT_URL_S3=https://t3.storage.dev
+export AWS_ENDPOINT_URL_IAM=https://iam.storage.dev
 
-# 2. Pull the working set only. Memory, run metadata, and artifacts
-#    stay in the fork and are read by key, never copied into the VM.
+# 2. Copy the working set to local disk so ordinary file tools
+#    (git, editors, build steps) can work on it. Memory, run
+#    metadata, and artifacts stay in the fork, read by key.
 tigris cp -r "t3://${FORK}/workspace/" /workspace/
 
 # 3. Bind every storage tool to the fork. Any `storage` command or
@@ -131,6 +138,7 @@ can touch the base.
 # run.py
 import json
 import subprocess
+from collections.abc import Callable
 
 from daytona import CreateSandboxFromSnapshotParams, Daytona
 
@@ -139,13 +147,31 @@ SNAPSHOT = "agent-runtime"
 
 
 def tigris(*args: str) -> str:
-    """Run a Tigris CLI command and return its stdout."""
+    """Run a Tigris CLI command and return its stdout.
+
+    check=True means a failing command raises CalledProcessError,
+    so a failed fork or key mint aborts the run before the sandbox
+    ever boots.
+    """
     return subprocess.run(
         ["tigris", *args], check=True, capture_output=True, text=True
     ).stdout
 
 
-def run_agent(run_id: str, command: str, validate) -> None:
+def validate(fork: str) -> bool:
+    """Decide whether the run's changes deserve promotion.
+
+    Point your eval suite at t3://{fork} using the same fork-scoped
+    key. Returns False until you implement it, so nothing reaches
+    the base bucket by accident.
+    """
+    # TODO: implement your own validation logic
+    return False
+
+
+def run_agent(
+    run_id: str, command: str, validate: Callable[[str], bool]
+) -> None:
     fork = f"run-{run_id}"
 
     # 1. Fork the world. Copy-on-write and metadata-only, so it is
@@ -202,13 +228,20 @@ if __name__ == "__main__":
     run_agent(
         run_id="4187",
         command="python -m agent",
-        validate=lambda fork: True,  # your eval suite goes here
+        validate=validate,
     )
 ```
 
-`validate` is where your eval suite runs against the fork before anything
-touches the base: point it at `t3://{fork}` with the same scoped key. Failed
-runs cost you nothing but the deltas they wrote.
+`validate` ships as a stub that returns `False`, so nothing is promoted until
+you wire your eval suite into it. Failed runs cost you nothing but the deltas
+they wrote.
+
+One deliberate asymmetry in the cleanup: the access key and the sandbox are
+deleted in `finally`, so they die even when the run crashes or times out, but
+the fork is only deleted on the happy path. A run that died mid-flight leaves
+its fork behind, with dead credentials, so you can inspect exactly what the
+agent did before it failed. Sweep old `run-*` buckets on whatever schedule suits
+you.
 
 ## Optional: mount the fork instead of copying
 

--- a/docs/agents/agent-langgraph.mdx
+++ b/docs/agents/agent-langgraph.mdx
@@ -1,0 +1,170 @@
+---
+id: agent-langgraph
+title: "Checkpoint LangGraph Agents on Tigris"
+---
+
+# Checkpoint LangGraph Agents on Tigris
+
+_[`langgraph-checkpoint-tigris`](https://pypi.org/project/langgraph-checkpoint-tigris/)
+is a LangGraph checkpoint saver. It stores each checkpoint as an immutable
+object in a Tigris bucket over the S3 API, and adds a zero-copy `fork()` that
+branches an agent's entire thread history by reference. That lets you test a
+change against real accumulated state instead of fixtures._
+
+## What a checkpointer does in LangGraph
+
+A LangGraph graph is a state machine. Each time it advances (a node runs, a tool
+returns, a message gets appended) the runtime can persist the graph's state as a
+**checkpoint**. Checkpoints are grouped by `thread_id`, so a thread is the full,
+ordered history of one conversation or task. That is where a LangGraph agent's
+memory lives. When the next request for `thread_id="cust-ana"` comes in, the
+runtime loads that thread's latest checkpoint and the agent picks up with its
+prior context, even after a process restart.
+
+The checkpointer is the storage behind this. LangGraph defines a
+`BaseCheckpointSaver` interface and ships savers for memory, SQLite, and
+Postgres. `TigrisSaver` implements the same interface, except it writes each
+checkpoint as an immutable, uniquely-keyed object in a Tigris bucket rather than
+rows in a database. It's the same interface, so you pass it as `checkpointer=`
+and your graph code stays the same.
+
+## Why back checkpoints with object storage
+
+For one agent on one machine, the saver you pick barely matters. It starts to
+matter when you run a fleet: many agents, or a multi-tenant platform where every
+tenant needs its own isolated state.
+
+Give each tenant or agent its own bucket and the isolation is a bucket boundary
+enforced by IAM, instead of a `WHERE tenant_id` you have to remember on every
+query. A leaked key is scoped to one bucket. Checkpoint reads and writes are
+plain S3 requests, so there's no connection pool to size or exhaust when traffic
+gets bursty and parallel. A bucket is one API call to create and costs nothing
+while it sits idle, so there's no stateful service to run and patch per tenant.
+And because Tigris serves objects close to the compute, an agent in another
+region reads its state locally rather than reaching back to a primary database.
+
+The catch: the saver finds a thread's latest checkpoint by listing objects, with
+no mutable pointer, so it needs strongly consistent reads. Use a Single-region
+or Multi-region bucket (see Prerequisites).
+
+## Prerequisites
+
+- **Python** 3.9+ and `pip`
+- A **Tigris account** with an access key (`tid_...` / `tsec_...`). Create one
+  with the [access key guide](/docs/iam/manage-access-key/).
+- A **Single-region or Multi-region** Tigris bucket. These give the strongly
+  consistent reads the saver needs to find the latest checkpoint. Global and
+  Dual-region buckets are only eventually consistent across regions.
+
+## 1. Install
+
+```bash
+pip install -U langgraph-checkpoint-tigris
+```
+
+## 2. Configure credentials
+
+The saver runs on `boto3` and reads the standard S3 environment variables. Point
+them at the Tigris endpoint:
+
+```bash
+AWS_ACCESS_KEY_ID=tid_your_access_key
+AWS_SECRET_ACCESS_KEY=tsec_your_secret_key
+AWS_ENDPOINT_URL_S3=https://t3.storage.dev
+```
+
+## 3. Use it as a checkpointer
+
+Pass a `TigrisSaver` as the `checkpointer=` for any compiled graph. Call
+`setup()` once to prepare the bucket layout; after that the graph writes a
+checkpoint for every thread as it runs.
+
+```python
+from langgraph.checkpoint.tigris import TigrisSaver
+
+with TigrisSaver.from_conn_string("my-agent-bucket") as checkpointer:
+    checkpointer.setup()
+    graph = build_graph().compile(checkpointer=checkpointer)
+
+    graph.invoke(
+        {"messages": [{"role": "user", "content": "hello"}]},
+        {"configurable": {"thread_id": "cust-ana"}},
+    )
+```
+
+The `thread_id` is the unit of memory. Reuse it on a later `invoke` and the
+conversation resumes from its last checkpoint; pass a new one and you get a
+fresh, isolated history. LangGraph's persistence features (conversation memory,
+human-in-the-loop interrupts, time-travel replay from an earlier checkpoint) all
+go through the saver, so they work the same way on Tigris.
+
+For async graphs, use `AsyncTigrisSaver` with `async with` and
+`await checkpointer.setup()`.
+
+## 4. Fork the whole agent for evaluation
+
+`fork()` branches the entire bucket (every thread, every checkpoint) by
+reference. It's O(1) and shares immutable blocks with the source, so the fork
+copies no data and returns immediately no matter how much history the bucket
+holds. Writes to the fork stay in the fork; the source is untouched. The source
+bucket has to be snapshot-enabled.
+
+```python
+from langgraph.checkpoint.tigris._fork import create_snapshot_bucket
+
+# One-time: make the production bucket snapshot-enabled.
+create_snapshot_bucket(checkpointer.client, "my-agent-bucket")
+
+# Branch prod into a throwaway bucket and point a candidate graph at it.
+fork = checkpointer.fork("my-agent-bucket-eval")
+candidate = build_graph(new_prompt).compile(checkpointer=fork)
+candidate.invoke(probe, {"configurable": {"thread_id": "cust-ana"}})
+
+# Writes land only in the fork. Drop it when you're done.
+```
+
+### Why this matters to LangGraph users
+
+Before you ship a prompt, model, or tool change, the thing you actually want to
+know is whether it helps on real conversations, not on fixtures you wrote to
+pass. Forking gives you a way to check. Fork production, point a candidate graph
+at the fork, and replay real threads through it. Every probe gets answered with
+the customer's actual history in context, because the fork inherited every
+checkpoint. Run a second fork as the baseline and compare the two.
+
+The same move covers debugging and experiments. To chase a bug, fork prod and
+step the one bad thread in isolation, with the exact state that produced it and
+no risk to live data. To compare variants, fork once per variant and run them in
+parallel for the storage cost of the shared source. Drop the forks afterward and
+nothing sticks around.
+
+On a Postgres-backed saver the closest equivalent is `pg_dump` and restore, and
+that cost grows with how much history you've accumulated. So in practice the
+eval quietly falls back to fixtures that don't look like production.
+
+### Pinning a fork to a point in time
+
+Tigris keeps snapshotting a snapshot-enabled bucket as it changes. By default
+`fork()` branches from the source's current state, but pass `snapshot_version`
+(a UNIX nanosecond timestamp) to branch from a past snapshot instead. That's how
+you ask "what would this thread have done last Tuesday" against the state as it
+was then:
+
+```python
+fork = checkpointer.fork(
+    "my-agent-bucket-debug",
+    snapshot_version="1751631910140685342",
+)
+```
+
+The checkpointer only forks and enables snapshots. It doesn't manage snapshots
+otherwise; to browse or restore them directly, use the Tigris snapshot API and
+dashboard.
+
+## References
+
+- [`langgraph-checkpoint-tigris` on PyPI](https://pypi.org/project/langgraph-checkpoint-tigris/)
+- [LangGraph documentation](https://langchain-ai.github.io/langgraph/)
+- [LangGraph persistence concepts](https://langchain-ai.github.io/langgraph/concepts/persistence/)
+- [Snapshots and forks on Tigris](/docs/buckets/snapshots-and-forks/)
+- [Tigris IAM and access keys](/docs/iam/manage-access-key/)

--- a/sidebars.js
+++ b/sidebars.js
@@ -449,6 +449,11 @@ const sidebars = {
                 },
                 {
                   type: "doc",
+                  label: "LangGraph",
+                  id: "agents/agent-langgraph",
+                },
+                {
+                  type: "doc",
                   label: "Weka",
                   id: "guides/weka",
                 },

--- a/sidebars.js
+++ b/sidebars.js
@@ -454,6 +454,11 @@ const sidebars = {
                 },
                 {
                   type: "doc",
+                  label: "Daytona",
+                  id: "agents/agent-daytona",
+                },
+                {
+                  type: "doc",
                   label: "Weka",
                   id: "guides/weka",
                 },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and sidebar navigation only; no application or infrastructure code changes.
> 
> **Overview**
> Adds two **AI & ML** integration guides under `docs/agents/` and wires them into **Guides → Integrations → AI & ML** in `sidebars.js`.
> 
> The **Daytona** page documents an end-to-end harness pattern: snapshot-enabled base bucket, per-run fork + fork-scoped access key, sandbox entrypoint (CLI/MCP/storagesdk), optional promotion after validation, and optional `mount-s3` instead of `tigris cp`.
> 
> The **LangGraph** page documents `langgraph-checkpoint-tigris` (`TigrisSaver` / `AsyncTigrisSaver`), S3 env setup, bucket consistency requirements, and zero-copy `fork()` for eval/debugging (including `snapshot_version`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb66637e08c5259d49c84f01f17809e6a6dca76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->