### PR TITLE
docs: refresh acceleration-gateway docs for open-source TAG

### DIFF
--- a/docs/acceleration-gateway/architecture.mdx
+++ b/docs/acceleration-gateway/architecture.mdx
@@ -38,13 +38,19 @@ and path:
 
 TAG supports AWS Signature Version 4 authentication in two modes:
 
-TAG forwards the client's original Authorization header as-is and adds
-cryptographically signed proxy headers so Tigris can validate both the client's
-identity and TAG's identity. TAG also performs local SigV4 validation using
-pre-derived signing keys learned from Tigris responses, enabling cache hits to
-be served without an upstream round-trip. Anonymous requests (missing auth) are
-forwarded to Tigris for authoritative handling (e.g., public bucket access),
-while malformed auth headers are rejected at TAG.
+- **Transparent proxy** (default, Tigris only): TAG forwards the client's
+  original Authorization header as-is and adds cryptographically signed proxy
+  headers so Tigris can validate both the client's identity and TAG's identity.
+  TAG also performs local SigV4 validation using pre-derived signing keys
+  learned from Tigris responses, enabling cache hits to be served without an
+  upstream round-trip.
+- **Signing mode** (any S3-compatible service): TAG validates the client's
+  signature against its local credential store and re-signs the request for the
+  upstream with the same credentials.
+
+Anonymous requests (missing auth) are forwarded upstream for authoritative
+handling (e.g., public bucket access), while malformed auth headers are rejected
+at TAG.
 
 See [Security and Access Control](security.mdx) for the full authentication
 flow.
@@ -90,12 +96,13 @@ checksum.
 
 ## Request forwarding
 
-TAG forwards client requests to Tigris as-is, preserving the original
-Authorization header. TAG adds four proxy headers so Tigris can validate the
-client's signature against the original host.
+In transparent proxy mode, TAG forwards client requests to Tigris as-is,
+preserving the original Authorization header. TAG adds four proxy headers so
+Tigris can validate the client's signature against the original host.
 
-No local credential store is needed. URL encoding is preserved exactly as
-received from the client.
+No local credential store is needed in this mode (signing mode validates against
+and re-signs from a local store). URL encoding is preserved exactly as received
+from the client.
 
 ## Request flows
 

--- a/docs/acceleration-gateway/benchmarks.md
+++ b/docs/acceleration-gateway/benchmarks.md
@@ -16,9 +16,9 @@ Benchmarks were run on Amazon EC2 using
 | Benchmark client | c6in.16xlarge | 64    | 128 GiB | —         | 100 Gbps |
 | TAG server       | i3en.24xlarge | 96    | 768 GiB | 60 TB SSD | 100 Gbps |
 
-TAG was run as a single instance via `native/run.sh`. During the benchmarks, TAG
-CPU usage stayed under 1200% and memory usage remained around 24 GB, leaving
-significant headroom on the server.
+TAG was run as a single instance via `deploy/native/run.sh`. During the
+benchmarks, TAG CPU usage stayed under 1200% and memory usage remained around 24
+GB, leaving significant headroom on the server.
 
 ## Results — warp
 

--- a/docs/acceleration-gateway/configuration.md
+++ b/docs/acceleration-gateway/configuration.md
@@ -12,23 +12,32 @@ variables. Environment variables take precedence over file configuration.
 
 ## Environment variables
 
-| Variable                   | Description                                                       | Default                 |
-| -------------------------- | ----------------------------------------------------------------- | ----------------------- |
-| `AWS_ACCESS_KEY_ID`        | Tigris access key (TAG's own credentials, not client credentials) | (required)              |
-| `AWS_SECRET_ACCESS_KEY`    | Tigris secret key                                                 | (required)              |
-| `TAG_CACHE_DISK_PATH`      | Path to cache data directory                                      | `/var/tmp/tag`          |
-| `TAG_CACHE_MAX_DISK_USAGE` | Max disk usage in bytes (0 = unlimited)                           | `0`                     |
-| `TAG_HTTP_PORT`            | HTTP listen port                                                  | `8080`                  |
-| `TAG_LOG_LEVEL`            | Log level: `debug`, `info`, `warn`, `error`                       | `info`                  |
-| `TAG_LOG_FORMAT`           | Log format: `json` or `console`                                   | `json`                  |
-| `TAG_TLS_CERT_FILE`        | Path to TLS certificate file (PEM format)                         | (none)                  |
-| `TAG_TLS_KEY_FILE`         | Path to TLS private key file (PEM format)                         | (none)                  |
-| `TAG_CACHE_GRPC_ADDR`      | Address for gRPC server                                           | `:9000`                 |
-| `TAG_CACHE_NODE_ID`        | Unique node identifier for cluster mode (clustering)              | (none)                  |
-| `TAG_CACHE_CLUSTER_ADDR`   | Address for memberlist gossip (clustering)                        | `:7000`                 |
-| `TAG_CACHE_ADVERTISE_ADDR` | Address advertised to other nodes (clustering)                    | (defaults to gRPC addr) |
-| `TAG_CACHE_SEED_NODES`     | Comma-separated seed nodes for cluster discovery (clustering)     | (none)                  |
-| `TAG_PPROF_ENABLED`        | Enable pprof endpoints (`true` or `1`)                            | `false`                 |
+| Variable                          | Description                                                       | Default                  |
+| --------------------------------- | ----------------------------------------------------------------- | ------------------------ |
+| `AWS_ACCESS_KEY_ID`               | Tigris access key (TAG's own credentials, not client credentials) | (required)               |
+| `AWS_SECRET_ACCESS_KEY`           | Tigris secret key                                                 | (required)               |
+| `TAG_UPSTREAM_ENDPOINT`           | Upstream S3 endpoint URL                                          | `https://t3.storage.dev` |
+| `TAG_TRANSPARENT_PROXY`           | Transparent proxy mode; set `false`/`0` for signing mode          | `true`                   |
+| `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                       | `100`                    |
+| `TAG_MAX_INFLIGHT_REQUESTS`       | Max concurrent S3 requests before shedding with 503 SlowDown      | `1024`                   |
+| `TAG_CACHE_DISK_PATH`             | Path to cache data directory                                      | `/var/tmp/tag`           |
+| `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                           | `0`                      |
+| `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)   | `24h`                    |
+| `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                   | `false`                  |
+| `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                          | `256`                    |
+| `TAG_CACHE_DELETE_BATCH_SIZE`     | File deletions processed per deletion-queue batch                 | `1000`                   |
+| `TAG_CACHE_RECOVERY_WORKERS`      | Parallel workers for startup file recovery                        | `16`                     |
+| `TAG_HTTP_PORT`                   | HTTP listen port                                                  | `8080`                   |
+| `TAG_LOG_LEVEL`                   | Log level: `debug`, `info`, `warn`, `error`                       | `info`                   |
+| `TAG_LOG_FORMAT`                  | Log format: `json` or `console`                                   | `json`                   |
+| `TAG_TLS_CERT_FILE`               | Path to TLS certificate file (PEM format)                         | (none)                   |
+| `TAG_TLS_KEY_FILE`                | Path to TLS private key file (PEM format)                         | (none)                   |
+| `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                           | `:9000`                  |
+| `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode (clustering)              | (none)                   |
+| `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip (clustering)                        | `:7000`                  |
+| `TAG_CACHE_ADVERTISE_ADDR`        | Address advertised to other nodes (clustering)                    | (defaults to gRPC addr)  |
+| `TAG_CACHE_SEED_NODES`            | Comma-separated seed nodes for cluster discovery (clustering)     | (none)                   |
+| `TAG_PPROF_ENABLED`               | Enable pprof endpoints (`true` or `1`)                            | `false`                  |
 
 `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are TAG's own Tigris credentials
 with read-only access to all buckets accessed through TAG (required). Clients
@@ -84,6 +93,12 @@ upstream:
   # Higher values improve throughput for cache-miss scenarios
   # Default: 100
   max_idle_conns_per_host: 100
+
+  # Transparent proxy mode forwards client requests as-is with proxy headers
+  # (Tigris only). Set to false for signing mode, which validates and re-signs
+  # requests and works with any S3-compatible endpoint.
+  # Default: true
+  transparent_proxy: true
 
 # Cache configuration
 cache:
@@ -165,8 +180,35 @@ deployments.
 
 ### Endpoint validation
 
-The upstream endpoint must match one of the allowed host patterns: `localhost`
-or `*.storage.dev`. TAG exits at startup if the endpoint does not match.
+The upstream endpoint must be a well-formed absolute `http://` or `https://` URL
+with a host. In **transparent proxy mode** (the default) the host must also
+match one of `localhost`, `*.tigris.dev`, or `*.storage.dev`; TAG exits at
+startup otherwise. **Signing mode** does not apply this allowlist and accepts
+any S3-compatible endpoint — see
+[Using TAG with other S3-compatible services](#using-tag-with-other-s3-compatible-services).
+
+### Using TAG with other S3-compatible services
+
+Signing mode re-signs requests with standard AWS SigV4, so it works against any
+S3-compatible endpoint (AWS S3, MinIO, Ceph, etc.), not just Tigris:
+
+```yaml
+upstream:
+  transparent_proxy: false
+  endpoint: "https://s3.us-east-1.amazonaws.com"
+  # Set the backend's region; the default "auto" only works with Tigris. AWS and
+  # other region-sensitive services reject signatures whose credential-scope
+  # region does not match the endpoint.
+  region: "us-east-1"
+```
+
+- Transparent proxy mode and its zero-config, no-double-auth experience are
+  Tigris-only. Third-party backends are supported on a best-effort,
+  community-supported basis.
+- The `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` credentials are the
+  credentials for that backend; clients must present the same credentials, and
+  they need permissions covering whatever operations clients perform (read-only
+  is insufficient if clients write).
 
 ### Cluster mode
 

--- a/docs/acceleration-gateway/deployment-guide.md
+++ b/docs/acceleration-gateway/deployment-guide.md
@@ -117,8 +117,10 @@ where the old one left off.
 application's. In Kubernetes, verify the secret exists:
 `kubectl get secret -n tag tag-credentials`
 
-**"invalid upstream endpoint"** — TAG only allows connections to `localhost` or
-`*.storage.dev`. Check `TAG_UPSTREAM_ENDPOINT`.
+**"invalid upstream endpoint"** — in transparent proxy mode TAG only allows
+`localhost`, `*.tigris.dev`, or `*.storage.dev`. Check `TAG_UPSTREAM_ENDPOINT`,
+or switch to signing mode (`TAG_TRANSPARENT_PROXY=false`) to use another
+S3-compatible endpoint.
 
 **"TLS certificate or key file not found"** — If either `TAG_TLS_CERT_FILE` or
 `TAG_TLS_KEY_FILE` is set, both must point to valid files.

--- a/docs/acceleration-gateway/docker.md
+++ b/docs/acceleration-gateway/docker.md
@@ -5,14 +5,20 @@ Run TAG using Docker Compose. For all configuration options, see the
 
 ## Prerequisites
 
-Clone the [tag-deploy](https://github.com/tigrisdata/tag-deploy) repository:
+Clone the [tigrisdata/tag](https://github.com/tigrisdata/tag) repository and
+switch to the deployment Compose directory:
 
 ```bash
-git clone https://github.com/tigrisdata/tag-deploy.git
-cd tag-deploy
+git clone https://github.com/tigrisdata/tag.git
+cd tag/deploy/docker
 ```
 
-Create a `.env` file in the `docker/` directory with your Tigris credentials:
+The examples below use the **released-image** Compose files (`*.release.yml`),
+which pull the published `tigrisdata/tag` image — nothing to build. (To build
+the image from source instead, use the plain Compose files in the repository's
+top-level `docker/` directory.)
+
+Create a `.env` file in this directory with your Tigris credentials:
 
 ```bash
 AWS_ACCESS_KEY_ID=your_access_key
@@ -26,18 +32,17 @@ use their own credentials directly.
 ## Single node
 
 ```bash
-cd docker
-docker compose up -d
+docker compose -f docker-compose.release.yml up -d
 ```
 
 TAG will be available at `http://localhost:8080`.
 
 ```bash
 # View logs
-docker compose logs -f tag
+docker compose -f docker-compose.release.yml logs -f tag
 
 # Stop
-docker compose down
+docker compose -f docker-compose.release.yml down
 ```
 
 ## Cluster mode
@@ -45,8 +50,7 @@ docker compose down
 Run 3 TAG nodes with an embedded distributed cache cluster:
 
 ```bash
-cd docker
-docker compose -f docker-compose-cluster.yml up -d
+docker compose -f docker-compose-cluster.release.yml up -d
 ```
 
 TAG endpoints:
@@ -60,19 +64,22 @@ cluster.
 
 ```bash
 # View logs
-docker compose -f docker-compose-cluster.yml logs -f
+docker compose -f docker-compose-cluster.release.yml logs -f
 
 # Stop and remove volumes
-docker compose -f docker-compose-cluster.yml down -v
+docker compose -f docker-compose-cluster.release.yml down -v
 ```
 
 ## Environment variables
 
-You can add optional environment variables to the `.env` file:
+You can add optional environment variables to the `.env` file. The
+released-image Compose files default to the `latest` published image; pin a
+specific release by setting `TAG_VERSION`:
 
 ```bash
 AWS_ACCESS_KEY_ID=your_access_key
 AWS_SECRET_ACCESS_KEY=your_secret_key
+TAG_VERSION=v1.11.0
 TAG_LOG_LEVEL=info
 ```
 
@@ -80,11 +87,12 @@ See the full [Configuration Reference](configuration.md) for all options.
 
 ## Upgrading
 
-Update the image tag in your `docker-compose.yml` and recreate the container:
+Set `TAG_VERSION` in your `.env` (or leave it unset to track `latest`), then
+pull and recreate:
 
 ```bash
-docker compose pull
-docker compose up -d
+docker compose -f docker-compose.release.yml pull
+docker compose -f docker-compose.release.yml up -d
 ```
 
 The cache volume is preserved across container recreations — TAG picks up the

--- a/docs/acceleration-gateway/index.mdx
+++ b/docs/acceleration-gateway/index.mdx
@@ -2,15 +2,15 @@
 title: Tigris Acceleration Gateway
 sidebar_label: Overview
 description:
-  Overview of Tigris Acceleration Gateway (TAG), an S3-compatible caching proxy
-  for Tigris object storage.
+  Overview of Tigris Acceleration Gateway (TAG), an open-source, S3-compatible
+  caching proxy for Tigris object storage.
 ---
 
 import TAGOverviewDiagram from "@site/src/components/diagrams/TAGOverviewDiagram";
 
 # TAG — Tigris Acceleration Gateway
 
-TAG is a high-performance S3-compatible caching proxy for
+TAG is a high-performance, **open-source** S3-compatible caching proxy for
 [Tigris object storage](https://www.tigrisdata.com). You deploy it between your
 application and Tigris, and it transparently caches objects on local NVMe
 storage — giving you sub-millisecond read latency without sacrificing S3 API
@@ -22,6 +22,14 @@ compatibility.
 
 You don't need to change any application code. Just point your S3 client at TAG
 instead of Tigris and your reads are automatically accelerated.
+
+:::info[Open source]
+
+TAG is free and open source under the Apache License 2.0. Browse the code,
+deployment manifests, and issues — or contribute — at
+[github.com/tigrisdata/tag](https://github.com/tigrisdata/tag).
+
+:::
 
 ## Why TAG
 
@@ -90,6 +98,9 @@ results, see [Benchmarks](./benchmarks).
 
 ## Key features
 
+- **Open source** — Apache 2.0 licensed. Self-host, inspect, and modify freely;
+  source and manifests at
+  [github.com/tigrisdata/tag](https://github.com/tigrisdata/tag).
 - **S3-compatible API** — Standard AWS SDKs, AWS CLI, or any S3-compatible
   library. Path-style addressing only.
 - **Transparent proxy** — TAG forwards your SigV4 credentials to Tigris as-is.

--- a/docs/acceleration-gateway/index.mdx
+++ b/docs/acceleration-gateway/index.mdx
@@ -147,11 +147,13 @@ see [Cache Control](./cache-control).
 
 ## Security
 
-Your clients sign requests with their own Tigris credentials, and TAG forwards
-them to Tigris as-is — it never sees or stores your secret keys. After a
-client's first request, TAG learns derived signing keys from Tigris (encrypted
-with AES-256-GCM), so it can validate subsequent requests locally without
-calling home.
+In transparent proxy mode (the default), your clients sign requests with their
+own Tigris credentials and TAG forwards them to Tigris as-is — it never sees or
+stores your secret keys. After a client's first request, TAG learns derived
+signing keys from Tigris (encrypted with AES-256-GCM), so it can validate
+subsequent requests locally without calling home. TAG can also run in signing
+mode, which validates and re-signs requests and works with any S3-compatible
+backend.
 
 For the full authentication flow, authorization lifecycle, and credential setup,
 see [Security and Access Control](./security).
@@ -164,3 +166,12 @@ connection stats.
 
 For the full metrics reference, PromQL examples, alerting recommendations, and
 scrape configuration, see [Metrics Reference](./metrics).
+
+## Open source
+
+TAG is open source under the
+[Apache License 2.0](https://github.com/tigrisdata/tag/blob/main/LICENSE). The
+source, deployment manifests, and issue tracker live at
+[github.com/tigrisdata/tag](https://github.com/tigrisdata/tag), and
+contributions are welcome — see
+[CONTRIBUTING.md](https://github.com/tigrisdata/tag/blob/main/CONTRIBUTING.md).

--- a/docs/acceleration-gateway/kubernetes.md
+++ b/docs/acceleration-gateway/kubernetes.md
@@ -10,11 +10,11 @@ options, see the [Configuration Reference](configuration.md).
 - `kubectl` configured to access the cluster
 - Tigris access key and secret key with read access to all buckets that will be
   accessed through TAG
-- Clone the [tag-deploy](https://github.com/tigrisdata/tag-deploy) repository:
+- Clone the [tigrisdata/tag](https://github.com/tigrisdata/tag) repository:
 
 ```bash
-git clone https://github.com/tigrisdata/tag-deploy.git
-cd tag-deploy
+git clone https://github.com/tigrisdata/tag.git
+cd tag
 ```
 
 ## Deploy
@@ -37,7 +37,7 @@ kubectl create secret generic tag-credentials \
 ### 3. Apply the manifests
 
 ```bash
-kubectl apply -k kubernetes/base/ -n tag
+kubectl apply -k deploy/kubernetes/base/ -n tag
 ```
 
 This deploys a 3-replica StatefulSet with:
@@ -59,7 +59,7 @@ kubectl exec -n tag tag-0 -- curl -s http://localhost:8080/health
 
 ## Kubernetes manifests
 
-The `kubernetes/base/` directory uses Kustomize:
+The `deploy/kubernetes/base/` directory uses Kustomize:
 
 | File                    | Description                                  |
 | ----------------------- | -------------------------------------------- |
@@ -72,14 +72,14 @@ The `kubernetes/base/` directory uses Kustomize:
 To customize the image version or other settings, create an overlay:
 
 ```yaml
-# kubernetes/overlays/production/kustomization.yaml
+# deploy/kubernetes/overlays/production/kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.8.0
+    newTag: v1.11.0
 ```
 
 ## Production considerations
@@ -142,7 +142,7 @@ Update the image tag in your Kustomize overlay or directly in the StatefulSet,
 then apply:
 
 ```bash
-kubectl apply -k kubernetes/overlays/production/ -n tag
+kubectl apply -k deploy/kubernetes/overlays/production/ -n tag
 ```
 
 The StatefulSet performs a rolling update by default — one pod at a time is

--- a/docs/acceleration-gateway/native.md
+++ b/docs/acceleration-gateway/native.md
@@ -24,7 +24,7 @@ binary to `/usr/local/bin`, and installs a default config to
 `/etc/tag/config.yaml`:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/tigrisdata/tag-deploy/main/native/install.sh | bash
+curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
 ```
 
 Verify the installation:

--- a/docs/acceleration-gateway/quickstart.mdx
+++ b/docs/acceleration-gateway/quickstart.mdx
@@ -7,6 +7,10 @@ Get TAG running in under 5 minutes. TAG caches your Tigris objects on local disk
 so repeated reads are served in microseconds instead of milliseconds — and you
 don't need to change any application code.
 
+TAG is open source under the Apache License 2.0 — the code and deployment
+manifests live at
+[github.com/tigrisdata/tag](https://github.com/tigrisdata/tag).
+
 ## Prerequisites
 
 You need a pair of Tigris credentials (`AWS_ACCESS_KEY_ID` /

--- a/docs/acceleration-gateway/quickstart.mdx
+++ b/docs/acceleration-gateway/quickstart.mdx
@@ -20,8 +20,8 @@ authenticate separately with their own credentials.
 <TabItem value="native" label="Native Binary" default>
 
 ```bash
-# Download and install TAG
-curl -sSL https://raw.githubusercontent.com/tigrisdata/tag-deploy/main/native/install.sh | bash
+# Download and install TAG (latest release)
+curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash
 
 # Set your Tigris credentials
 export AWS_ACCESS_KEY_ID=<your-access-key>
@@ -32,23 +32,25 @@ tag --config /etc/tag/config.yaml
 ```
 
 The install script auto-detects your OS (Linux/macOS) and architecture
-(amd64/arm64) and places the binary in `/usr/local/bin`.
+(amd64/arm64), places the binary in `/usr/local/bin`, and installs a default
+config at `/etc/tag/config.yaml`. To pin a specific release, use
+`https://tag-releases.t3.storage.dev/v1.11.0/install.sh`.
 
 </TabItem>
 <TabItem value="docker" label="Docker">
 
 ```bash
-git clone https://github.com/tigrisdata/tag-deploy.git
-cd tag-deploy
+git clone https://github.com/tigrisdata/tag.git
+cd tag/deploy/docker
 
-# Create docker/.env with credentials
-cat > docker/.env <<EOF
+# Create .env with credentials
+cat > .env <<EOF
 AWS_ACCESS_KEY_ID=your_access_key
 AWS_SECRET_ACCESS_KEY=your_secret_key
 EOF
 
-# Start TAG
-cd docker && docker compose up -d
+# Start TAG (pulls the published tigrisdata/tag image)
+docker compose -f docker-compose.release.yml up -d
 ```
 
 The Docker image (`tigrisdata/tag`) uses Alpine Linux, runs as a non-root user,
@@ -60,8 +62,8 @@ For cluster mode and more options, see the [Docker guide](docker.md).
 <TabItem value="kubernetes" label="Kubernetes">
 
 ```bash
-git clone https://github.com/tigrisdata/tag-deploy.git
-cd tag-deploy
+git clone https://github.com/tigrisdata/tag.git
+cd tag
 
 kubectl create namespace tag
 
@@ -70,7 +72,7 @@ kubectl create secret generic tag-credentials \
   --from-literal=AWS_ACCESS_KEY_ID=your_access_key \
   --from-literal=AWS_SECRET_ACCESS_KEY=your_secret_key
 
-kubectl apply -k kubernetes/base/ -n tag
+kubectl apply -k deploy/kubernetes/base/ -n tag
 ```
 
 This deploys a 3-replica StatefulSet with embedded caching, gossip-based cluster

--- a/docs/acceleration-gateway/security.mdx
+++ b/docs/acceleration-gateway/security.mdx
@@ -25,17 +25,22 @@ endpoint URL at TAG. TAG never sees or stores client secret keys.
 
 ### TAG's own credentials
 
-Your application must provide TAG with its own Tigris credentials via
-environment variables. These credentials must have read-only access to all
-buckets that clients will access through TAG:
+Your application must provide TAG with credentials via environment variables:
 
 ```bash
 export AWS_ACCESS_KEY_ID=<TAG's access key>
 export AWS_SECRET_ACCESS_KEY=<TAG's secret key>
 ```
 
-Both TAG's access key and client access keys must belong to the same Tigris
-organization.
+In **transparent proxy mode** (the default) these are TAG's own Tigris
+credentials, used only to sign proxy headers and perform background cache
+fetches — so **read-only** access to the cached buckets is sufficient, and TAG's
+access key must belong to the same Tigris organization as client access keys. In
+**signing mode** these credentials populate TAG's local credential store:
+clients authenticate with them and TAG re-signs every request with them, so they
+must carry whatever permissions clients need (read-only is not sufficient if
+clients write). See [Credential handling by mode](#credential-handling-by-mode)
+below.
 
 ## Authentication
 
@@ -50,6 +55,31 @@ signature in a single round-trip.
 TAG never sees client secret keys, client credentials do not need to be stored
 anywhere other than on the client, and Tigris retains full control over
 authorization decisions.
+
+### Signing mode
+
+Transparent proxy mode works only with Tigris (the `X-Tigris-Proxy-*` identity
+headers are meaningful only to Tigris). Set `TAG_TRANSPARENT_PROXY=false` (or
+`upstream.transparent_proxy: false`) to run **signing mode** instead, which
+works against any S3-compatible service — Tigris, AWS S3, MinIO, and others.
+
+In signing mode TAG validates the incoming request signature against its local
+credential store, then **re-signs** the request for the upstream with the **same
+access key and secret** and streams it on. It re-signs (rather than forwarding
+the original signature) because it may transform the request — this is _not_
+identity translation; the upstream sees the same identity as the client. Because
+TAG must know the secret for every access key it serves, clients must
+authenticate with the credentials in TAG's store (by default the
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` pair).
+
+### Credential handling by mode
+
+| Aspect                            | Transparent proxy (default)                                                | Signing mode                                                                                     |
+| --------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Upstream request signature        | Client's original signature, forwarded unchanged                           | Re-signed by TAG with the client's own credentials                                               |
+| Does TAG need client secret keys? | No — cache hits are validated locally using keys learned from Tigris       | Yes — the secret for each client access key must be in TAG's store                               |
+| Role of `AWS_*` credentials       | TAG's own identity: signs proxy headers and background fetches (read-only) | The store's contents: clients present them and TAG re-signs every request (reads **and** writes) |
+| Works with non-Tigris backends    | No (Tigris only)                                                           | Yes (any S3-compatible service)                                                                  |
 
 ## Local authentication
 
@@ -111,17 +141,23 @@ which knows TAG's key) can produce a valid proxy signature.
 
 ## Endpoint validation
 
-TAG validates the upstream endpoint at startup to prevent misconfiguration and
-SSRF attacks.
+TAG validates the upstream endpoint at startup. In **every mode** it must be a
+well-formed absolute `http://` or `https://` URL with a host.
 
-**Allowed hosts:**
+In **transparent proxy mode** (the default) the host must additionally be one of
+the following — the `X-Tigris-Proxy-*` identity headers are meaningful only to
+Tigris:
 
-| Pattern         | Example                  | Use case                |
-| --------------- | ------------------------ | ----------------------- |
-| `localhost`     | `http://localhost:8080`  | Development and testing |
-| `*.storage.dev` | `https://t3.storage.dev` | Tigris storage domains  |
+| Pattern         | Example                          | Use case                  |
+| --------------- | -------------------------------- | ------------------------- |
+| `localhost`     | `http://localhost:8080`          | Development and testing   |
+| `*.tigris.dev`  | `https://fly.storage.tigris.dev` | Tigris production domains |
+| `*.storage.dev` | `https://t3.storage.dev`         | Tigris storage domains    |
 
-Any other endpoint causes a fatal startup error.
+Any other host is a fatal startup error in transparent mode. **Signing mode**
+does not apply this allowlist — it can front any S3-compatible endpoint. TAG
+only ever forwards to the single operator-configured upstream (never a
+client-chosen one), so this is not an open proxy.
 
 ## Error mapping
 

--- a/docs/acceleration-gateway/tls.md
+++ b/docs/acceleration-gateway/tls.md
@@ -63,7 +63,7 @@ variables:
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.8.0
+    image: tigrisdata/tag:v1.11.0
     ports:
       - "8080:8080"
     environment:
@@ -135,7 +135,7 @@ Set the environment variables before starting TAG:
 ```bash
 export TAG_TLS_CERT_FILE=/path/to/cert.pem
 export TAG_TLS_KEY_FILE=/path/to/key.pem
-./native/run.sh start
+./deploy/native/run.sh start
 ```
 
 When TLS is enabled, test with:

--- a/docs/acceleration-gateway/usage.md
+++ b/docs/acceleration-gateway/usage.md
@@ -11,6 +11,15 @@ TAG works with any S3-compatible client. The only change you need to make is
 pointing the endpoint URL at TAG and enabling path-style addressing. Standard S3
 operations work as expected — this page covers the TAG-specific setup.
 
+:::info[Credentials by mode]
+
+In transparent proxy mode (the default), clients authenticate with their own
+Tigris credentials — TAG forwards the signature to Tigris and never stores
+client secrets. In signing mode, clients must use credentials known to TAG's
+credential store. See [Security and Access Control](./security) for details.
+
+:::
+
 ## AWS CLI
 
 Pass `--endpoint-url` with each command, or set up a named profile so you don't

--- a/docs/acceleration-gateway/usage.md
+++ b/docs/acceleration-gateway/usage.md
@@ -16,7 +16,7 @@ operations work as expected — this page covers the TAG-specific setup.
 In transparent proxy mode (the default), clients authenticate with their own
 Tigris credentials — TAG forwards the signature to Tigris and never stores
 client secrets. In signing mode, clients must use credentials known to TAG's
-credential store. See [Security and Access Control](./security) for details.
+credential store. See [Security and Access Control](security.mdx) for details.
 
 :::
 


### PR DESCRIPTION
Refreshes `docs/acceleration-gateway/` (source of tigrisdata.com/docs) now that TAG is open-sourced, consolidated into `tigrisdata/tag`, and `tag-deploy` is deprecated/archived. Content compared against the canonical repo docs (`tigrisdata/tag/docs`, `README`, `deploy/`).

Product name kept as **Acceleration Gateway** (staleness-only pass, no rename — the repo/README's "Access Gateway" discrepancy is left for you to reconcile separately).

## What changed (12 files)

**Install & deployment paths**
- All `tigrisdata/tag-deploy` references → `tigrisdata/tag` (`quickstart`, `native`, `docker`, `kubernetes`).
- Native install → the release-bucket one-liner: `curl -fsSL https://tag-releases.t3.storage.dev/latest/install.sh | bash`.
- Paths → `deploy/kubernetes/base/`, `deploy/native/`, `deploy/docker/`; Kubernetes apply is `kubectl apply -k deploy/kubernetes/base/`.
- Docker uses the released-image Compose (`*.release.yml`) with `TAG_VERSION`; distinguishes build-from-source.

**Signing mode / third-party S3 (biggest content gap)**
- Documented that **signing mode works with any S3-compatible endpoint** (AWS, MinIO, …), transparent mode stays Tigris-only.
- Fixed the self-contradicting "two modes" text in `architecture.mdx`.
- Added a **Credential handling by mode** table to `security.mdx`; corrected the credential model (re-signs with the *same* client identity — not translation; read-only only suffices in transparent mode).
- Added a **"Using TAG with other S3-compatible services"** section to `configuration.md` with the `region` caveat.

**Endpoint validation**
- Added `*.tigris.dev` and the transparent-mode-only qualifier in `security`, `configuration`, `deployment-guide`; noted signing mode isn't an open proxy.

**Configuration**
- Added missing env vars (`TAG_CACHE_TTL` 24h, `TAG_MAX_INFLIGHT_REQUESTS`, `TAG_CACHE_MAX_CONCURRENT_WRITES`, `TAG_TRANSPARENT_PROXY`, `TAG_UPSTREAM_ENDPOINT`, and more — names verified against source) and the `transparent_proxy` YAML field.

**Open source + versions**
- Added an **Apache 2.0 / github.com/tigrisdata/tag** section to the overview.
- Bumped hardcoded image tags `v1.8.0 → v1.11.0`.

## Verification
- ✅ No stale `tag-deploy`/old-path/old-version references remain (repo-wide grep).
- ✅ Env var names verified against `tigrisdata/tag/config/config.go`; CLI flags confirmed to still exist.
- ✅ `prettier --check` passes (pre-commit hook green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security behavior changes in this repo.
> 
> **Overview**
> Refreshes **Acceleration Gateway** documentation now that TAG lives in **`tigrisdata/tag`** and **`tag-deploy` is gone**. Install and deploy instructions point at the release install URL (`tag-releases.t3.storage.dev`), **`deploy/docker`**, **`deploy/kubernetes`**, and **`docker-compose*.release.yml`** with **`TAG_VERSION`** (e.g. **v1.11.0**).
> 
> The largest content update is **two auth modes**: **transparent proxy** (Tigris-only, default) vs **signing mode** (any S3-compatible backend). Docs add a credential comparison table, clarify that signing mode **re-signs with the same client identity** (not credential translation), and document **`TAG_TRANSPARENT_PROXY`**, endpoint allowlists (**`*.tigris.dev`** in transparent mode only), and a **third-party S3** YAML example including the **`region`** caveat.
> 
> The overview and quickstart now highlight **Apache 2.0** and GitHub; the configuration reference gains missing env vars and **`transparent_proxy`** in YAML. Usage adds a short note on credentials by mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bdf9f1e0209b803ca5fc62ef7965d4a5c446340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->