### PR TITLE
docs(acceleration-gateway): update TAG to v1.11.1 and document populate memory budget

### DIFF
--- a/docs/acceleration-gateway/configuration.md
+++ b/docs/acceleration-gateway/configuration.md
@@ -12,32 +12,33 @@ variables. Environment variables take precedence over file configuration.
 
 ## Environment variables
 
-| Variable                          | Description                                                       | Default                  |
-| --------------------------------- | ----------------------------------------------------------------- | ------------------------ |
-| `AWS_ACCESS_KEY_ID`               | Tigris access key (TAG's own credentials, not client credentials) | (required)               |
-| `AWS_SECRET_ACCESS_KEY`           | Tigris secret key                                                 | (required)               |
-| `TAG_UPSTREAM_ENDPOINT`           | Upstream S3 endpoint URL                                          | `https://t3.storage.dev` |
-| `TAG_TRANSPARENT_PROXY`           | Transparent proxy mode; set `false`/`0` for signing mode          | `true`                   |
-| `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                       | `100`                    |
-| `TAG_MAX_INFLIGHT_REQUESTS`       | Max concurrent S3 requests before shedding with 503 SlowDown      | `1024`                   |
-| `TAG_CACHE_DISK_PATH`             | Path to cache data directory                                      | `/var/tmp/tag`           |
-| `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                           | `0`                      |
-| `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)   | `24h`                    |
-| `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                   | `false`                  |
-| `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                          | `256`                    |
-| `TAG_CACHE_DELETE_BATCH_SIZE`     | File deletions processed per deletion-queue batch                 | `1000`                   |
-| `TAG_CACHE_RECOVERY_WORKERS`      | Parallel workers for startup file recovery                        | `16`                     |
-| `TAG_HTTP_PORT`                   | HTTP listen port                                                  | `8080`                   |
-| `TAG_LOG_LEVEL`                   | Log level: `debug`, `info`, `warn`, `error`                       | `info`                   |
-| `TAG_LOG_FORMAT`                  | Log format: `json` or `console`                                   | `json`                   |
-| `TAG_TLS_CERT_FILE`               | Path to TLS certificate file (PEM format)                         | (none)                   |
-| `TAG_TLS_KEY_FILE`                | Path to TLS private key file (PEM format)                         | (none)                   |
-| `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                           | `:9000`                  |
-| `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode (clustering)              | (none)                   |
-| `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip (clustering)                        | `:7000`                  |
-| `TAG_CACHE_ADVERTISE_ADDR`        | Address advertised to other nodes (clustering)                    | (defaults to gRPC addr)  |
-| `TAG_CACHE_SEED_NODES`            | Comma-separated seed nodes for cluster discovery (clustering)     | (none)                   |
-| `TAG_PPROF_ENABLED`               | Enable pprof endpoints (`true` or `1`)                            | `false`                  |
+| Variable                          | Description                                                             | Default                  |
+| --------------------------------- | ----------------------------------------------------------------------- | ------------------------ |
+| `AWS_ACCESS_KEY_ID`               | Tigris access key (TAG's own credentials, not client credentials)       | (required)               |
+| `AWS_SECRET_ACCESS_KEY`           | Tigris secret key                                                       | (required)               |
+| `TAG_UPSTREAM_ENDPOINT`           | Upstream S3 endpoint URL                                                | `https://t3.storage.dev` |
+| `TAG_TRANSPARENT_PROXY`           | Transparent proxy mode; set `false`/`0` for signing mode                | `true`                   |
+| `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                             | `100`                    |
+| `TAG_MAX_INFLIGHT_REQUESTS`       | Max concurrent S3 requests before shedding with 503 SlowDown            | `1024`                   |
+| `TAG_CACHE_DISK_PATH`             | Path to cache data directory                                            | `/var/tmp/tag`           |
+| `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                                 | `0`                      |
+| `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)         | `24h`                    |
+| `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                         | `false`                  |
+| `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                                | `256`                    |
+| `TAG_CACHE_MAX_POPULATE_MEMORY`   | Aggregate memory budget (bytes) for concurrent cache-populate buffering | `1073741824` (1 GiB)     |
+| `TAG_CACHE_DELETE_BATCH_SIZE`     | File deletions processed per deletion-queue batch                       | `1000`                   |
+| `TAG_CACHE_RECOVERY_WORKERS`      | Parallel workers for startup file recovery                              | `16`                     |
+| `TAG_HTTP_PORT`                   | HTTP listen port                                                        | `8080`                   |
+| `TAG_LOG_LEVEL`                   | Log level: `debug`, `info`, `warn`, `error`                             | `info`                   |
+| `TAG_LOG_FORMAT`                  | Log format: `json` or `console`                                         | `json`                   |
+| `TAG_TLS_CERT_FILE`               | Path to TLS certificate file (PEM format)                               | (none)                   |
+| `TAG_TLS_KEY_FILE`                | Path to TLS private key file (PEM format)                               | (none)                   |
+| `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                 | `:9000`                  |
+| `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode (clustering)                    | (none)                   |
+| `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip (clustering)                              | `:7000`                  |
+| `TAG_CACHE_ADVERTISE_ADDR`        | Address advertised to other nodes (clustering)                          | (defaults to gRPC addr)  |
+| `TAG_CACHE_SEED_NODES`            | Comma-separated seed nodes for cluster discovery (clustering)           | (none)                   |
+| `TAG_PPROF_ENABLED`               | Enable pprof endpoints (`true` or `1`)                                  | `false`                  |
 
 `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are TAG's own Tigris credentials
 with read-only access to all buckets accessed through TAG (required). Clients
@@ -123,6 +124,19 @@ cache:
   # Max disk usage in bytes (0 = unlimited)
   # Default: 0
   max_disk_usage_bytes: 0
+
+  # Max concurrent cache-populate operations (upstream fetch + streaming write).
+  # When saturated, objects are still served from upstream, just not cached.
+  # Default: 256 (0 or unset = default; negative = disabled)
+  max_concurrent_writes: 256
+
+  # Aggregate memory budget for concurrent cache-populate buffering. Each populate
+  # reserves its object size, capped at the per-populate buffer ceiling, so many
+  # small objects populate concurrently while a burst of large objects is throttled
+  # to keep buffered memory bounded. This, rather than the raw count above, is what
+  # bounds populate memory; both limits apply.
+  # Default: 1073741824 (1 GiB) (0 or unset = default; negative = memory cap disabled)
+  max_populate_memory_bytes: 1073741824
 
   # Unique node identifier for cluster mode
   # Required for multi-node deployments

--- a/docs/acceleration-gateway/docker.md
+++ b/docs/acceleration-gateway/docker.md
@@ -79,7 +79,7 @@ specific release by setting `TAG_VERSION`:
 ```bash
 AWS_ACCESS_KEY_ID=your_access_key
 AWS_SECRET_ACCESS_KEY=your_secret_key
-TAG_VERSION=v1.11.0
+TAG_VERSION=v1.11.1
 TAG_LOG_LEVEL=info
 ```
 

--- a/docs/acceleration-gateway/kubernetes.md
+++ b/docs/acceleration-gateway/kubernetes.md
@@ -79,7 +79,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.11.0
+    newTag: v1.11.1
 ```
 
 ## Production considerations

--- a/docs/acceleration-gateway/quickstart.mdx
+++ b/docs/acceleration-gateway/quickstart.mdx
@@ -38,7 +38,7 @@ tag --config /etc/tag/config.yaml
 The install script auto-detects your OS (Linux/macOS) and architecture
 (amd64/arm64), places the binary in `/usr/local/bin`, and installs a default
 config at `/etc/tag/config.yaml`. To pin a specific release, use
-`https://tag-releases.t3.storage.dev/v1.11.0/install.sh`.
+`https://tag-releases.t3.storage.dev/v1.11.1/install.sh`.
 
 </TabItem>
 <TabItem value="docker" label="Docker">

--- a/docs/acceleration-gateway/tls.md
+++ b/docs/acceleration-gateway/tls.md
@@ -63,7 +63,7 @@ variables:
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.11.0
+    image: tigrisdata/tag:v1.11.1
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
Follows tigrisdata/tag#105, which bumped the same pins in the TAG repo.

## 1. Version pins pointed at a build with known issues

The docs pinned **v1.11.0**, which lacks two fixes shipped since:

- **tigrisdata/tag#99** — cache-populate memory was bounded by *count*, not bytes, which caused a production OOM → `/health` liveness restarts → 503s.
- **tigrisdata/tag#95** — ETag-versioned body keys, fixing truncated/empty bodies on concurrent read+write of frequently-updated objects.

Anyone following these docs would deploy the affected build, so:

| File | Was | Now |
|---|---|---|
| `kubernetes.md` | `newTag: v1.11.0` | `v1.11.1` |
| `docker.md` | `TAG_VERSION=v1.11.0` | `v1.11.1` |
| `tls.md` | `image: tigrisdata/tag:v1.11.0` | `v1.11.1` |
| `quickstart.mdx` | pinned `install.sh` example `v1.11.0` | `v1.11.1` |

The `latest` install URLs in `native.md` / `quickstart.mdx` already resolve to the newest release and are left as-is.

## 2. Config-reference gap

`TAG_CACHE_MAX_POPULATE_MEMORY` / `max_populate_memory_bytes` was **missing entirely** from the public docs. It's the knob that actually bounds cache-populate memory — a byte-unaware count alone can pin many GB under large-object fan-out — so it's exactly what an operator would reach for when tuning or responding to memory pressure.

- Added it to the **environment variables** table.
- Added it to the **Full configuration reference** YAML block, along with `max_concurrent_writes`, which was also missing there despite the section claiming to be complete.

## Verification

- `v1.11.1` exists on Docker Hub (pushed 2026-07-16T21:19Z) and `tag-releases.t3.storage.dev/v1.11.1/install.sh` → 200.
- Prettier clean (pre-commit hook passed).
- The Docusaurus build currently fails on `partner-integrations/api/{account,snapshots}` (`cant find current sidebar in context`) — I confirmed it **fails identically on clean `main`**, so it's pre-existing and unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code impact.
> 
> **Overview**
> Updates acceleration-gateway docs so deployment examples point at **TAG v1.11.1** instead of **v1.11.0** (Docker `TAG_VERSION`, Kustomize `newTag`, TLS compose image, and pinned install URL in quickstart).
> 
> Documents **`TAG_CACHE_MAX_POPULATE_MEMORY`** / **`max_populate_memory_bytes`** (default 1 GiB) in the env table and full YAML reference, including how it works with **`max_concurrent_writes`** to cap cache-populate buffering. The env-vars table column alignment is adjusted for the new row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeffb463d544bfbbb5bd03971dcfa409a0a35e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->