### PR TITLE
docs: point CLI install scripts to storage monorepo

### DIFF
--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -24,14 +24,14 @@ Tigris resources such as buckets, objects, access keys, and IAM policies.
           <div>
 
             ```bash
-            curl -fsSL https://github.com/tigrisdata/cli/releases/latest/download/install.sh | sh
+            curl -fsSL https://raw.githubusercontent.com/tigrisdata/storage/main/packages/cli/scripts/install.sh | sh
             ```
 
           </div>
           <div>
 
             ```powershell
-            irm https://github.com/tigrisdata/cli/releases/latest/download/install.ps1 | iex
+            irm https://raw.githubusercontent.com/tigrisdata/storage/main/packages/cli/scripts/install.ps1 | iex
             ```
 
           </div>


### PR DESCRIPTION
## Summary

The Tigris CLI (`@tigrisdata/cli`) moved from the standalone repo `tigrisdata/cli` (now archived) into the `tigrisdata/storage` monorepo at `packages/cli`. This updates the docs to reference the new canonical install locations.

## Changes

- `docs/cli/index.mdx` — the standalone-binary install one-liners now fetch the install scripts from the monorepo:
  - macOS/Linux: `curl -fsSL https://raw.githubusercontent.com/tigrisdata/storage/main/packages/cli/scripts/install.sh | sh`
  - Windows: `irm https://raw.githubusercontent.com/tigrisdata/storage/main/packages/cli/scripts/install.ps1 | iex`

Homebrew (`brew install tigrisdata/tap/tigris`) and npm (`npm install -g @tigrisdata/cli`) commands are unchanged.

## Notes

- No `github.com/tigrisdata/cli` or `github.com/tigrisdata/agent-shell` repo hyperlinks existed in the docs, so nothing else needed updating. The agent-shell docs (`docs/ai/agent-shell/index.mdx`) only reference the npm package `@tigrisdata/agent-shell`, which is unchanged.
- Verified the edit passes Prettier.

Assisted-by: Claude Opus 4.8 via Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL updates with no runtime or security logic changes.
> 
> **Overview**
> Updates the **Native** install instructions in `docs/cli/index.mdx` so standalone CLI installers pull scripts from the `tigrisdata/storage` monorepo (`packages/cli/scripts/`) instead of the archived `tigrisdata/cli` GitHub releases URLs.
> 
> macOS/Linux and Windows one-liners now use `raw.githubusercontent.com/tigrisdata/storage/main/packages/cli/scripts/install.sh` and `install.ps1` respectively. Homebrew and npm install paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a7acaabd9e6a6249cc3a3ecf4b70fc0dba3eb25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->