### PR TITLE
Add RAGFlow integration guide

### DIFF
--- a/docs/guides/ragflow.md
+++ b/docs/guides/ragflow.md
@@ -1,0 +1,175 @@
+---
+description:
+  "Use Tigris as RAGFlow's storage backend: replace the bundled MinIO container
+  with globally distributed, zero-egress-fee object storage for your knowledge
+  base. Full config, single-bucket mode, and snapshots before re-ingestion."
+keywords:
+  [
+    ragflow,
+    ragflow storage backend,
+    ragflow s3,
+    ragflow minio alternative,
+    RAG knowledge base storage,
+    STORAGE_IMPL,
+    object storage,
+  ]
+---
+
+# RAGFlow on Tigris
+
+[RAGFlow](https://ragflow.io) is an open-source RAG engine: it parses your
+documents, chunks and embeds them, and serves grounded answers with citations.
+Everything it knows lives in its storage backend — the uploaded documents and
+the parsed artifacts derived from them. By default that backend is a MinIO
+container; set `STORAGE_IMPL=AWS_S3` and it speaks to any S3-compatible store
+instead.
+
+To use Tigris as RAGFlow's storage backend: set `STORAGE_IMPL=AWS_S3` in
+`docker/.env` and point the `s3` section of `service_conf.yaml.template` at
+`https://t3.storage.dev` with `region_name: auto` and
+`addressing_style: virtual`. The full configuration is below. Tigris is
+[documented in RAGFlow's own configuration docs](https://ragflow.io/docs/dev/configurations#s3-tigris)
+as a supported backend, and this guide is the Tigris-side walkthrough.
+
+## Why put your knowledge base on Tigris
+
+- **One less stateful service.** Drop the MinIO container from your compose file
+  entirely. Your corpus lives in a bucket that outlives the deployment, survives
+  host migrations, and needs no volume management.
+- **Re-ingestion is free.** Changing chunking or embedding settings means
+  RAGFlow re-reads the entire corpus. On Tigris there are
+  [no egress fees](https://www.tigrisdata.com/pricing/), so re-processing your
+  documents costs nothing in transfer, however often you tune.
+- **Snapshot before you re-parse.** Re-ingestion is RAGFlow's most destructive
+  routine operation. [Snapshots](/docs/snapshots/) make a bad re-parse a
+  rollback instead of a restore-from-backup, and [forks](/docs/forks/) let you
+  A/B two chunking configurations against zero-copy branches of the same corpus.
+- **Deployments anywhere, corpus in one place.** One global endpoint, served
+  from the region nearest each deployment. A staging instance on another cloud
+  reads the same bucket at local latency.
+
+## Prerequisites
+
+- Tigris **Access Key ID** and **Secret Access Key** (see the
+  [Access Key guide](/docs/iam/manage-access-key/#create-an-access-key)). When
+  creating the key, grant it **Editor** access to just the `ragflow` bucket —
+  single-bucket mode (below) means that's all RAGFlow needs.
+- A Tigris **bucket** with snapshots enabled:
+
+  ```bash
+  tigris buckets create ragflow --enable-snapshots
+  ```
+
+  An existing bucket can be switched to Snapshot under **Bucket Settings →
+  Storage Settings** in the Dashboard; see
+  [Bucket Snapshots and Forks](/docs/buckets/snapshots-and-forks/) for the
+  restrictions.
+
+- A [RAGFlow](https://ragflow.io/docs/dev/) deployment (Docker Compose in this
+  guide)
+
+## Configure RAGFlow
+
+Already running RAGFlow against its bundled MinIO with a corpus you want to
+keep? [Migrate the data to Tigris first](/docs/migration/minio/) — the
+shadow-bucket flow copies your objects without downtime — then switch the config
+below.
+
+Two files, both under `docker/` in your RAGFlow deployment.
+
+In `.env`, switch the storage implementation:
+
+```bash
+STORAGE_IMPL=AWS_S3
+```
+
+In `service_conf.yaml.template`, configure the `s3` section:
+
+```yaml
+s3:
+  access_key: "tid_YOUR_ACCESS_KEY"
+  secret_key: "tsec_YOUR_SECRET_KEY"
+  region_name: "auto"
+  endpoint_url: "https://t3.storage.dev"
+  bucket: "ragflow"
+  prefix_path: "data"
+  signature_version: "v4"
+  addressing_style: "virtual"
+```
+
+Three values are load-bearing:
+
+- `region_name` must be `auto`. (The field is `region_name`, not `region` —
+  RAGFlow's connector reads `region_name`.)
+- `addressing_style` must be `virtual`.
+- `bucket` + `prefix_path` enable **single-bucket mode**: RAGFlow's logical
+  buckets become prefixes under `ragflow/data/`, so the whole knowledge base
+  lives in one physical bucket. This is what makes a
+  [scoped access key](/docs/iam/manage-access-key/) practical — grant the key
+  that one bucket and RAGFlow can touch nothing else.
+
+With storage externalized, you can remove the `minio` service from
+`docker-compose-base.yml`.
+
+## Restart and verify
+
+```bash
+docker compose -f docker-compose.yml down
+docker compose -f docker-compose.yml up -d
+```
+
+Upload a document in the RAGFlow UI, then check it landed:
+
+```bash
+tigris ls ragflow/data/
+```
+
+You should see RAGFlow's objects under the prefix. If startup fails with a
+storage error, check `docker logs` for the ragflow server container:
+authentication errors usually mean the key pair, `SignatureDoesNotMatch` usually
+means `region_name` or `addressing_style` diverged from the values above.
+
+## Snapshot before re-ingestion
+
+Before changing chunking configuration, embedding models, or bulk-deleting a
+knowledge base, take a snapshot:
+
+```bash
+tigris snapshots take ragflow before-reingest
+```
+
+If the re-parse goes wrong, roll back by forking from the snapshot and pointing
+RAGFlow at the fork. Snapshots are read-only; the fork is a writable bucket
+restored to the state you captured:
+
+```bash
+# Find the snapshot version
+tigris snapshots list ragflow
+
+# Create a writable bucket from it
+tigris buckets create ragflow-restored --fork-of ragflow --source-snapshot <version>
+```
+
+Then set `bucket: "ragflow-restored"` in `service_conf.yaml.template` and
+restart.
+
+To compare two chunking configurations against the same corpus, fork the bucket
+and point a second RAGFlow instance at the fork:
+
+```bash
+tigris buckets create ragflow-experiment --fork-of ragflow
+```
+
+The second instance's config is identical except for
+`bucket: "ragflow-experiment"`. Forks are copy-on-write: instant regardless of
+corpus size, and unchanged documents share storage with the parent. Throw the
+experiment away when you've picked a winner.
+
+:::note
+
+The bucket holds your documents and parsed artifacts, but RAGFlow also keeps
+chunk metadata and vectors in its database and search engine. After rolling back
+the bucket, re-parse the affected knowledge bases so the index matches the
+restored corpus.
+
+:::

--- a/docs/guides/ragflow.md
+++ b/docs/guides/ragflow.md
@@ -42,8 +42,9 @@ as a supported backend, and this guide is the Tigris-side walkthrough.
   documents costs nothing in transfer, however often you tune.
 - **Snapshot before you re-parse.** Re-ingestion is RAGFlow's most destructive
   routine operation. [Snapshots](/docs/snapshots/) make a bad re-parse a
-  rollback instead of a restore-from-backup, and [forks](/docs/forks/) let you
-  A/B two chunking configurations against zero-copy branches of the same corpus.
+  rollback instead of a restore-from-backup, and [forks](/docs/forks/) give an
+  experiment its own zero-copy copy of the corpus to re-parse against, without
+  touching the original documents.
 - **Deployments anywhere, corpus in one place.** One global endpoint, served
   from the region nearest each deployment. A staging instance on another cloud
   reads the same bucket at local latency.
@@ -99,8 +100,11 @@ s3:
 
 Three values are load-bearing:
 
-- `region_name` must be `auto`. (The field is `region_name`, not `region` —
-  RAGFlow's connector reads `region_name`.)
+- `region_name` must be `auto`. The field is `region_name`, not `region`:
+  current RAGFlow connectors read `region_name` (the template's own commented
+  examples still show `region`, which those connectors ignore). If auth fails
+  with `SignatureDoesNotMatch` on an older release, check which key your
+  installed connector actually reads and set `auto` there.
 - `addressing_style` must be `virtual`.
 - `bucket` + `prefix_path` enable **single-bucket mode**: RAGFlow's logical
   buckets become prefixes under `ragflow/data/`, so the whole knowledge base
@@ -153,23 +157,29 @@ tigris buckets create ragflow-restored --fork-of ragflow --source-snapshot <vers
 Then set `bucket: "ragflow-restored"` in `service_conf.yaml.template` and
 restart.
 
-To compare two chunking configurations against the same corpus, fork the bucket
-and point a second RAGFlow instance at the fork:
+To test a different chunking or embedding configuration without risking your
+production corpus, fork the bucket and run a second RAGFlow instance against the
+fork:
 
 ```bash
 tigris buckets create ragflow-experiment --fork-of ragflow
 ```
 
 The second instance's config is identical except for
-`bucket: "ragflow-experiment"`. Forks are copy-on-write: instant regardless of
-corpus size, and unchanged documents share storage with the parent. Throw the
-experiment away when you've picked a winner.
+`bucket: "ragflow-experiment"`. The fork is copy-on-write, so it gives that
+instance a zero-copy copy of the same source documents — instant regardless of
+corpus size — to re-parse with different settings without touching the original.
+Note the fork isolates the **documents**, not the index: each RAGFlow instance
+builds its own chunk metadata and vectors (see below), so the second instance
+re-parses the corpus to produce its own index. Throw the experiment away when
+you've picked a winner.
 
 :::note
 
-The bucket holds your documents and parsed artifacts, but RAGFlow also keeps
-chunk metadata and vectors in its database and search engine. After rolling back
-the bucket, re-parse the affected knowledge bases so the index matches the
-restored corpus.
+A bucket snapshot or fork captures your documents and parsed artifacts, but not
+RAGFlow's database or search engine — where knowledge-base metadata, chunks, and
+vectors live. A bucket rollback or fork does not clone that index state: after
+either, re-parse the affected knowledge bases in the target instance so its
+index matches the bucket contents.
 
 :::

--- a/sidebars.js
+++ b/sidebars.js
@@ -462,6 +462,11 @@ const sidebars = {
                   label: "Weka",
                   id: "guides/weka",
                 },
+                {
+                  type: "doc",
+                  label: "RAGFlow",
+                  id: "guides/ragflow",
+                },
               ],
             },
             {


### PR DESCRIPTION
Adds `docs/guides/ragflow.md`: using Tigris as RAGFlow's storage backend in place of the bundled MinIO container.

- Full config: `STORAGE_IMPL=AWS_S3` plus the `service_conf.yaml.template` s3 block, with the three load-bearing values called out (`region_name: auto`, `addressing_style: virtual`, single-bucket mode via `bucket` + `prefix_path`)
- Scoped access key and snapshot-enabled bucket in prerequisites
- Snapshot-before-re-ingestion workflow, including the full rollback path (fork from snapshot, repoint config) and A/B testing chunking configs against a fork
- Note on RAGFlow state outside the bucket (DB/index) requiring re-parse after rollback
- Links to the MinIO shadow-bucket migration for existing deployments

Also registers the guide in `sidebars.js`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or application code impact.
> 
> **Overview**
> Adds **`docs/guides/ragflow.md`**, a walkthrough for using Tigris as RAGFlow’s S3 storage backend instead of bundled MinIO.
> 
> The guide covers **`STORAGE_IMPL=AWS_S3`**, the **`service_conf.yaml.template`** `s3` block (endpoint, **`region_name: auto`**, **`addressing_style: virtual`**, single-bucket mode via **`bucket` + `prefix_path`**), scoped keys, snapshot-enabled buckets, restart/verify steps, and links to MinIO migration for existing corpora.
> 
> It also documents **snapshot-before-re-ingestion**, rollback via fork-from-snapshot, and A/B testing with bucket forks, plus a note that RAGFlow’s DB/search index is outside the bucket and needs re-parse after rollback.
> 
> **`sidebars.js`** registers the page under **Guides → Integrations → AI & ML** as **RAGFlow**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa957778f88aba36433a9b260f2b3bd470b436db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->