### PR TITLE
docs(tag): update Acceleration Gateway docs for v1.12.0

### DIFF
--- a/docs/acceleration-gateway/cache-control.md
+++ b/docs/acceleration-gateway/cache-control.md
@@ -37,13 +37,38 @@ Cached objects are evicted through two mechanisms:
 
 - **TTL expiry** — Objects expire after the configured TTL (default 24 hours).
   The next request for an expired object triggers revalidation with Tigris.
-- **LRU eviction** — TAG tracks disk usage and when it approaches the
-  `max_disk_usage_bytes` limit, the least recently used objects are evicted to
-  keep disk usage below the watermark. Reads and writes continue normally — the
-  LRU mechanism works proactively in the background.
+- **Disk-cap eviction** — TAG tracks disk usage and when it approaches the
+  `max_disk_usage_bytes` limit, objects are evicted to keep disk usage below the
+  watermark. Reads and writes continue normally — eviction works proactively in
+  the background.
 
-If `max_disk_usage_bytes` is `0` (the default), LRU eviction is disabled and
-objects are only removed by TTL expiry or explicit invalidation.
+The eviction order is controlled by `eviction_policy`:
+
+- **`lru`** (default) — evict least-recently-used objects first.
+- **`fifo`** — evict oldest-written objects first. Better for write-once
+  workloads (e.g. dated parquet) where a rare read of an old object should not
+  keep it resident at the expense of newer, hotter data. Under LRU such a read
+  would refresh the object's recency and protect it from eviction; FIFO ignores
+  reads and evicts strictly by write order.
+
+If `max_disk_usage_bytes` is `0` (the default), disk-cap eviction is disabled
+(and `eviction_policy` has no effect); objects are only removed by TTL expiry or
+explicit invalidation.
+
+## Cache warming on write
+
+By default TAG populates the cache on reads (an object is cached the first time
+it is read). With `warm_on_write` enabled, a successful write also warms the
+cache: after a `PutObject`, `CompleteMultipartUpload`, or `CopyObject`, TAG
+triggers a background fetch of the object so a read soon after the write is a
+cache hit.
+
+This is **cache-warm-on-write** (write-around plus asynchronous warming), not
+strict write-through — the write still invalidates the cache, and the warm is a
+separate best-effort background fetch (deduplicated and shed under the cache
+populate budget). It costs one extra upstream GET per write, so it defaults off;
+enable it for write-then-read pipelines. `CompleteMultipartUpload` is only made
+hot this way, since TAG never sees the assembled multipart body.
 
 ## Automatic cache invalidation
 
@@ -53,6 +78,7 @@ TAG automatically invalidates cached objects when they are modified through TAG:
 - **DeleteObject** — cache entry deleted before forwarding the delete
 - **DeleteObjects** (bulk) — cache entries deleted for all keys in the request
 - **CopyObject** — cache entry deleted for the destination key
+- **CompleteMultipartUpload** — cache entry deleted for the completed object
 
 Objects modified directly on Tigris (bypassing TAG) remain in cache until they
 expire (default TTL: 24 hours) or are revalidated via `Cache-Control: no-cache`.

--- a/docs/acceleration-gateway/configuration.md
+++ b/docs/acceleration-gateway/configuration.md
@@ -12,33 +12,35 @@ variables. Environment variables take precedence over file configuration.
 
 ## Environment variables
 
-| Variable                          | Description                                                             | Default                  |
-| --------------------------------- | ----------------------------------------------------------------------- | ------------------------ |
-| `AWS_ACCESS_KEY_ID`               | Tigris access key (TAG's own credentials, not client credentials)       | (required)               |
-| `AWS_SECRET_ACCESS_KEY`           | Tigris secret key                                                       | (required)               |
-| `TAG_UPSTREAM_ENDPOINT`           | Upstream S3 endpoint URL                                                | `https://t3.storage.dev` |
-| `TAG_TRANSPARENT_PROXY`           | Transparent proxy mode; set `false`/`0` for signing mode                | `true`                   |
-| `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                             | `100`                    |
-| `TAG_MAX_INFLIGHT_REQUESTS`       | Max concurrent S3 requests before shedding with 503 SlowDown            | `1024`                   |
-| `TAG_CACHE_DISK_PATH`             | Path to cache data directory                                            | `/var/tmp/tag`           |
-| `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                                 | `0`                      |
-| `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)         | `24h`                    |
-| `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                         | `false`                  |
-| `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                                | `256`                    |
-| `TAG_CACHE_MAX_POPULATE_MEMORY`   | Aggregate memory budget (bytes) for concurrent cache-populate buffering | `1073741824` (1 GiB)     |
-| `TAG_CACHE_DELETE_BATCH_SIZE`     | File deletions processed per deletion-queue batch                       | `1000`                   |
-| `TAG_CACHE_RECOVERY_WORKERS`      | Parallel workers for startup file recovery                              | `16`                     |
-| `TAG_HTTP_PORT`                   | HTTP listen port                                                        | `8080`                   |
-| `TAG_LOG_LEVEL`                   | Log level: `debug`, `info`, `warn`, `error`                             | `info`                   |
-| `TAG_LOG_FORMAT`                  | Log format: `json` or `console`                                         | `json`                   |
-| `TAG_TLS_CERT_FILE`               | Path to TLS certificate file (PEM format)                               | (none)                   |
-| `TAG_TLS_KEY_FILE`                | Path to TLS private key file (PEM format)                               | (none)                   |
-| `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                 | `:9000`                  |
-| `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode (clustering)                    | (none)                   |
-| `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip (clustering)                              | `:7000`                  |
-| `TAG_CACHE_ADVERTISE_ADDR`        | Address advertised to other nodes (clustering)                          | (defaults to gRPC addr)  |
-| `TAG_CACHE_SEED_NODES`            | Comma-separated seed nodes for cluster discovery (clustering)           | (none)                   |
-| `TAG_PPROF_ENABLED`               | Enable pprof endpoints (`true` or `1`)                                  | `false`                  |
+| Variable                          | Description                                                                     | Default                  |
+| --------------------------------- | ------------------------------------------------------------------------------- | ------------------------ |
+| `AWS_ACCESS_KEY_ID`               | Tigris access key (TAG's own credentials, not client credentials)               | (required)               |
+| `AWS_SECRET_ACCESS_KEY`           | Tigris secret key                                                               | (required)               |
+| `TAG_UPSTREAM_ENDPOINT`           | Upstream S3 endpoint URL                                                        | `https://t3.storage.dev` |
+| `TAG_TRANSPARENT_PROXY`           | Transparent proxy mode; set `false`/`0` for signing mode                        | `true`                   |
+| `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                                     | `100`                    |
+| `TAG_MAX_INFLIGHT_REQUESTS`       | Max concurrent S3 requests before shedding with 503 SlowDown                    | `1024`                   |
+| `TAG_CACHE_DISK_PATH`             | Path to cache data directory                                                    | `/var/tmp/tag`           |
+| `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                                         | `0`                      |
+| `TAG_CACHE_EVICTION_POLICY`       | Eviction order when the disk cap is hit: `lru` or `fifo` (oldest-written first) | `lru`                    |
+| `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)                 | `24h`                    |
+| `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                                 | `false`                  |
+| `TAG_CACHE_WARM_ON_WRITE`         | Warm the cache after a successful write via a background fetch (`true`/`false`) | `false`                  |
+| `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                                        | `256`                    |
+| `TAG_CACHE_MAX_POPULATE_MEMORY`   | Aggregate memory budget (bytes) for concurrent cache-populate buffering         | `1073741824` (1 GiB)     |
+| `TAG_CACHE_DELETE_BATCH_SIZE`     | File deletions processed per deletion-queue batch                               | `1000`                   |
+| `TAG_CACHE_RECOVERY_WORKERS`      | Parallel workers for startup file recovery                                      | `16`                     |
+| `TAG_HTTP_PORT`                   | HTTP listen port                                                                | `8080`                   |
+| `TAG_LOG_LEVEL`                   | Log level: `debug`, `info`, `warn`, `error`                                     | `info`                   |
+| `TAG_LOG_FORMAT`                  | Log format: `json` or `console`                                                 | `json`                   |
+| `TAG_TLS_CERT_FILE`               | Path to TLS certificate file (PEM format)                                       | (none)                   |
+| `TAG_TLS_KEY_FILE`                | Path to TLS private key file (PEM format)                                       | (none)                   |
+| `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                         | `:9000`                  |
+| `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode (clustering)                            | (none)                   |
+| `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip (clustering)                                      | `:7000`                  |
+| `TAG_CACHE_ADVERTISE_ADDR`        | Address advertised to other nodes (clustering)                                  | (defaults to gRPC addr)  |
+| `TAG_CACHE_SEED_NODES`            | Comma-separated seed nodes for cluster discovery (clustering)                   | (none)                   |
+| `TAG_PPROF_ENABLED`               | Enable pprof endpoints (`true` or `1`)                                          | `false`                  |
 
 `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are TAG's own Tigris credentials
 with read-only access to all buckets accessed through TAG (required). Clients
@@ -124,6 +126,26 @@ cache:
   # Max disk usage in bytes (0 = unlimited)
   # Default: 0
   max_disk_usage_bytes: 0
+
+  # Eviction order when the disk cap is reached: "lru" (default) or "fifo".
+  # "fifo" evicts oldest-written objects first — better for write-once workloads
+  # (e.g. dated parquet) where a rare read of an old object should not keep it
+  # resident at the expense of newer, hotter data.
+  # NOTE: eviction only runs when max_disk_usage_bytes > 0. With no disk cap the
+  # cache is never evicted and this setting has no effect.
+  # Default: lru
+  eviction_policy: lru
+
+  # Warm the cache after a successful write (PutObject / CompleteMultipartUpload /
+  # CopyObject) by triggering a background full-object fetch, so a read soon after a
+  # write hits cache. This is cache-warm-on-write (write-around plus async warming),
+  # NOT strict write-through: the write still invalidates, and the warm is a
+  # separate, best-effort background fetch — deduplicated and shed under the cache
+  # populate budget. It costs one extra upstream GET per write, so it defaults off.
+  # An anonymous write warms with an unsigned fetch, so the object is cached as
+  # public-read only if it is genuinely publicly readable.
+  # Default: false
+  warm_on_write: false
 
   # Max concurrent cache-populate operations (upstream fetch + streaming write).
   # When saturated, objects are still served from upstream, just not cached.

--- a/docs/acceleration-gateway/docker.md
+++ b/docs/acceleration-gateway/docker.md
@@ -79,7 +79,7 @@ specific release by setting `TAG_VERSION`:
 ```bash
 AWS_ACCESS_KEY_ID=your_access_key
 AWS_SECRET_ACCESS_KEY=your_secret_key
-TAG_VERSION=v1.11.1
+TAG_VERSION=v1.12.0
 TAG_LOG_LEVEL=info
 ```
 

--- a/docs/acceleration-gateway/index.mdx
+++ b/docs/acceleration-gateway/index.mdx
@@ -113,6 +113,10 @@ results, see [Benchmarks](./benchmarks).
   the full object, so future ranges come from cache.
 - **Write-through invalidation** — Writes, deletes, and copies invalidate cache
   entries immediately.
+- **Cache warming on write** — Optionally (opt-in) warm the cache after a write
+  so a read soon after is a cache hit, ideal for write-then-read pipelines.
+- **Configurable eviction** — LRU or FIFO (oldest-written-first) eviction under
+  a disk cap; FIFO suits write-once workloads like dated parquet.
 - **Multi-node clustering** — Gossip discovery, consistent hashing, and gRPC
   routing for distributed caching across nodes.
 

--- a/docs/acceleration-gateway/kubernetes.md
+++ b/docs/acceleration-gateway/kubernetes.md
@@ -79,7 +79,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.11.1
+    newTag: v1.12.0
 ```
 
 ## Production considerations

--- a/docs/acceleration-gateway/metrics.md
+++ b/docs/acceleration-gateway/metrics.md
@@ -88,6 +88,22 @@ sum by (operation, result) (rate(tag_cache_operations_total[5m]))
 
 **Type:** Counter — number of range requests served from cached full objects.
 
+### tag_cache_size_bytes
+
+**Type:** Gauge — current logical size of **this node's** local cache in bytes
+(sum of stored object lengths). Per-node; sum across nodes for a cluster-wide
+total.
+
+```promql
+# Cluster-wide cache size
+sum(tag_cache_size_bytes)
+```
+
+The embedded cache also exports `ocache_disk_usage_bytes{type="total"}` (same
+logical size) and `ocache_segment_size_bytes` (physical on-disk segment bytes)
+directly; `tag_cache_size_bytes` is the stable, TAG-owned name for the logical
+size.
+
 ## Broadcast metrics
 
 ### tag_broadcast_shared_total
@@ -129,6 +145,12 @@ rate(tag_broadcast_shared_total[5m]) /
 ### tag_active_background_fetches
 
 **Type:** Gauge — currently active background fetches.
+
+### tag_warm_on_write_triggered_total
+
+**Type:** Counter — cache warms triggered by a successful write (when
+`cache.warm_on_write` is enabled). The warm's own outcome is recorded by the
+`tag_background_fetches_*` metrics.
 
 ```promql
 # Background fetch success rate

--- a/docs/acceleration-gateway/quickstart.mdx
+++ b/docs/acceleration-gateway/quickstart.mdx
@@ -38,7 +38,7 @@ tag --config /etc/tag/config.yaml
 The install script auto-detects your OS (Linux/macOS) and architecture
 (amd64/arm64), places the binary in `/usr/local/bin`, and installs a default
 config at `/etc/tag/config.yaml`. To pin a specific release, use
-`https://tag-releases.t3.storage.dev/v1.11.1/install.sh`.
+`https://tag-releases.t3.storage.dev/v1.12.0/install.sh`.
 
 </TabItem>
 <TabItem value="docker" label="Docker">

--- a/docs/acceleration-gateway/tls.md
+++ b/docs/acceleration-gateway/tls.md
@@ -63,7 +63,7 @@ variables:
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.11.1
+    image: tigrisdata/tag:v1.12.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
Updates the Acceleration Gateway docs for the TAG **v1.12.0** release — version bump plus the new features and config options.

## Version bump
`v1.11.1` → `v1.12.0` in the pinned image/version references: `kubernetes.md`, `tls.md`, `docker.md`, and the `quickstart.mdx` install URL.

## New config options
- **`eviction_policy`** (`TAG_CACHE_EVICTION_POLICY`) — `lru` (default) or `fifo` (oldest-written-first). Added to the env-var table, the YAML reference, and the **Cache eviction** section (LRU vs FIFO, with the write-once / dated-parquet rationale). Only applies when `max_disk_usage_bytes > 0`.
- **`warm_on_write`** (`TAG_CACHE_WARM_ON_WRITE`) — opt-in cache-warm-on-write. New **Cache warming on write** section clarifying it's write-around + async warming (not strict write-through) and that it's the only way `CompleteMultipartUpload` objects become hot.

## Other updates
- Added **CompleteMultipartUpload** to the automatic-invalidation list.
- Added metrics **`tag_cache_size_bytes`** and **`tag_warm_on_write_triggered_total`** (and noted the `ocache_disk_usage_bytes` equivalent).
- Added **Cache warming on write** and **Configurable eviction** to the key-features list.

Formatting verified with `prettier --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code impact.
> 
> **Overview**
> Updates Acceleration Gateway documentation for **TAG v1.12.0**, including pinned version references (`v1.11.1` → `v1.12.0` in Docker, Kubernetes, TLS, and quickstart install URL).
> 
> Documents new cache options **`eviction_policy`** (`TAG_CACHE_EVICTION_POLICY`, `lru` vs `fifo`) and **`warm_on_write`** (`TAG_CACHE_WARM_ON_WRITE`) in the configuration reference and a expanded **Cache eviction** section plus new **Cache warming on write** section (async warm after writes, not write-through).
> 
> Also adds **CompleteMultipartUpload** to automatic invalidation, **`tag_cache_size_bytes`** and **`tag_warm_on_write_triggered_total`** to the metrics reference, and brief feature bullets on the overview page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f60c62db3151b309b03cd204feb757dbe9e1683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->