### PR TITLE
Emphasize that specific object versions can be removed from snapshots

### DIFF
--- a/docs/snapshots/index.mdx
+++ b/docs/snapshots/index.mdx
@@ -7,8 +7,9 @@ A **snapshot** captures the state of an entire bucket at a specific point in
 time. Unlike per-object versioning which tracks individual objects, snapshots
 provide a consistent view of all objects in a bucket together.
 
-- Snapshots are immutable: once created, their contents change only if you
-  explicitly delete a specific object version.
+- Snapshots are read-only: once created, you can't add to or overwrite them. The
+  only way to alter a snapshot is to permanently delete a specific object
+  version.
 - Writes go to the live bucket; snapshots remain frozen.
 - Deletions in the live bucket don't affect prior snapshots.
 - Snapshots can seed a [fork](/docs/forks), an instant, isolated copy of a
@@ -23,12 +24,13 @@ snapshot captures references to the object versions. This makes creating
 snapshots fast O(1) operations regardless of bucket size, and snapshots do not
 impact performance.
 
-Once created, a snapshot cannot be changed. If you delete an object in the live
-bucket, it will still be in the snapshot. If you add an object to the live
-bucket, it will not be in the snapshot.
+Once created, a snapshot is read-only. Writes to the live bucket never modify
+it: if you delete an object in the live bucket, it will still be in the
+snapshot; if you add an object to the live bucket, it will not be in the
+snapshot.
 
-The one exception: you can explicitly delete a specific object version from a
-snapshot. This is the only way a snapshot's contents change after creation. See
+The only operation that alters a snapshot is permanently deleting a specific
+object version from it. See
 [supported object versioning APIs](/docs/buckets/snapshots-and-forks#supported-apis)
 for details.
 

--- a/docs/snapshots/index.mdx
+++ b/docs/snapshots/index.mdx
@@ -7,7 +7,8 @@ A **snapshot** captures the state of an entire bucket at a specific point in
 time. Unlike per-object versioning which tracks individual objects, snapshots
 provide a consistent view of all objects in a bucket together.
 
-- Snapshots are immutable: once created, they never change.
+- Snapshots are immutable: once created, their contents change only if you
+  explicitly delete a specific object version.
 - Writes go to the live bucket; snapshots remain frozen.
 - Deletions in the live bucket don't affect prior snapshots.
 - Snapshots can seed a [fork](/docs/forks), an instant, isolated copy of a
@@ -24,8 +25,12 @@ impact performance.
 
 Once created, a snapshot cannot be changed. If you delete an object in the live
 bucket, it will still be in the snapshot. If you add an object to the live
-bucket, it will not be in the snapshot. Snapshots are only deleted when all
-references to them are removed, like when you delete the bucket.
+bucket, it will not be in the snapshot.
+
+The one exception: you can explicitly delete a specific object version from a
+snapshot. This is the only way a snapshot's contents change after creation. See
+[supported object versioning APIs](/docs/buckets/snapshots-and-forks#supported-apis)
+for details.
 
 The same way you'd git tag a release, you can name your snapshot with a
 meaningful version and reference it from other tools.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or security impact.
> 
> **Overview**
> Updates the **Snapshots** overview (`docs/snapshots/index.mdx`) to describe snapshots as **read-only** rather than only “immutable,” and to spell out that the **only** way to change a snapshot is to **permanently delete a specific object version**.
> 
> The intro bullet and **How snapshots work** section are aligned: live-bucket writes still don’t affect snapshots, and the old note about snapshots being deleted only when references are removed is dropped in favor of the versioning-deletion model. A link to **supported object versioning APIs** on the snapshots-and-forks doc is added for the deletion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 325de20ba53fe75d5b9d3a1aa8f493e8d4c6ae69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->