### PR TITLE
docs(tag): document TAG_UPSTREAM_REGION env variable

### DIFF
--- a/docs/acceleration-gateway/configuration.md
+++ b/docs/acceleration-gateway/configuration.md
@@ -17,6 +17,7 @@ variables. Environment variables take precedence over file configuration.
 | `AWS_ACCESS_KEY_ID`               | Tigris access key (TAG's own credentials, not client credentials)               | (required)               |
 | `AWS_SECRET_ACCESS_KEY`           | Tigris secret key                                                               | (required)               |
 | `TAG_UPSTREAM_ENDPOINT`           | Upstream S3 endpoint URL                                                        | `https://t3.storage.dev` |
+| `TAG_UPSTREAM_REGION`             | Upstream region for SigV4 signing scope                                         | `auto`                   |
 | `TAG_TRANSPARENT_PROXY`           | Transparent proxy mode; set `false`/`0` for signing mode                        | `true`                   |
 | `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                                     | `100`                    |
 | `TAG_MAX_INFLIGHT_REQUESTS`       | Max concurrent S3 requests before shedding with 503 SlowDown                    | `1024`                   |


### PR DESCRIPTION
Follow-up to the v1.12.0 docs update (#507) and tigrisdata/tag#118.

The upstream region is now settable via the `TAG_UPSTREAM_REGION` env var (previously config-file-only via `upstream.region`), matching how the endpoint uses `TAG_UPSTREAM_ENDPOINT`. Adds the row to the Acceleration Gateway env-var table. Default remains `auto` (correct for Tigris; set a specific region for non-Tigris S3 endpoints in signing mode).

Formatting verified with `prettier --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior impact in this repo.
> 
> **Overview**
> Documents **`TAG_UPSTREAM_REGION`** in the Acceleration Gateway environment-variable table, alongside **`TAG_UPSTREAM_ENDPOINT`**.
> 
> The row describes the upstream region used for **SigV4 signing scope**, with default **`auto`** (same as `upstream.region` in the YAML reference). Operators can set a concrete region via env when using non-Tigris S3 endpoints in signing mode, without relying on config-file-only docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5244016eb9d4a3fc0e5ebdccc9b48b58eb5b8ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->