### PR TITLE
docs(tag): clarify cache hit/miss metric accounting

### DIFF
--- a/docs/acceleration-gateway/metrics.md
+++ b/docs/acceleration-gateway/metrics.md
@@ -60,11 +60,18 @@ histogram_quantile(0.99, sum(rate(tag_request_duration_seconds_bucket[5m])) by (
 
 ### tag_cache_hits_total
 
-**Type:** Counter — total number of cache hits.
+**Type:** Counter — every request served from cache, including range-from-cache
+hits and conditional 304 (Not Modified) responses. Recorded in lockstep with the
+`X-Cache: HIT` header.
 
 ### tag_cache_misses_total
 
-**Type:** Counter — total number of cache misses.
+**Type:** Counter — total number of cache misses (recorded in lockstep with
+`X-Cache: MISS`).
+
+These two counters count only `HIT` and `MISS`. `REVALIDATED` responses (object
+changed on upstream) are neither — they are tracked by the `tag_revalidations_*`
+metrics — and `BYPASS`/`DISABLED` requests are not counted at all.
 
 ### tag_cache_operations_total
 
@@ -76,7 +83,7 @@ histogram_quantile(0.99, sum(rate(tag_request_duration_seconds_bucket[5m])) by (
 | `result`    | Result: `hit`, `miss`, `success`, `error` |
 
 ```promql
-# Cache hit ratio
+# Cache hit ratio (of hit/miss decisions; excludes REVALIDATED)
 rate(tag_cache_hits_total[5m]) /
 (rate(tag_cache_hits_total[5m]) + rate(tag_cache_misses_total[5m]))
 


### PR DESCRIPTION
Mirrors tigrisdata/tag#120 in the Acceleration Gateway metrics docs.

`tag_cache_hits_total` / `tag_cache_misses_total` are now recorded in lockstep with the `X-Cache` header and count only `HIT`/`MISS`:
- hits include range-from-cache hits and conditional 304 responses;
- `REVALIDATED` (object changed on upstream) is neither — it's tracked by `tag_revalidations_*`;
- `BYPASS`/`DISABLED` requests aren't counted.

Also notes on the hit-ratio query that it excludes `REVALIDATED`.

Formatting verified with `prettier --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to metrics descriptions; no runtime or observability behavior changes in this repo.
> 
> **Overview**
> Updates **Acceleration Gateway** cache metrics docs in `metrics.md` to match TAG behavior (tigrisdata/tag#120).
> 
> **`tag_cache_hits_total`** and **`tag_cache_misses_total`** are documented as incrementing in lockstep with **`X-Cache: HIT`** and **`X-Cache: MISS`**. Hits explicitly include range-from-cache and conditional **304** responses.
> 
> A new note clarifies that only **HIT**/**MISS** are counted: **`REVALIDATED`** belongs under **`tag_revalidations_*`**, and **BYPASS**/**DISABLED** requests are excluded.
> 
> The sample **cache hit ratio** PromQL comment now states the ratio is over hit/miss decisions and **excludes REVALIDATED**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b22b304d5a3b150a8e20123141f180ca4162f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->