### PR TITLE
docs(acceleration-gateway): add serve-locality metric, bump to v1.14.0

### DIFF
--- a/docs/acceleration-gateway/docker.md
+++ b/docs/acceleration-gateway/docker.md
@@ -79,7 +79,7 @@ specific release by setting `TAG_VERSION`:
 ```bash
 AWS_ACCESS_KEY_ID=your_access_key
 AWS_SECRET_ACCESS_KEY=your_secret_key
-TAG_VERSION=v1.12.0
+TAG_VERSION=v1.14.0
 TAG_LOG_LEVEL=info
 ```
 

--- a/docs/acceleration-gateway/kubernetes.md
+++ b/docs/acceleration-gateway/kubernetes.md
@@ -79,7 +79,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.12.0
+    newTag: v1.14.0
 ```
 
 ## Production considerations

--- a/docs/acceleration-gateway/metrics.md
+++ b/docs/acceleration-gateway/metrics.md
@@ -108,9 +108,12 @@ cross-node data-plane cost. Single-node mode is always `local`.
 | `locality` | `local` (this node owns the key) or `remote` (pulled from a peer) |
 
 ```promql
-# Remote serve ratio (fraction of cache reads pulled cross-node; lower is better)
-rate(tag_cache_serve_locality_total{locality="remote"}[5m]) /
-rate(tag_cache_serve_locality_total[5m])
+# Remote serve ratio (fraction of cache reads pulled cross-node; lower is better).
+# Aggregate with sum() so the denominator is local+remote; dividing the raw
+# vectors would match locality="remote" against itself and always report 1.
+sum(rate(tag_cache_serve_locality_total{locality="remote"}[5m]))
+/
+sum(rate(tag_cache_serve_locality_total[5m]))
 
 # Cross-node read rate per node
 sum by (pod) (rate(tag_cache_serve_locality_total{locality="remote"}[5m]))

--- a/docs/acceleration-gateway/metrics.md
+++ b/docs/acceleration-gateway/metrics.md
@@ -95,6 +95,30 @@ sum by (operation, result) (rate(tag_cache_operations_total[5m]))
 
 **Type:** Counter — number of range requests served from cached full objects.
 
+### tag_cache_serve_locality_total
+
+**Type:** Counter — cache body reads labeled by whether this node owns the key
+(`locality="local"`, served from local storage) or had to pull it from a peer
+over gRPC (`locality="remote"`). In a cluster the single-owner consistent-hash
+ring routes most reads to the owning node, so a high `remote` share is the
+cross-node data-plane cost. Single-node mode is always `local`.
+
+| Label      | Description                                                       |
+| ---------- | ----------------------------------------------------------------- |
+| `locality` | `local` (this node owns the key) or `remote` (pulled from a peer) |
+
+```promql
+# Remote serve ratio (fraction of cache reads pulled cross-node; lower is better)
+rate(tag_cache_serve_locality_total{locality="remote"}[5m]) /
+rate(tag_cache_serve_locality_total[5m])
+
+# Cross-node read rate per node
+sum by (pod) (rate(tag_cache_serve_locality_total{locality="remote"}[5m]))
+```
+
+Only populated when the embedded cache client can report key ownership (cluster
+mode). When it cannot, the counter stays at 0 rather than guessing a locality.
+
 ### tag_cache_size_bytes
 
 **Type:** Gauge — current logical size of **this node's** local cache in bytes

--- a/docs/acceleration-gateway/quickstart.mdx
+++ b/docs/acceleration-gateway/quickstart.mdx
@@ -38,7 +38,7 @@ tag --config /etc/tag/config.yaml
 The install script auto-detects your OS (Linux/macOS) and architecture
 (amd64/arm64), places the binary in `/usr/local/bin`, and installs a default
 config at `/etc/tag/config.yaml`. To pin a specific release, use
-`https://tag-releases.t3.storage.dev/v1.12.0/install.sh`.
+`https://tag-releases.t3.storage.dev/v1.14.0/install.sh`.
 
 </TabItem>
 <TabItem value="docker" label="Docker">

--- a/docs/acceleration-gateway/tls.md
+++ b/docs/acceleration-gateway/tls.md
@@ -63,7 +63,7 @@ variables:
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.12.0
+    image: tigrisdata/tag:v1.14.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## Summary

Documents TAG v1.14.0's new metric and refreshes version references.

- **New metric** `tag_cache_serve_locality_total{locality="local"|"remote"}` in the metrics reference — makes the cross-node cache data-plane cost visible on dashboards. In a cluster the single-owner consistent-hash ring routes most reads to the owning node, so a high `remote` share is the cost of pulling bodies from peers over gRPC. Mirrors the entry in the TAG repo's `docs/metrics.md`.
- **Version bump** `v1.12.0` → `v1.14.0` across the acceleration-gateway docs (kubernetes, tls, docker, quickstart).

In production this metric reads ~87% remote on the 7-node cluster, matching the ~6/7 single-owner-ring prediction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (metric reference and version strings); no runtime or security behavior is modified in this repo.
> 
> **Overview**
> **TAG v1.14.0** is reflected in deployment examples: pinned **`TAG_VERSION`**, Kustomize **`newTag`**, Docker **`image`**, and the quickstart install URL all move from **`v1.12.0`** to **`v1.14.0`**.
> 
> The **[metrics reference](metrics.md)** adds **`tag_cache_serve_locality_total`** with `locality="local"|"remote"` so operators can see whether cache body reads hit local storage or are pulled from a peer over gRPC. It includes PromQL for remote-serve ratio (with **`sum()`** so the ratio is correct) and per-pod cross-node read rate, plus a note that the counter is only meaningful in cluster mode when ownership can be reported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29cd437a785cead01bfedddaf409e263002b94a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->