### PR TITLE
fix typos, grammar, and broken markup

### DIFF
--- a/docs/buckets/cors.md
+++ b/docs/buckets/cors.md
@@ -33,7 +33,7 @@ And for HTTP `GET` access you want to allow it from all the origins.
 
 You can achieve this behavior by specifying CORS rules. Tigris will serve the
 CORS headers according to the defined CORS rules, instructing modern web
-browsers to adhere security practices.
+browsers to adhere to security practices.
 
 Below is an example of a CORS configuration that achieves the desired behavior:
 

--- a/docs/buckets/object-notifications.md
+++ b/docs/buckets/object-notifications.md
@@ -32,11 +32,11 @@ Tigris supports basic authentication and token authentication for webhooks. When
 configuring the webhook in the Tigris Dashboard, you can choose the
 authentication type and provide the necessary credentials.
 
-For basic authentication, the header will set as follows:
+For basic authentication, the header will be set as follows:
 
 `Authorization: Basic <base64 encoded username:password>`
 
-For token authentication, the header will set as follows:
+For token authentication, the header will be set as follows:
 
 `Authorization: Bearer <token>`
 

--- a/docs/buckets/settings/index.mdx
+++ b/docs/buckets/settings/index.mdx
@@ -156,7 +156,7 @@ your source bucket in sync with Tigris.
 ![TTL Configuration](./ttl-configuration.webp)
 
 You can set the default time-to-live (TTL) for objects in the bucket. This is
-useful for buckets that contain ephmemeral data that should be deleted after a
+useful for buckets that contain ephemeral data that should be deleted after a
 certain period of time. For more information see the
 [Object Expiration](/docs/buckets/objects-expiration/) documentation.
 

--- a/docs/buckets/sharing.md
+++ b/docs/buckets/sharing.md
@@ -90,7 +90,7 @@ organization. The sharing is limited to access keys from the other organization.
 To share a bucket with users from another organization:
 
 - Receive the access key ID (starts with `tid_`) from the user outside your
-  organization you want to share the bucket.
+  organization you want to share the bucket with.
 - Go to the [Tigris Dashboard](https://console.storage.dev).
 - Click on the bucket you want to share.
 - Click on the `Share` button.

--- a/docs/buckets/soft-delete.md
+++ b/docs/buckets/soft-delete.md
@@ -103,7 +103,7 @@ moves to a soft-deleted state where it is hidden from your normal bucket list
 but stays recoverable until the retention window expires.
 
 The buckets page in the Tigris Dashboard has a segmented control above the list
-with an **All buckets**, **Own by me**, and **Deleted buckets** segment. The
+with an **All buckets**, **Owned by me**, and **Deleted buckets** segment. The
 **Deleted buckets** segment is where every bucket that was deleted while soft
 delete was enabled shows up — each row in this view represents a soft-deleted
 bucket that is still within its retention window.

--- a/docs/cli/access-keys/rotate.mdx
+++ b/docs/cli/access-keys/rotate.mdx
@@ -3,8 +3,14 @@
 Rotate an access key's secret. The current secret is immediately invalidated and
 a new one is returned.
 
-:::warning The new secret is shown only once. Store it immediately — it cannot
-be retrieved again. ::: **Alias:** `r`
+:::warning
+
+The new secret is shown only once. Store it immediately — it cannot be retrieved
+again.
+
+:::
+
+**Alias:** `r`
 
 ## Usage
 
@@ -18,7 +24,3 @@ t3 keys r <id> [flags]
 | Name               | Required | Default | Description              |
 | ------------------ | -------- | ------- | ------------------------ |
 | `--yes`, `--force` | No       | —       | Skip confirmation prompt |
-
-```
-
-```

--- a/docs/concepts/authnz.md
+++ b/docs/concepts/authnz.md
@@ -63,7 +63,7 @@ used to determine the access level of the key.
 ### Role-Based-Access-Control (RBAC)
 
 The table below shows the operations that can be performed by the access key
-based on the role assigned to the it.
+based on the role assigned to it.
 
 | Operation                          | Admin | Editor | ReadOnly |
 | ---------------------------------- | ----- | ------ | -------- |

--- a/docs/iam/index.md
+++ b/docs/iam/index.md
@@ -15,8 +15,8 @@ attached to access keys, Tigris focuses on what developers really need.
   storage management.
 - Access keys can have directly attached policies. Tigris does not use IAM
   Users, IAM Groups, or IAM Roles.
-- All users in an Organization and can create access keys and attach IAM
-  policies to them.
+- All users in an Organization can create access keys and attach IAM policies to
+  them.
 
 ## Prebuilt Roles for Organization Members
 

--- a/docs/legal/data-processing.md
+++ b/docs/legal/data-processing.md
@@ -3,7 +3,7 @@
 _Last updated: November 18, 2025_
 
 Pursuant to the Tigris Subscription Agreement (“**the Agreement**”), Customer,
-on behalf of itself and its affiliates, and Tigris Data Inc. (referred in herein
+on behalf of itself and its affiliates, and Tigris Data Inc. (referred to herein
 as “**Vendor**”) (each a “**Party**”; collectively the “**Parties**”), the
 Parties hereby adopt this Data Processing Addendum (“**DPA**”) for so long as
 Vendor processes Personal Data on behalf of Customer. This DPA prevails over any
@@ -89,7 +89,7 @@ conflicting terms of the Agreement.
    1.9 “**SCCs**” means the clauses annexed to the EU Commission Implementing
    Decision 2021/914 of June 4, 2021 on standard contractual clauses for the
    transfer of personal data to third countries pursuant to Regulation (EU)
-   2016/679 of the European Parliament and of the Council , as amended or
+   2016/679 of the European Parliament and of the Council, as amended or
    replaced from time to time.
 
    1.10 “**UK Addendum**” means the addendum to the SCCs issued by the UK
@@ -144,7 +144,7 @@ conflicting terms of the Agreement.
    consistent with Customer’s obligations under applicable Privacy Laws.
 
    3.3 **Compliance Monitoring** - Customer has the right to monitor Vendor’s
-   compliance with this. DPA through measures, including, but not limited to,
+   compliance with this DPA through measures, including, but not limited to,
    ongoing manual reviews, automated scans, regular assessments, audits, or
    other annual technical and operational testing not more than once every 12
    months. Vendor shall cooperate fully with any audit initiated by Customer,
@@ -163,7 +163,7 @@ conflicting terms of the Agreement.
    commercially reasonable security procedures and practices, appropriate to the
    nature of the information, to protect Customer Personal Data from
    unauthorized access, destruction, use, modification, or disclosure. Without
-   limiting the forgoing, the Parties shall comply with the Security Measures
+   limiting the foregoing, the Parties shall comply with the Security Measures
    set forth at Appendix B when Processing Customer Personal Data.
 
 4. **Restrictions on Processing.**
@@ -372,7 +372,7 @@ conflicting terms of the Agreement.
      information.
    - Contact information (company, email, phone, physical address).
    - Any other category of Personal Data contained within the data, information,
-     and materials Customer submits to the Services or has Tigris Data(or
+     and materials Customer submits to the Services or has Tigris Data (or
      another third party) submit into the Services on its behalf.
 
 3. **Tigris Object Storage Service is not intended to meet any legal obligations

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -23,7 +23,7 @@ or about you or your devices from various sources, as described below.
   such as the names and email addresses of individuals who you would like to
   authorize to use our Services, as well as other relevant information we and
   our service providers may require to host your company's data on our Platform
-  or otherwise provide the Services. ‍
+  or otherwise provide the Services.
 - **Communications.** If you contact us directly, we receive additional
   information about you. For example, if you contact us for customer support, we
   may receive your name, email address, the contents of the message and any
@@ -31,7 +31,7 @@ or about you or your devices from various sources, as described below.
   If you subscribe to our newsletter, we will collect certain information from
   you, such as your name, company, and email address. When we send you emails,
   we may track whether you open them to learn how to deliver a better customer
-  experience and improve our Services. ‍
+  experience and improve our Services.
 - **Careers.** If you decide that you wish to apply for a job with us, you may
   submit your contact information and your resume online. We and our third-party
   service providers will collect the information you choose to provide on your
@@ -51,7 +51,7 @@ or about you or your devices from various sources, as described below.
   help us improve them, we automatically receive information about your
   interactions with our Services, like the pages or content you view and the
   dates and times of your visits.
-- ‍**Information from Cookies and Similar Technologies.** We and our third-party
+- **Information from Cookies and Similar Technologies.** We and our third-party
   partners collect information using cookies, pixel tags, or similar
   technologies. Our third-party partners, such as analytics and advertising
   partners, may use these technologies to collect information about your online
@@ -96,22 +96,22 @@ We use the information we collect:
 
 - **Affiliates.** We may share any information we receive with our affiliates
   for any of the purposes described in this Privacy Policy.
-- ‍Vendors and Service Providers. We may share any information we receive with
-  vendors and service providers retained in connection with the provision of our
-  Services.
+- **Vendors and Service Providers.** We may share any information we receive
+  with vendors and service providers retained in connection with the provision
+  of our Services.
 - **Analytics Partners.** We use analytics services such as Google Analytics to
   collect and process certain analytics data. These services may also collect
   information about your use of other websites, apps, and online resources. You
   can learn more about Google's practices by visiting
-  https://www.google.com/policies/privacy/partners/.
-- ‍**As Required By Law and Similar Disclosures.** We may access, preserve, and
+  [https://www.google.com/policies/privacy/partners/](https://www.google.com/policies/privacy/partners/).
+- **As Required By Law and Similar Disclosures.** We may access, preserve, and
   disclose your information if we believe doing so is required or appropriate
   to: (a) comply with law enforcement requests and legal process, such as a
   court order or subpoena; (b) respond to your requests; or (c) protect your,
   our, or others rights, property, or safety. For the avoidance of doubt, the
   disclosure of your information may occur if you post any objectionable content
   on or through the Services.
-- ‍**Merger, Sale, or Other Asset Transfers.** We may transfer your information
+- **Merger, Sale, or Other Asset Transfers.** We may transfer your information
   to service providers, advisors, potential transactional partners, or other
   third parties in connection with the consideration, negotiation, or completion
   of a corporate transaction in which we are acquired by or merged with another

--- a/docs/legal/service-terms.md
+++ b/docs/legal/service-terms.md
@@ -743,7 +743,7 @@ PARTICIPATE IN ANY CLASS ACTION OR REPRESENTATIVE PROCEEDING.
 
     20.7 **Arbitration Relief.** Except as provided in Section 20.8, the
     arbitrator can award any relief that would be available if the claims had
-    been brough in a court of competent jurisdiction. If the arbitrator awards
+    been brought in a court of competent jurisdiction. If the arbitrator awards
     you an amount higher than the last written settlement amount offered by
     Tigris Data before an arbitrator was selected, Tigris Data will pay to you
     the higher of: (a) the amount awarded by the arbitrator and (b) US$10,000.

--- a/docs/legal/sla.md
+++ b/docs/legal/sla.md
@@ -29,7 +29,7 @@ Tigris Data for the affected Services for the relevant calendar month
 corresponding with the Actual Availability provided (as a percentage of total
 time) for the relevant calendar month, as set forth in the table below.
 
-For requests to Standrad tier, and Archive tier, the following table applies:
+For requests to Standard tier, and Archive tier, the following table applies:
 
 | **Actual Availability**                            | **Credit Percentage** |
 | -------------------------------------------------- | --------------------- |

--- a/docs/libraries/lancedb/index.mdx
+++ b/docs/libraries/lancedb/index.mdx
@@ -180,7 +180,7 @@ const db = await lancedb.connect(`s3://${bucketName}/ml-datasets/food101`, {
 In this example, we connected to the path `s3://my-bucket/ml-datasets/food101`
 with the Tigris endpoint and region we specified. The `db` object is a handle to
 a LanceDB database stored remotely on Tigris. We’ve configured it to talk to
-Tigris instead of S3 by setting the the endpoint to Tigris’
+Tigris instead of S3 by setting the endpoint to Tigris’
 [`https://t3.storage.dev`](https://t3.storage.dev), so even though the path
 starts with `s3://`, it’s actually talking to Tigris.
 

--- a/docs/mcp/remote.mdx
+++ b/docs/mcp/remote.mdx
@@ -41,7 +41,7 @@ Run this command:
 claude mcp add --scope user --transport http tigris https://mcp.storage.dev/mcp
 ```
 
-Then run `claude` use the `/mcp` command to authenticate.
+Then run `claude` and use the `/mcp` command to authenticate.
 
 ### Cursor
 

--- a/docs/model-storage/fly-io.mdx
+++ b/docs/model-storage/fly-io.mdx
@@ -74,7 +74,7 @@ To build a custom variant of the image, you need these tools installed:
 - [Replicate's cog tool](https://github.com/replicate/cog)
 - [jq](https://jqlang.github.io/jq/)
 
-To install all of the tool depedencies at once, clone the template repo and run
+To install all of the tool dependencies at once, clone the template repo and run
 `brew bundle`.
 
 </details>

--- a/docs/model-storage/skypilot.mdx
+++ b/docs/model-storage/skypilot.mdx
@@ -85,7 +85,7 @@ To build a custom variant of the image, you need these tools installed:
 - [Replicate's cog tool](https://github.com/replicate/cog)
 - [jq](https://jqlang.github.io/jq/)
 
-To install all of the tool depedencies at once, clone the template repo and run
+To install all of the tool dependencies at once, clone the template repo and run
 `brew bundle`.
 
 </details>

--- a/docs/objects/upload-via-html-form.md
+++ b/docs/objects/upload-via-html-form.md
@@ -22,8 +22,8 @@ to AWS S3:
 
 - Due to Tigris being a globally accessible service with global replication, the
   region segment of the `X-Amz-Credential` is designated as `auto`.
-- Tigris supports only `public-read` and `private` ACLs at Object. Read more
-  about it [here](/docs/objects/acl/).
+- Tigris supports only `public-read` and `private` ACLs at the object level.
+  Read more about it [here](/docs/objects/acl/).
 - For signature verification, Tigris only supports AWS signature version 4.
 
 ## Example

--- a/docs/quickstarts/bufstream.mdx
+++ b/docs/quickstarts/bufstream.mdx
@@ -164,4 +164,4 @@ Bufstream now uses Tigris for:
 You can continue producing and consuming messages using `kafkactl` or integrate
 with your existing Kafka-compatible apps.
 
-:tada: Congratulations, you’ve successfully deployed Bufstream on Tigris.
+🎉 Congratulations, you’ve successfully deployed Bufstream on Tigris.

--- a/docs/quickstarts/ipython.mdx
+++ b/docs/quickstarts/ipython.mdx
@@ -11,7 +11,7 @@ To run it you will need the following:
 2. An [access keypair](https://storage.new/accesskey)
 3. A computer running Python 3.10 (or later) that has internet access (OS and
    CPU architecture does not matter)
-4. A tigris bucket
+4. A Tigris bucket
 5. The
    [uv python environment manager](https://docs.astral.sh/uv/getting-started/installation/)
 

--- a/docs/quickstarts/mcp.mdx
+++ b/docs/quickstarts/mcp.mdx
@@ -25,8 +25,7 @@ recommend reviewing the source code before employing this MCP server.
 
 ## Example Prompts
 
-Once the MCP Server is running, you can can issue natural-language commands such
-as:
+Once the MCP Server is running, you can issue natural-language commands such as:
 
 **Bucket actions**
 

--- a/docs/sdks/tigris/examples.mdx
+++ b/docs/sdks/tigris/examples.mdx
@@ -6,14 +6,14 @@ import TabItem from "@theme/TabItem";
 If you want to see it the Storage SDK used with your tool of choice, we have
 some ready examples available at
 [our community repo](https://github.com/tigrisdata-community/storage-sdk-examples).
-Something missing there that you you'd like to see? Let us know and we'll be
-more than happy to add in examples.
+Something missing there that you'd like to see? Let us know and we'll be more
+than happy to add in examples.
 
 ## Viewing and downloading files
 
 `get` function can be used to get a file from a bucket. `contentDisposition`
-option can be to either `attachment` or `inline` depending on whether you want
-to trigger a download or display the file in the browser.
+option can be set to either `attachment` or `inline` depending on whether you
+want to trigger a download or display the file in the browser.
 
 <Tabs>
 <TabItem value="server" label="Server" default>

--- a/docs/sdks/tigris/using-sdk.mdx
+++ b/docs/sdks/tigris/using-sdk.mdx
@@ -348,7 +348,7 @@ if (result.error) {
 ## Presigning an object
 
 `getPresignedUrl` function can be used to presign an object from a bucket and
-retreive the presigned URL.
+retrieve the presigned URL.
 
 ### `getPresignedUrl`
 

--- a/docs/snapshots/index.mdx
+++ b/docs/snapshots/index.mdx
@@ -4,7 +4,7 @@ import TabItem from "@theme/TabItem";
 # Snapshots
 
 A **snapshot** captures the state of an entire bucket at a specific point in
-time. Unlike per-object versioning which tracks individual objects, snapshots
+time. Unlike per-object versioning, which tracks individual objects, snapshots
 provide a consistent view of all objects in a bucket together.
 
 - Snapshots are read-only: once created, you can't add to or overwrite them. The
@@ -20,8 +20,8 @@ provide a consistent view of all objects in a bucket together.
 Traditional snapshots require deep copies of entire buckets, expensive O(n)
 operations that don't scale. Tigris is built on an append-only architecture
 where immutability is a core design principle. Instead of copying data, a
-snapshot captures references to the object versions. This makes creating
-snapshots fast O(1) operations regardless of bucket size, and snapshots do not
+snapshot captures references to the object versions. This makes snapshot
+creation a fast O(1) operation regardless of bucket size, and snapshots do not
 impact performance.
 
 Once created, a snapshot is read-only. Writes to the live bucket never modify
@@ -34,8 +34,8 @@ object version from it. See
 [supported object versioning APIs](/docs/buckets/snapshots-and-forks#supported-apis)
 for details.
 
-The same way you'd git tag a release, you can name your snapshot with a
-meaningful version and reference it from other tools.
+Just as you'd `git tag` a release, you can name your snapshot with a meaningful
+version and reference it from other tools.
 
 ## Billing
 

--- a/docs/training/big-data-skypilot/index.mdx
+++ b/docs/training/big-data-skypilot/index.mdx
@@ -28,7 +28,7 @@ leverages Tigris to store training data and SkyPilot to manage compute.
 - Accounts with your desired cloud providers (AWS, Lambda Labs, RunPod,
   Fluidstack, etc; we'll use AWS in this guide)
 
-## Setting up your enviroment variables
+## Setting up your environment variables
 
 Copy `.env.example` to `.env` in the root of the training repository.
 
@@ -274,8 +274,8 @@ And then we stack a new [LoRA](https://github.com/microsoft/LoRA) (Low-Rank
 Adaptation) model on top of it.
 
 We use a LoRA adapter here because this requires much less system resources to
-train than doing a full-blown finetuing run on the dataset. When you use a LoRA,
-you freeze most of the weights in the original model and only train a few
+train than doing a full-blown finetuning run on the dataset. When you use a
+LoRA, you freeze most of the weights in the original model and only train a few
 weights that are stacked on top of the original model. This allows you to train
 models on much larger datasets without having to worry about running out of GPU
 memory or cloud credits as quickly.

--- a/docs/training/csi-s3/index.md
+++ b/docs/training/csi-s3/index.md
@@ -22,8 +22,8 @@ manager:
 brew install helm
 ```
 
-Create an admin token in the [Tigris Dash](https://console.storage.dev). Its
-credentials will be used in the next step.
+Create an admin token in the [Tigris Dashboard](https://console.storage.dev).
+Its credentials will be used in the next step.
 
 With that admin token, install the csi-s3 operator:
 
@@ -121,7 +121,7 @@ Using a bucket that already exists is easy but slightly more involved. You need
 to create a PersistentVolume pointing to the bucket and then a
 PersistentVolumeClaim that points to that PersistentVolume. For example, here is
 the PersistentVolume and PersistentVolumeClaim pair for the bucket named
-`mybucket` :
+`mybucket`:
 
 ```yaml
 apiVersion: v1

--- a/docs/training/tigrisfs.mdx
+++ b/docs/training/tigrisfs.mdx
@@ -54,7 +54,7 @@ dpkg -i tigrisfs_1.2.1_linux_amd64.deb
 </details>
 
 <details>
-  <summary>MacOS ARM64</summary>
+  <summary>macOS ARM64</summary>
 
 You may need to install osxfuse/macfuse first.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and copy edits only; no runtime, API, or security logic changes.
> 
> **Overview**
> This PR is a **documentation-only** pass across many pages: spelling and grammar fixes (e.g. *ephmemeral* → *ephemeral*, *Standrad* → *Standard*, *retreive* → *retrieve*, *finetuing* → *finetuning*), clearer wording, and small consistency tweaks (e.g. *Tigris bucket*, *macOS*, dashboard naming).
> 
> **Markup and formatting** get the most visible fixes: the `tigris access-keys rotate` **:::warning** admonition is split onto proper lines so it renders; stray empty fenced blocks after the flags table are removed; the privacy policy’s sharing section uses proper **bold** list labels and a markdown link for Google’s privacy URL instead of a bare URL; Bufstream’s celebration uses 🎉 instead of `:tada:`.
> 
> Legal and IAM copy picks up minor corrections (*referred to herein*, *forgoing* → *foregoing*, IAM bullet grammar). No product behavior or APIs change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f381bd0167019237ab0e93f5db23869565258a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->