### PR TITLE
docs(migration): apply ASD-STE100 rules

### DIFF
--- a/docs/migration/aws-s3.mdx
+++ b/docs/migration/aws-s3.mdx
@@ -49,7 +49,7 @@ bucket on demand and caches them for future access. No downtime required.
 
 You can also enable **write-through** mode, which syncs new writes back to your
 S3 bucket. This means your existing S3 bucket stays up to date throughout the
-migration, and you can take as long as you need before completing the cutover.
+migration. You can take as long as you need before you complete the cutover.
 
 ### Prerequisites
 
@@ -73,7 +73,7 @@ Before starting, make sure you have:
 4. Go to the user's **Security credentials** tab and click **Create access key**
    under the **Access keys** section.
 5. Select **Third-party service** as the use case, then copy the **Access key
-   ID** and **Secret access key**. The secret won't be shown again.
+   ID** and **Secret access key**. AWS does not show the secret again.
 
 ### Step 2: Configure the shadow bucket
 
@@ -114,8 +114,8 @@ tigris buckets set-migration my-bucket \
 Add `--write-through` for write-through mode, or `--disable` to clear the
 migration configuration.
 
-**2. Actively migrate (optional).** Lazy migration only copies objects when
-they're requested. To migrate every remaining object server-side, run
+**2. Actively migrate (optional).** Lazy migration only copies objects when your
+application requests them. To migrate every remaining object server-side, run
 [`tigris buckets migrate`](/docs/cli/buckets/migrate):
 
 ```bash
@@ -159,17 +159,17 @@ existing bucket names, object keys, and API calls stay the same.
 
 ### Step 4: Verify the migration
 
-Once your application points to Tigris, objects are migrated on first access. To
-verify:
+After you point your application to Tigris, Tigris migrates objects on first
+access. To make sure that the migration works:
 
 1. Request an object that exists in your S3 bucket
-2. Confirm it returns successfully through Tigris
-3. Check that subsequent requests are served directly from Tigris
+2. Make sure that it returns successfully through Tigris
+3. Make sure that Tigris serves subsequent requests directly
 
 ### Step 5: Enable write-through (optional)
 
 To keep your S3 bucket in sync during the migration, enable **write-through** in
-the shadow bucket settings. With write-through enabled:
+the shadow bucket configuration. With write-through enabled:
 
 - New objects written to Tigris are also written to your S3 bucket
 - Deletes apply to both Tigris and S3
@@ -179,7 +179,7 @@ This keeps your S3 bucket current so you can fall back at any point.
 
 ### Step 6: Complete the migration
 
-Once your workloads are running well on Tigris, disable the shadow bucket
+After your workloads run well on Tigris, disable the shadow bucket
 configuration. Tigris becomes your primary object store.
 
 ## FAQ
@@ -187,7 +187,7 @@ configuration. Tigris becomes your primary object store.
 ### Does migration require downtime?
 
 No. Shadow bucket migration happens transparently. Your application continues
-serving requests while objects are migrated on first access.
+serving requests while Tigris migrates objects on first access.
 
 ### Do I need to change my application code?
 
@@ -200,9 +200,9 @@ Yes. If you enable write-through mode, your S3 bucket stays in sync with all new
 writes. You can switch back to S3 at any point by reverting your endpoint
 configuration.
 
-### What happens to objects I haven't accessed yet?
+### What happens to objects I have not accessed yet?
 
-They remain in your S3 bucket. Tigris only copies objects when they're first
+They remain in your S3 bucket. Tigris only copies objects when they are first
 requested. Objects that are never accessed are never transferred.
 
 ### How much does Tigris cost compared to S3?

--- a/docs/migration/cloudflare-r2.mdx
+++ b/docs/migration/cloudflare-r2.mdx
@@ -33,9 +33,9 @@ APIs. The differences are in performance, global distribution, and features.
   global distribution that follows access patterns, multi-region geo-redundancy,
   dual-region, or single-region — each with built-in consistency and
   availability guarantees. R2 does not offer configurable data placement.
-- **Storage tiers.** R2 offers a single storage class. Tigris provides Standard,
+- **Storage tiers.** R2 offers a single storage class. Tigris has Standard,
   Infrequent Access, and Archive tiers.
-- **IAM policies.** R2 has limited access control. Tigris provides
+- **IAM policies.** R2 has limited access control. Tigris has
   [fine-grained IAM policies](/docs/iam/) with IP-based restrictions, time-based
   conditions, and per-key policy attachments.
 - **Higher availability.** Tigris offers a 99.99% availability SLA compared to
@@ -48,8 +48,8 @@ Instead of copying all your data upfront, Tigris fetches objects from your R2
 bucket on demand and caches them for future access. No downtime required.
 
 You can also enable **write-through** mode, which syncs new writes back to your
-R2 bucket. This means your existing R2 bucket stays up to date throughout the
-migration, and you can take as long as you need before completing the cutover.
+R2 bucket. Your existing R2 bucket stays up to date throughout the migration.
+You can take as long as you need before you complete the cutover.
 
 ### Prerequisites
 
@@ -68,8 +68,8 @@ Before starting, make sure you have:
 4. Click **Create Account API token** and select the appropriate permissions.
    Use read-only for basic migration, or read-write if you plan to use
    write-through mode.
-5. Copy and securely store the **Access Key ID** and **Secret Access Key**. The
-   secret won't be shown again.
+5. Copy and securely store the **Access Key ID** and **Secret Access Key**.
+   Cloudflare does not show the secret again.
 6. Note your account-specific endpoint, shown alongside your access keys. It
    looks like `https://<account-id>.r2.cloudflarestorage.com`.
 
@@ -112,8 +112,8 @@ tigris buckets set-migration my-bucket \
 Add `--write-through` for write-through mode, or `--disable` to clear the
 migration configuration.
 
-**2. Actively migrate (optional).** Lazy migration only copies objects when
-they're requested. To migrate every remaining object server-side, run
+**2. Actively migrate (optional).** Lazy migration only copies objects when your
+application requests them. To migrate every remaining object server-side, run
 [`tigris buckets migrate`](/docs/cli/buckets/migrate):
 
 ```bash
@@ -157,17 +157,17 @@ existing bucket names, object keys, and API calls stay the same.
 
 ### Step 4: Verify the migration
 
-Once your application points to Tigris, objects are migrated on first access. To
-verify:
+After you point your application to Tigris, Tigris migrates objects on first
+access. To make sure that the migration works:
 
 1. Request an object that exists in your R2 bucket
-2. Confirm it returns successfully through Tigris
-3. Check that subsequent requests are served directly from Tigris
+2. Make sure that Tigris returns the object without errors
+3. Make sure that Tigris serves later requests directly
 
 ### Step 5: Enable write-through (optional)
 
 To keep your R2 bucket in sync during the migration, enable **write-through** in
-the shadow bucket settings. With write-through enabled:
+the shadow bucket configuration. With write-through enabled:
 
 - New objects written to Tigris are also written to your R2 bucket
 - Deletes apply to both Tigris and R2
@@ -177,7 +177,7 @@ This keeps your R2 bucket current so you can fall back at any point.
 
 ### Step 6: Complete the migration
 
-Once your workloads are running well on Tigris, disable the shadow bucket
+After your workloads run well on Tigris, disable the shadow bucket
 configuration. Tigris becomes your primary object store.
 
 ## FAQ
@@ -185,7 +185,7 @@ configuration. Tigris becomes your primary object store.
 ### Does migration require downtime?
 
 No. Shadow bucket migration happens transparently. Your application continues
-serving requests while objects are migrated on first access.
+serving requests while Tigris migrates objects on first access.
 
 ### Do I need to change my application code?
 
@@ -205,7 +205,7 @@ is significantly faster for small object workloads, automatically distributes
 data across regions, and offers storage tiers and fine-grained IAM policies that
 R2 does not.
 
-### What happens to objects I haven't accessed yet?
+### What happens to objects I have not accessed yet?
 
-They remain in your R2 bucket. Tigris only copies objects when they're first
+They remain in your R2 bucket. Tigris only copies objects when they are first
 requested. Objects that are never accessed are never transferred.

--- a/docs/migration/gcs.mdx
+++ b/docs/migration/gcs.mdx
@@ -46,9 +46,10 @@ Tigris supports [lazy migration](/docs/migration/) using **shadow buckets**.
 Instead of copying all your data upfront, Tigris fetches objects from your GCS
 bucket on demand and caches them for future access. No downtime required.
 
-You can also enable **write-through** mode, which syncs new writes back to your
-GCS bucket. This means your existing GCS bucket stays up to date throughout the
-migration, and you can take as long as you need before completing the cutover.
+You can also enable **write-through** mode. This mode syncs new writes back to
+your GCS bucket, so your existing GCS bucket stays up to date throughout the
+migration. You can take as much time as you need before you complete the
+cutover.
 
 ### Prerequisites
 
@@ -65,11 +66,11 @@ for GCS access.
 
 1. Go to the
    [Google Cloud Console Interoperability page](https://console.cloud.google.com/storage/settings;tab=interoperability).
-2. If you don't already have a service account with access to your GCS bucket,
-   create one in the
+2. Make sure that you have a service account with access to your GCS bucket. If
+   you do not have one, create it in the
    [IAM & Admin section](https://console.cloud.google.com/iam-admin/serviceaccounts).
-   Assign it `Storage Object Viewer` for read-only migration, or
-   `Storage Object Admin` if you plan to use write-through mode.
+   If you plan to use write-through mode, assign `Storage Object Admin`.
+   Otherwise, assign `Storage Object Viewer` for read-only migration.
 3. On the Interoperability page, find the service account and click **Create
    Key** under the **HMAC Keys** section.
 4. Copy and securely store the **Access Key** and **Secret Key**.
@@ -112,8 +113,8 @@ tigris buckets set-migration my-bucket \
 Add `--write-through` for write-through mode, or `--disable` to clear the
 migration configuration.
 
-**2. Actively migrate (optional).** Lazy migration only copies objects when
-they're requested. To migrate every remaining object server-side, run
+**2. Actively migrate (optional).** Lazy migration only copies objects when your
+application requests them. To migrate every remaining object server-side, run
 [`tigris buckets migrate`](/docs/cli/buckets/migrate):
 
 ```bash
@@ -157,17 +158,17 @@ existing bucket names, object keys, and API calls stay the same.
 
 ### Step 4: Verify the migration
 
-Once your application points to Tigris, objects are migrated on first access. To
-verify:
+After you point your application to Tigris, Tigris migrates objects on first
+access. To make sure that the migration works:
 
 1. Request an object that exists in your GCS bucket
-2. Confirm it returns successfully through Tigris
-3. Check that subsequent requests are served directly from Tigris
+2. Make sure that the object returns successfully through Tigris
+3. Make sure that Tigris serves subsequent requests directly
 
 ### Step 5: Enable write-through (optional)
 
 To keep your GCS bucket in sync during the migration, enable **write-through**
-in the shadow bucket settings. With write-through enabled:
+in the shadow bucket configuration. With write-through enabled:
 
 - New objects written to Tigris are also written to your GCS bucket
 - Deletes apply to both Tigris and GCS
@@ -177,15 +178,15 @@ This keeps your GCS bucket current so you can fall back at any point.
 
 ### Step 6: Complete the migration
 
-Once your workloads are running well on Tigris, disable the shadow bucket
+After your workloads run well on Tigris, disable the shadow bucket
 configuration. Tigris becomes your primary object store.
 
 ## FAQ
 
 ### Does migration require downtime?
 
-No. Shadow bucket migration happens transparently. Your application continues
-serving requests while objects are migrated on first access.
+No. Shadow bucket migration happens transparently. Your application continues to
+serve requests while Tigris migrates objects on first access.
 
 ### Do I need to change my application code?
 
@@ -204,10 +205,10 @@ Tigris uses S3-compatible APIs for migration. GCS supports S3-compatible access
 through its Interoperability API, which requires HMAC-style credentials rather
 than the OAuth tokens used by GCS's native JSON API.
 
-### What happens to objects I haven't accessed yet?
+### What happens to objects I have not accessed yet?
 
-They remain in your GCS bucket. Tigris only copies objects when they're first
-requested. Objects that are never accessed are never transferred.
+They remain in your GCS bucket. Tigris only copies objects when they are first
+requested. Tigris never transfers objects that you never access.
 
 ### How much does Tigris cost compared to GCS?
 

--- a/docs/migration/index.mdx
+++ b/docs/migration/index.mdx
@@ -21,10 +21,10 @@ import TabItem from "@theme/TabItem";
 # Migrate to Tigris Object Storage
 
 Tigris supports zero-downtime migration from any S3-compatible storage provider
-using shadow buckets. Data is migrated lazily as it's accessed, so there's no
-need for a large upfront data transfer. With write-through mode enabled, new
-writes are synced back to your old bucket, so you can take as long as you need
-to complete the migration.
+with shadow buckets. Tigris migrates data lazily as clients access it. This
+removes the need for a large upfront data transfer. When you enable
+write-through mode, Tigris syncs new writes back to your old bucket. You can
+take as long as you need to complete the migration.
 
 ## Provider-specific guides
 
@@ -38,52 +38,57 @@ to complete the migration.
 
 ## How shadow bucket migration works
 
-Once you've specified your **shadow bucket** (the source S3-compatible bucket),
-Tigris handles requests so that data is gradually migrated as it is accessed.
+After you specify your **shadow bucket** (the source S3-compatible bucket),
+Tigris handles requests and migrates data gradually as clients access it.
 
-This approach works well for large-scale migrations where copying all data at
-once would be slow or expensive. Instead of migrating everything up front,
-Tigris fetches objects from the shadow bucket only when requested and copies
-them into your Tigris bucket asynchronously. Only actively used data is
-migrated, reducing both latency and cost.
+This approach works well for large-scale migrations, where copying all data at
+once can be slow or expensive. Instead of migrating everything up front, Tigris
+fetches objects from the shadow bucket only when a client requests them. Tigris
+copies the objects into your Tigris bucket asynchronously. Tigris migrates only
+actively used data. This reduces both latency and cost.
 
 ## Write-through mode: migrate at your own pace
 
 Most migration tools force a hard cutover: you copy your data, switch over, and
 hope nothing breaks. Tigris takes a different approach.
 
-With the optional **write-through** setting enabled, Tigris syncs all new writes
+With the optional **write-through** mode enabled, Tigris syncs all new writes
 back to your original bucket. Your old bucket stays up to date with every new
 object, update, and delete. This means you can run on Tigris in production while
 keeping your previous storage provider fully current.
 
-There's no deadline to finish the migration. You can run in write-through mode
-for days, weeks, or months while you verify that everything works. If you need
-to roll back, your old bucket has all the latest data. When you're ready, turn
-off write-through and decommission the old bucket.
+There is no deadline to finish the migration. You can run in write-through mode
+for days, weeks, or months while you make sure that everything works. If you
+need to roll back, your old bucket has all the latest data. When you are ready,
+turn off write-through and decommission the old bucket.
 
-Under the hood:
+Internally, Tigris does the following:
 
-- When an object is requested, Tigris checks its own bucket first. If the object
-  is not found, Tigris fetches it from the shadow bucket, returns it, and
-  asynchronously copies it for future access.
-- When uploading an object with write-through enabled, Tigris writes it to both
-  the shadow bucket and the Tigris bucket at the same time, keeping both in
-  sync.
-- Objects in the Tigris bucket are stored in the region closest to the user.
-- When an object is deleted, it's removed from both the Tigris and shadow
-  buckets.
+- When a client requests an object, Tigris checks its own bucket first. If
+  Tigris does not find the object, it fetches the object from the shadow bucket,
+  returns the object, and copies it asynchronously for future access.
+- When a client uploads an object with write-through enabled, Tigris writes it
+  to the shadow bucket and the Tigris bucket at the same time. This keeps both
+  buckets in sync.
+- Tigris stores objects in the Tigris bucket in the region closest to the user.
+- When a client deletes an object, Tigris removes it from both the Tigris bucket
+  and the shadow bucket.
 
-<!-- prettier-ignore -->
+{/* prettier-ignore */}
 :::note
-Object listing behavior depends on whether write-through mode is
-enabled. When write-through is enabled, the list API returns the full contents
-of the shadow bucket. When write-through is disabled, the list API only includes
-objects that have already been migrated into Tigris; objects that exist solely
-in the shadow bucket are not listed until they are accessed and migrated.
 
-  <!-- prettier-ignore -->
+Object listing behavior depends on whether you enable or disable write-through
+mode.
 
+When you enable write-through mode, the list API returns the full contents of
+the shadow bucket.
+
+When you disable write-through mode, the list API includes only the objects that
+are already in the Tigris bucket. The API does not list objects that exist only
+in the shadow bucket. Tigris lists these objects only after a client accesses
+them and Tigris migrates them.
+
+{/* prettier-ignore */}
 :::
 
 ## Enable Data Migration
@@ -101,8 +106,8 @@ To enable data migration from any S3-compatible bucket:
 - Click on `Buckets` in the left menu.
 - Click on the bucket to which you wish to migrate data.
 - Click `Settings`.
-- Find the `Enable Data Migration` setting and enable the toggle.
-- Provide the access details for your source bucket, or `Shadow Bucket`.
+- Find `Enable Data Migration` and turn on the toggle.
+- Enter the access details for your source bucket, or `Shadow Bucket`.
 
 ![Shadow bucket migration](./shadow-bucket-migration.webp)
 
@@ -130,8 +135,8 @@ tigris buckets set-migration my-bucket \
 Add `--write-through` to enable write-through mode, or `--disable` to clear the
 migration configuration.
 
-**2. Actively migrate (optional).** Lazy migration only copies objects when
-they're accessed. To migrate every remaining object server-side, run
+**2. Actively migrate (optional).** Lazy migration only copies objects when a
+client accesses them. To migrate every remaining object server-side, run
 [`tigris buckets migrate`](/docs/cli/buckets/migrate):
 
 ```bash
@@ -149,17 +154,19 @@ The command runs in the foreground and reports progress as it goes.
 
 ## Copying object ACLs
 
-By default, migrated objects inherit the access control settings of the bucket
-to which they are migrated. However, if the bucket is configured to
-[allow object ACLs](/docs/objects/acl.md#enabling-object-acls), the migration
-process will copy object ACLs from the shadow bucket to the Tigris bucket. The
-following rules apply:
+By default, Tigris configures access control on migrated objects to match the
+destination bucket. However, if you configure the bucket to
+[allow object ACLs](/docs/objects/acl.md#enabling-object-acls), Tigris copies
+object ACLs during migration. Tigris copies these ACLs from the shadow bucket to
+the Tigris bucket. The following rules apply:
 
 - Tigris bucket is private:
-  - Public S3 objects will be migrated as public and have explicit `public-read`
-    ACL set.
-  - Private S3 objects will be migrated as private and inherit bucket ACL.
+  - Tigris migrates public S3 objects as public objects and sets an explicit
+    `public-read` ACL.
+  - Tigris migrates private S3 objects as private objects. These objects inherit
+    the bucket ACL.
 - Tigris bucket is public:
-  - Public S3 objects will be migrated as public and inherit bucket ACL.
-  - Private S3 objects will be copied as private and have explicit `private` ACL
-    set.
+  - Tigris migrates public S3 objects as public objects. These objects inherit
+    the bucket ACL.
+  - Tigris copies private S3 objects as private objects and sets an explicit
+    `private` ACL.

--- a/docs/migration/minio.mdx
+++ b/docs/migration/minio.mdx
@@ -26,9 +26,9 @@ change.
 
 Many engineers run [MinIO](https://min.io/) to avoid the egress fees charged by
 cloud providers like AWS S3. Self-hosting gives you control over your data and
-eliminates per-GB transfer costs, but it also means provisioning hardware,
-managing upgrades, monitoring cluster health, configuring replication, and
-scaling capacity yourself.
+eliminates per-GB transfer costs. But you must also provision hardware, manage
+upgrades, monitor cluster health, configure replication, and scale capacity
+yourself.
 
 Tigris charges **zero egress fees** and is fully managed. You get the same cost
 savings without running infrastructure.
@@ -55,12 +55,12 @@ Tigris does address common compliance requirements:
 - **HIPAA**: Tigris will sign Business Associate Agreements (BAAs) for customers
   who need HIPAA compliance.
 - **Data residency**: Tigris supports
-  [region restrictions](/docs/buckets/settings/) so you can ensure data stays in
-  specific regions, for example restricting storage to the EU for GDPR
-  compliance.
+  [region restrictions](/docs/buckets/settings/) so you can make sure that data
+  stays in specific regions. For example, you can restrict storage to the EU for
+  GDPR compliance.
 - **SOC 2 Type II**: Tigris maintains SOC 2 Type II compliance, covering
   security, availability, and confidentiality controls.
-- **IAM controls**: Tigris provides [fine-grained access policies](/docs/iam/)
+- **IAM controls**: Tigris gives you [fine-grained access policies](/docs/iam/)
   with IP-based restrictions, time-based access conditions, and per-key policy
   attachments.
 
@@ -72,8 +72,7 @@ cluster on demand and caches them for future access. No downtime required.
 
 You can also enable **write-through** mode, which syncs new writes back to your
 MinIO bucket. This means your existing MinIO cluster stays up to date throughout
-the migration, and you can take as long as you need before completing the
-cutover.
+the migration. You can take as long as you need before you complete the cutover.
 
 ### Prerequisites
 
@@ -89,11 +88,10 @@ Before starting, make sure you have:
 
 :::note
 
-If your MinIO instance is behind a firewall or on a private network, you'll need
-to ensure Tigris can reach it. This may require configuring firewall rules or
-setting up a reverse proxy. If your MinIO instance cannot be made accessible,
-consider using [rclone](/docs/quickstarts/rclone/) to copy data directly
-instead.
+If your MinIO instance is behind a firewall or on a private network, Tigris must
+still be able to reach it. This can require new firewall rules or a reverse
+proxy. If you cannot make your MinIO instance accessible, you can use
+[rclone](/docs/quickstarts/rclone/) to copy data directly instead.
 
 :::
 
@@ -136,8 +134,8 @@ tigris buckets set-migration my-bucket \
 Add `--write-through` for write-through mode, or `--disable` to clear the
 migration configuration.
 
-**2. Actively migrate (optional).** Lazy migration only copies objects when
-they're requested. To migrate every remaining object server-side, run
+**2. Actively migrate (optional).** Lazy migration only copies objects when your
+application requests them. To migrate every remaining object server-side, run
 [`tigris buckets migrate`](/docs/cli/buckets/migrate):
 
 ```bash
@@ -181,17 +179,18 @@ existing bucket names, object keys, and API calls stay the same.
 
 ### Step 3: Verify the migration
 
-Once your application points to Tigris, objects are migrated on first access. To
-verify:
+After you point your application to Tigris, Tigris migrates objects on first
+access. To make sure that the migration works:
 
 1. Request an object that exists in your MinIO bucket
-2. Confirm it returns successfully through Tigris
-3. Check that subsequent requests are served directly from Tigris
+2. Make sure that it returns successfully through Tigris
+3. Make sure that Tigris serves subsequent requests directly
 
 ### Step 4: Enable write-through (optional)
 
 To keep your MinIO cluster in sync during the migration, enable
-**write-through** in the shadow bucket settings. With write-through enabled:
+**write-through** in the shadow bucket configuration. With write-through
+enabled:
 
 - New objects written to Tigris are also written to your MinIO bucket
 - Deletes apply to both Tigris and MinIO
@@ -201,15 +200,15 @@ This keeps your MinIO cluster current so you can fall back at any point.
 
 ### Step 5: Complete the migration
 
-Once your workloads are running well on Tigris, disable the shadow bucket
+After your workloads run well on Tigris, disable the shadow bucket
 configuration. Tigris becomes your primary object store, and you can
 decommission your MinIO cluster.
 
 ## Bulk migration with rclone
 
-If you want to migrate all data upfront, or if your MinIO instance isn't
-publicly accessible, you can use [rclone](/docs/quickstarts/rclone/) to copy
-data directly.
+If you want to migrate all data upfront, use [rclone](/docs/quickstarts/rclone/)
+to copy data directly. This also works if your MinIO instance is not publicly
+accessible.
 
 Configure rclone with both your MinIO and Tigris endpoints:
 
@@ -236,7 +235,7 @@ Then sync the data:
 rclone sync minio:source-bucket tigris:destination-bucket --progress
 ```
 
-This copies all objects from your MinIO bucket to Tigris. Once the sync is
+This copies all objects from your MinIO bucket to Tigris. After the sync is
 complete, update your application to point to Tigris and decommission MinIO.
 
 ## FAQ
@@ -244,7 +243,7 @@ complete, update your application to point to Tigris and decommission MinIO.
 ### Does migration require downtime?
 
 No. Shadow bucket migration happens transparently. Your application continues
-serving requests while objects are migrated on first access.
+serving requests while Tigris migrates objects on first access.
 
 ### Do I need to change my application code?
 
@@ -257,15 +256,15 @@ Yes. If you enable write-through mode, your MinIO cluster stays in sync with all
 new writes. You can switch back to MinIO at any point by reverting your endpoint
 configuration.
 
-### What if my MinIO instance isn't publicly accessible?
+### What if my MinIO instance is not publicly accessible?
 
 Use [rclone](/docs/quickstarts/rclone/) to copy data directly from MinIO to
 Tigris. See the [bulk migration section](#bulk-migration-with-rclone) above.
 
-### What happens to objects I haven't accessed yet?
+### What happens to objects I have not accessed yet?
 
-They remain in your MinIO cluster. Tigris only copies objects when they're first
-requested. Objects that are never accessed are never transferred.
+They remain in your MinIO cluster. Tigris only copies objects when they are
+first requested. Objects that are never accessed are never transferred.
 
 ### Does Tigris meet compliance requirements?
 

--- a/docs/migration/s3-compatible.mdx
+++ b/docs/migration/s3-compatible.mdx
@@ -20,9 +20,9 @@ import TabItem from "@theme/TabItem";
 # Migrate from Any S3-Compatible Storage to Tigris
 
 Tigris can migrate data from any storage provider with an S3-compatible API.
-This guide covers providers that don't have a dedicated migration guide,
-including Backblaze B2, DigitalOcean Spaces, Wasabi, Hetzner Object Storage,
-Vultr Object Storage, and Linode/Akamai Object Storage.
+This guide covers providers that do not have a dedicated migration guide. These
+providers include Backblaze B2, DigitalOcean Spaces, Wasabi, Hetzner Object
+Storage, Vultr Object Storage, and Linode/Akamai Object Storage.
 
 For AWS S3, Google Cloud Storage, Cloudflare R2, or MinIO, see the
 [provider-specific guides](/docs/migration/).
@@ -56,7 +56,7 @@ provider:
 
 1. An S3-compatible endpoint URL
 2. An access key ID and secret access key
-3. The region (if the provider uses regions; otherwise set to `auto`)
+3. The region (or `auto` if the provider does not use regions)
 
 Check your provider's documentation for S3 compatibility or interoperability
 settings. Below are instructions for some common providers.
@@ -168,8 +168,8 @@ tigris buckets set-migration my-bucket \
 Add `--write-through` for write-through mode, or `--disable` to clear the
 migration configuration.
 
-**2. Actively migrate (optional).** Lazy migration only copies objects when
-they're requested. To migrate every remaining object server-side, run
+**2. Actively migrate (optional).** Lazy migration only copies an object when
+your application requests it. To migrate every remaining object server-side, run
 [`tigris buckets migrate`](/docs/cli/buckets/migrate):
 
 ```bash
@@ -213,22 +213,23 @@ existing bucket names, object keys, and API calls stay the same.
 
 ## Verify and complete
 
-Once your application points to Tigris, objects are migrated on first access.
-Request a few objects to confirm they're returned successfully.
+After you point your application to Tigris, Tigris migrates objects on first
+access. Request a few objects and make sure that Tigris returns them
+successfully.
 
 To keep your old bucket in sync during the migration, enable **write-through**
-in the shadow bucket settings. Your old bucket stays current so you can fall
-back at any point.
+in the shadow bucket configuration. Your old bucket stays current so you can
+fall back at any point.
 
-Once your workloads are running well on Tigris, disable the shadow bucket
-configuration and decommission your old storage.
+After your workloads run well on Tigris, disable the shadow bucket configuration
+and decommission your old storage.
 
 ## FAQ
 
 ### Does migration require downtime?
 
 No. Shadow bucket migration happens transparently. Your application continues
-serving requests while objects are migrated on first access.
+serving requests while Tigris migrates objects on first access.
 
 ### Do I need to change my application code?
 
@@ -241,12 +242,12 @@ Yes. If you enable write-through mode, your old bucket stays in sync with all
 new writes. You can switch back at any point by reverting your endpoint
 configuration.
 
-### My provider isn't listed. Can I still migrate?
+### My provider is not listed. Can I still migrate?
 
 Yes. Tigris can migrate from any storage that supports the S3 API. You need your
 provider's S3-compatible endpoint URL, access credentials, and region.
 
-### What happens to objects I haven't accessed yet?
+### What happens to objects I have not accessed yet?
 
-They remain in your old bucket. Tigris only copies objects when they're first
+They remain in your old bucket. Tigris only copies objects when they are first
 requested. Objects that are never accessed are never transferred.


### PR DESCRIPTION
Simplified Technical English is a subset of English that makes procedural documentation unambiguous. We are experimenting with using STE100 for procedural documentation in Tigris. The goal is to make procedural documentation easier to understand for a global audience. STE100 conformant text translates easily to other human languages and is easy for AI agents to follow.

Writing in this style also makes work products not look like "AI slop", which makes our documentation more trustable to users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only prose and MDX comment changes; no runtime, API, or configuration behavior is modified.
> 
> **Overview**
> **Rewrites migration documentation** (overview plus AWS S3, GCS, R2, MinIO, and generic S3-compatible guides) to follow **ASD-STE100** style: shorter sentences, explicit subjects (especially **Tigris** as the actor), and plainer verification language (for example **make sure that** instead of **confirm**).
> 
> Wording is aligned across guides: **shadow bucket configuration** (not settings), lazy copy triggers described as **when your application or a client requests** objects, and contractions or informal phrasing removed (**have not**, **do not**, **is not**). Credential steps now state plainly that **AWS/Cloudflare do not show the secret again**.
> 
> The **migration index** gets the largest edits—clearer shadow-bucket and write-through behavior, a reformatted listing note (MDX `{/* prettier-ignore */}`), dashboard steps, and STE-style **object ACL** rules. **MinIO** tightens the private-network note and reframes bulk **rclone** migration when the instance is not public.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b008b5c1d182e5735ce88f839f70cab19d40a24a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->