### PR TITLE
Acceleration Gateway: block caching default-on (1 MiB) + v1.17.0

### DIFF
--- a/docs/acceleration-gateway/architecture.mdx
+++ b/docs/acceleration-gateway/architecture.mdx
@@ -193,10 +193,18 @@ Key behaviors:
 - Once streaming starts, new requests for the same key start their own fetch
 - Listeners that read too slowly are disconnected to prevent memory buildup
 
-### Range request optimization
+### Range request serving
 
-When a byte-range request arrives for an uncached object, TAG serves the range
-immediately while fetching the full object in the background:
+By default (block-aligned caching), a byte-range request for an uncached object
+fetches and caches only the fixed-size **blocks** covering the requested range —
+not the whole object — so range reads of large objects stay cheap and the cache
+holds only the regions actually read. TAG serves the requested bytes
+immediately, pulling any missing covering blocks from Tigris, and later reads of
+the same blocks are served from local cache.
+
+With block caching disabled (`block_caching_enabled: false`), TAG instead serves
+the range immediately while fetching the **full object** in the background, so
+any later byte range of that object is served from cache:
 
 ```text
 Client                 TAG                    Embedded Cache         Tigris
@@ -222,7 +230,7 @@ Client                 TAG                    Embedded Cache         Tigris
   │                     │──────────────────────▶│                    │
 ```
 
-Benefits:
+Benefits of the whole-object background fetch:
 
 - **Low latency** — the client gets the requested range immediately
 - **Future ranges served from cache** — any byte range of the same object comes

--- a/docs/acceleration-gateway/architecture.mdx
+++ b/docs/acceleration-gateway/architecture.mdx
@@ -61,7 +61,7 @@ The core request handling layer that coordinates:
 
 - Cache lookups and writes
 - Request coalescing
-- Range request optimization with background fetching
+- Range request serving (block-aligned caching by default)
 - Request forwarding to Tigris
 - Cache invalidation on write operations
 
@@ -195,16 +195,47 @@ Key behaviors:
 
 ### Range request serving
 
-By default (block-aligned caching), a byte-range request for an uncached object
-fetches and caches only the fixed-size **blocks** covering the requested range —
-not the whole object — so range reads of large objects stay cheap and the cache
-holds only the regions actually read. TAG serves the requested bytes
-immediately, pulling any missing covering blocks from Tigris, and later reads of
-the same blocks are served from local cache.
+TAG serves a byte-range request for an uncached object with one of two
+strategies, selected by the `block_caching_enabled` setting.
 
-With block caching disabled (`block_caching_enabled: false`), TAG instead serves
-the range immediately while fetching the **full object** in the background, so
-any later byte range of that object is served from cache:
+#### Block caching (default)
+
+TAG fetches and caches only the fixed-size **blocks** covering the requested
+range — not the whole object — so range reads of large objects stay cheap and
+the cache holds only the regions actually read. It serves the requested bytes
+from those blocks, pulling any missing covering block from Tigris with an
+aligned range GET, and later reads of the same block are cache hits.
+
+```text
+Client                 TAG                    Embedded Cache         Tigris
+  │                     │                       │                    │
+  │ GET /bucket/key     │                       │                    │
+  │ Range: bytes=0-1023 │                       │                    │
+  │────────────────────▶│                       │                    │
+  │                     │ Covering block(s)?    │                    │
+  │                     │ Get block 0           │                    │
+  │                     │──────────────────────▶│                    │
+  │                     │◀──────────────────────│ not cached         │
+  │                     │                       │                    │
+  │                     │ GET Range: bytes=0-1048575 (aligned block) │
+  │                     │───────────────────────────────────────────▶│
+  │                     │◀───────────────────────────────────────────│
+  │                     │ Put block 0           │      206 Partial   │
+  │                     │──────────────────────▶│                    │
+  │◀────────────────────│  206 Partial (0-1023) │                    │
+  │  206 Partial        │                       │                    │
+```
+
+Because only the touched blocks are cached, block caching suits **sparse reads
+of large objects** (Parquet footers/row-groups, SST blocks). Size `block_size`
+to your workload's read granularity — see the
+[deployment guide](deployment-guide.md#block-aligned-caching).
+
+#### Whole-object caching
+
+With `block_caching_enabled: false`, TAG serves the requested range immediately
+while fetching the **full object** in the background, so any later byte range of
+that object is served from cache:
 
 ```text
 Client                 TAG                    Embedded Cache         Tigris

--- a/docs/acceleration-gateway/configuration.md
+++ b/docs/acceleration-gateway/configuration.md
@@ -12,38 +12,38 @@ variables. Environment variables take precedence over file configuration.
 
 ## Environment variables
 
-| Variable                          | Description                                                                     | Default                  |
-| --------------------------------- | ------------------------------------------------------------------------------- | ------------------------ |
-| `AWS_ACCESS_KEY_ID`               | Tigris access key (TAG's own credentials, not client credentials)               | (required)               |
-| `AWS_SECRET_ACCESS_KEY`           | Tigris secret key                                                               | (required)               |
-| `TAG_UPSTREAM_ENDPOINT`           | Upstream S3 endpoint URL                                                        | `https://t3.storage.dev` |
-| `TAG_UPSTREAM_REGION`             | Upstream region for SigV4 signing scope                                         | `auto`                   |
-| `TAG_TRANSPARENT_PROXY`           | Transparent proxy mode; set `false`/`0` for signing mode                        | `true`                   |
-| `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                                     | `100`                    |
-| `TAG_MAX_INFLIGHT_REQUESTS`       | Max concurrent S3 requests before shedding with 503 SlowDown                    | `1024`                   |
-| `TAG_CACHE_DISK_PATH`             | Path to cache data directory                                                    | `/var/tmp/tag`           |
-| `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                                         | `0`                      |
-| `TAG_CACHE_EVICTION_POLICY`       | Eviction order when the disk cap is hit: `lru` or `fifo` (oldest-written first) | `lru`                    |
-| `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)                 | `24h`                    |
-| `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                                 | `false`                  |
-| `TAG_CACHE_WARM_ON_WRITE`         | Warm the cache after a successful write via a background fetch (`true`/`false`) | `false`                  |
-| `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                                        | `256`                    |
-| `TAG_CACHE_MAX_POPULATE_MEMORY`   | Aggregate memory budget (bytes) for all cache buffering — populate + block-serve staging (one honest total) | `2147483648` (2 GiB)     |
+| Variable                          | Description                                                                                                           | Default                  |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `AWS_ACCESS_KEY_ID`               | Tigris access key (TAG's own credentials, not client credentials)                                                     | (required)               |
+| `AWS_SECRET_ACCESS_KEY`           | Tigris secret key                                                                                                     | (required)               |
+| `TAG_UPSTREAM_ENDPOINT`           | Upstream S3 endpoint URL                                                                                              | `https://t3.storage.dev` |
+| `TAG_UPSTREAM_REGION`             | Upstream region for SigV4 signing scope                                                                               | `auto`                   |
+| `TAG_TRANSPARENT_PROXY`           | Transparent proxy mode; set `false`/`0` for signing mode                                                              | `true`                   |
+| `TAG_MAX_IDLE_CONNS_PER_HOST`     | HTTP connection pool size per upstream host                                                                           | `100`                    |
+| `TAG_MAX_INFLIGHT_REQUESTS`       | Max concurrent S3 requests before shedding with 503 SlowDown                                                          | `1024`                   |
+| `TAG_CACHE_DISK_PATH`             | Path to cache data directory                                                                                          | `/var/tmp/tag`           |
+| `TAG_CACHE_MAX_DISK_USAGE`        | Max disk usage in bytes (0 = unlimited)                                                                               | `0`                      |
+| `TAG_CACHE_EVICTION_POLICY`       | Eviction order when the disk cap is hit: `lru` or `fifo` (oldest-written first)                                       | `lru`                    |
+| `TAG_CACHE_TTL`                   | Default TTL for cached objects (Go duration, e.g. `12h`, `30m`)                                                       | `24h`                    |
+| `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                                                                       | `false`                  |
+| `TAG_CACHE_WARM_ON_WRITE`         | Warm the cache after a successful write via a background fetch (`true`/`false`)                                       | `false`                  |
+| `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                                                                              | `256`                    |
+| `TAG_CACHE_MAX_POPULATE_MEMORY`   | Aggregate memory budget (bytes) for all cache buffering — populate + block-serve staging (one honest total)           | `2147483648` (2 GiB)     |
 | `TAG_CACHE_BLOCK_CACHING_ENABLED` | Cache large objects as fixed-size blocks (RFC 0001) so a range read fetches only the covering blocks (`true`/`false`) | `true`                   |
-| `TAG_CACHE_BLOCK_SIZE`            | Block granularity and the whole-vs-block boundary (bytes); size to your workload's read granularity | `1048576` (1 MiB)        |
-| `TAG_CACHE_DELETE_BATCH_SIZE`     | File deletions processed per deletion-queue batch                               | `1000`                   |
-| `TAG_CACHE_RECOVERY_WORKERS`      | Parallel workers for startup file recovery                                      | `16`                     |
-| `TAG_HTTP_PORT`                   | HTTP listen port                                                                | `8080`                   |
-| `TAG_LOG_LEVEL`                   | Log level: `debug`, `info`, `warn`, `error`                                     | `info`                   |
-| `TAG_LOG_FORMAT`                  | Log format: `json` or `console`                                                 | `json`                   |
-| `TAG_TLS_CERT_FILE`               | Path to TLS certificate file (PEM format)                                       | (none)                   |
-| `TAG_TLS_KEY_FILE`                | Path to TLS private key file (PEM format)                                       | (none)                   |
-| `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                         | `:9000`                  |
-| `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode (clustering)                            | (none)                   |
-| `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip (clustering)                                      | `:7000`                  |
-| `TAG_CACHE_ADVERTISE_ADDR`        | Address advertised to other nodes (clustering)                                  | (defaults to gRPC addr)  |
-| `TAG_CACHE_SEED_NODES`            | Comma-separated seed nodes for cluster discovery (clustering)                   | (none)                   |
-| `TAG_PPROF_ENABLED`               | Enable pprof endpoints (`true` or `1`)                                          | `false`                  |
+| `TAG_CACHE_BLOCK_SIZE`            | Block granularity and the whole-vs-block boundary (bytes); size to your workload's read granularity                   | `1048576` (1 MiB)        |
+| `TAG_CACHE_DELETE_BATCH_SIZE`     | File deletions processed per deletion-queue batch                                                                     | `1000`                   |
+| `TAG_CACHE_RECOVERY_WORKERS`      | Parallel workers for startup file recovery                                                                            | `16`                     |
+| `TAG_HTTP_PORT`                   | HTTP listen port                                                                                                      | `8080`                   |
+| `TAG_LOG_LEVEL`                   | Log level: `debug`, `info`, `warn`, `error`                                                                           | `info`                   |
+| `TAG_LOG_FORMAT`                  | Log format: `json` or `console`                                                                                       | `json`                   |
+| `TAG_TLS_CERT_FILE`               | Path to TLS certificate file (PEM format)                                                                             | (none)                   |
+| `TAG_TLS_KEY_FILE`                | Path to TLS private key file (PEM format)                                                                             | (none)                   |
+| `TAG_CACHE_GRPC_ADDR`             | Address for gRPC server                                                                                               | `:9000`                  |
+| `TAG_CACHE_NODE_ID`               | Unique node identifier for cluster mode (clustering)                                                                  | (none)                   |
+| `TAG_CACHE_CLUSTER_ADDR`          | Address for memberlist gossip (clustering)                                                                            | `:7000`                  |
+| `TAG_CACHE_ADVERTISE_ADDR`        | Address advertised to other nodes (clustering)                                                                        | (defaults to gRPC addr)  |
+| `TAG_CACHE_SEED_NODES`            | Comma-separated seed nodes for cluster discovery (clustering)                                                         | (none)                   |
+| `TAG_PPROF_ENABLED`               | Enable pprof endpoints (`true` or `1`)                                                                                | `false`                  |
 
 `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are TAG's own Tigris credentials
 with read-only access to all buckets accessed through TAG (required). Clients

--- a/docs/acceleration-gateway/configuration.md
+++ b/docs/acceleration-gateway/configuration.md
@@ -28,7 +28,9 @@ variables. Environment variables take precedence over file configuration.
 | `TAG_CACHE_DISABLED`              | Disable caching (`true` or `1`)                                                 | `false`                  |
 | `TAG_CACHE_WARM_ON_WRITE`         | Warm the cache after a successful write via a background fetch (`true`/`false`) | `false`                  |
 | `TAG_CACHE_MAX_CONCURRENT_WRITES` | Max concurrent cache-populate operations                                        | `256`                    |
-| `TAG_CACHE_MAX_POPULATE_MEMORY`   | Aggregate memory budget (bytes) for concurrent cache-populate buffering         | `1073741824` (1 GiB)     |
+| `TAG_CACHE_MAX_POPULATE_MEMORY`   | Aggregate memory budget (bytes) for all cache buffering — populate + block-serve staging (one honest total) | `2147483648` (2 GiB)     |
+| `TAG_CACHE_BLOCK_CACHING_ENABLED` | Cache large objects as fixed-size blocks (RFC 0001) so a range read fetches only the covering blocks (`true`/`false`) | `true`                   |
+| `TAG_CACHE_BLOCK_SIZE`            | Block granularity and the whole-vs-block boundary (bytes); size to your workload's read granularity | `1048576` (1 MiB)        |
 | `TAG_CACHE_DELETE_BATCH_SIZE`     | File deletions processed per deletion-queue batch                               | `1000`                   |
 | `TAG_CACHE_RECOVERY_WORKERS`      | Parallel workers for startup file recovery                                      | `16`                     |
 | `TAG_HTTP_PORT`                   | HTTP listen port                                                                | `8080`                   |
@@ -158,8 +160,18 @@ cache:
   # small objects populate concurrently while a burst of large objects is throttled
   # to keep buffered memory bounded. This, rather than the raw count above, is what
   # bounds populate memory; both limits apply.
-  # Default: 1073741824 (1 GiB) (0 or unset = default; negative = memory cap disabled)
-  max_populate_memory_bytes: 1073741824
+  # Default: 2147483648 (2 GiB) (0 or unset = default; negative = disabled). One honest
+  # total: block-serve staging draws from this same budget, capped at half of it.
+  max_populate_memory_bytes: 2147483648
+
+  # Block-aligned caching for large objects (RFC 0001). On by default: any object at or
+  # above block_size is cached as fixed-size blocks, so a range read populates and serves
+  # only the blocks it touches. Set false to cache whole objects instead.
+  block_caching_enabled: true
+
+  # Block granularity AND the whole-vs-block boundary. Size it to your workload's read
+  # granularity — an oversized block over-fetches on every miss. 0/unset = default (1 MiB).
+  block_size: 1048576
 
   # Unique node identifier for cluster mode
   # Required for multi-node deployments

--- a/docs/acceleration-gateway/deployment-guide.md
+++ b/docs/acceleration-gateway/deployment-guide.md
@@ -54,6 +54,28 @@ details on how clustering works.
 - [Kubernetes](kubernetes.md) — StatefulSet with autoscaling (recommended for
   production clusters)
 
+## Block-aligned caching
+
+**Block-aligned caching is on by default** (RFC 0001): any object at or above `block_size` is
+cached as fixed-size blocks, so a range read fetches and caches only the covering blocks instead of
+the whole object — ideal for **small ranges of large objects** (Parquet footers/row-groups,
+SlateDB/SST blocks, columnar analytics).
+
+The one knob that matters is **`block_size`** — size it to your workload's dominant read size:
+
+- **Too large** and every cache miss pulls a full block to serve a small range (upstream read
+  amplification). A 4 MiB block serving ~400 KB reads amplifies upstream traffic several-fold and
+  can be _worse_ than whole-object caching.
+- **Too small** adds per-block bookkeeping and more fetches per read.
+
+The `1048576` (1 MiB) default suits typical analytics footers/row-groups; raise it for larger reads,
+lower it (e.g. `65536` for 64 KiB reads), or set `TAG_CACHE_BLOCK_CACHING_ENABLED=false` to cache
+whole objects. Verify the fit with Prometheus:
+
+- **Upstream read amplification** — `sum(rate(tag_cache_block_bytes_populated_total[5m])) / sum(rate(tag_bytes_transferred_total{direction="out"}[5m]))` (bytes fetched into blocks ÷ bytes served). Aim for **≤ 1**; well above 1 means the block size is too large for the read pattern.
+- **Block hit ratio** — `tag_cache_block_hits_total / (tag_cache_block_hits_total + tag_cache_block_misses_total)`.
+- **Serve latency** — `histogram_quantile(0.95, sum(rate(tag_request_duration_seconds_bucket[5m])) by (le))`.
+
 ## TLS
 
 TAG supports HTTPS with TLS certificates for encrypted client connections. See

--- a/docs/acceleration-gateway/deployment-guide.md
+++ b/docs/acceleration-gateway/deployment-guide.md
@@ -56,25 +56,33 @@ details on how clustering works.
 
 ## Block-aligned caching
 
-**Block-aligned caching is on by default** (RFC 0001): any object at or above `block_size` is
-cached as fixed-size blocks, so a range read fetches and caches only the covering blocks instead of
-the whole object — ideal for **small ranges of large objects** (Parquet footers/row-groups,
-SlateDB/SST blocks, columnar analytics).
+**Block-aligned caching is on by default** (RFC 0001): any object at or above
+`block_size` is cached as fixed-size blocks, so a range read fetches and caches
+only the covering blocks instead of the whole object — ideal for **small ranges
+of large objects** (Parquet footers/row-groups, SlateDB/SST blocks, columnar
+analytics).
 
-The one knob that matters is **`block_size`** — size it to your workload's dominant read size:
+The one knob that matters is **`block_size`** — size it to your workload's
+dominant read size:
 
-- **Too large** and every cache miss pulls a full block to serve a small range (upstream read
-  amplification). A 4 MiB block serving ~400 KB reads amplifies upstream traffic several-fold and
-  can be _worse_ than whole-object caching.
+- **Too large** and every cache miss pulls a full block to serve a small range
+  (upstream read amplification). A 4 MiB block serving ~400 KB reads amplifies
+  upstream traffic several-fold and can be _worse_ than whole-object caching.
 - **Too small** adds per-block bookkeeping and more fetches per read.
 
-The `1048576` (1 MiB) default suits typical analytics footers/row-groups; raise it for larger reads,
-lower it (e.g. `65536` for 64 KiB reads), or set `TAG_CACHE_BLOCK_CACHING_ENABLED=false` to cache
-whole objects. Verify the fit with Prometheus:
+The `1048576` (1 MiB) default suits typical analytics footers/row-groups; raise
+it for larger reads, lower it (e.g. `65536` for 64 KiB reads), or set
+`TAG_CACHE_BLOCK_CACHING_ENABLED=false` to cache whole objects. Verify the fit
+with Prometheus:
 
-- **Upstream read amplification** — `sum(rate(tag_cache_block_bytes_populated_total[5m])) / sum(rate(tag_bytes_transferred_total{direction="out"}[5m]))` (bytes fetched into blocks ÷ bytes served). Aim for **≤ 1**; well above 1 means the block size is too large for the read pattern.
-- **Block hit ratio** — `tag_cache_block_hits_total / (tag_cache_block_hits_total + tag_cache_block_misses_total)`.
-- **Serve latency** — `histogram_quantile(0.95, sum(rate(tag_request_duration_seconds_bucket[5m])) by (le))`.
+- **Upstream read amplification** —
+  `sum(rate(tag_cache_block_bytes_populated_total[5m])) / sum(rate(tag_bytes_transferred_total{direction="out"}[5m]))`
+  (bytes fetched into blocks ÷ bytes served). Aim for **≤ 1**; well above 1
+  means the block size is too large for the read pattern.
+- **Block hit ratio** —
+  `rate(tag_cache_block_hits_total[5m]) / (rate(tag_cache_block_hits_total[5m]) + rate(tag_cache_block_misses_total[5m]))`.
+- **Serve latency** —
+  `histogram_quantile(0.95, sum(rate(tag_request_duration_seconds_bucket[5m])) by (le))`.
 
 ## TLS
 

--- a/docs/acceleration-gateway/docker.md
+++ b/docs/acceleration-gateway/docker.md
@@ -79,7 +79,7 @@ specific release by setting `TAG_VERSION`:
 ```bash
 AWS_ACCESS_KEY_ID=your_access_key
 AWS_SECRET_ACCESS_KEY=your_secret_key
-TAG_VERSION=v1.14.0
+TAG_VERSION=v1.17.0
 TAG_LOG_LEVEL=info
 ```
 

--- a/docs/acceleration-gateway/kubernetes.md
+++ b/docs/acceleration-gateway/kubernetes.md
@@ -79,7 +79,7 @@ resources:
   - ../../base
 images:
   - name: tigrisdata/tag
-    newTag: v1.14.0
+    newTag: v1.17.0
 ```
 
 ## Production considerations

--- a/docs/acceleration-gateway/quickstart.mdx
+++ b/docs/acceleration-gateway/quickstart.mdx
@@ -38,7 +38,7 @@ tag --config /etc/tag/config.yaml
 The install script auto-detects your OS (Linux/macOS) and architecture
 (amd64/arm64), places the binary in `/usr/local/bin`, and installs a default
 config at `/etc/tag/config.yaml`. To pin a specific release, use
-`https://tag-releases.t3.storage.dev/v1.14.0/install.sh`.
+`https://tag-releases.t3.storage.dev/v1.17.0/install.sh`.
 
 </TabItem>
 <TabItem value="docker" label="Docker">

--- a/docs/acceleration-gateway/tls.md
+++ b/docs/acceleration-gateway/tls.md
@@ -63,7 +63,7 @@ variables:
 ```yaml
 services:
   tag:
-    image: tigrisdata/tag:v1.14.0
+    image: tigrisdata/tag:v1.17.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
Mirrors the in-repo docs update (tigrisdata/tag #144) for the **v1.17.0** release, where block-aligned caching became the **default at 1 MiB**.

## Config reference (`configuration.md`)
- Add **`TAG_CACHE_BLOCK_CACHING_ENABLED`** (default `true`) and **`TAG_CACHE_BLOCK_SIZE`** (default `1048576` / 1 MiB) to the env table and YAML reference.
- Update **`TAG_CACHE_MAX_POPULATE_MEMORY`** default **1 GiB → 2 GiB** (now one honest total shared by populate + block-serve staging).

## Deployment guide (`deployment-guide.md`)
- New **Block-aligned caching** section: default-on, the **`block_size` sizing rule** (match your workload's read granularity — an oversized block over-fetches and can be worse than whole-object caching), and the Prometheus queries to verify.
- Uses the correct upstream-amplification metric: `tag_cache_block_bytes_populated_total / tag_bytes_transferred_total{direction="out"}` (not `direction="in"`, which counts client uploads).

## Version pins
- Bump `v1.14.0 → v1.17.0` in the kubernetes/tls/docker examples and the quickstart install command (they were three releases behind).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code; risk is limited to doc accuracy and example version pins.
> 
> **Overview**
> Updates Acceleration Gateway docs for **v1.17.0**, where block-aligned caching is **default-on** at **1 MiB** (`block_caching_enabled: true`, `block_size: 1048576`).
> 
> **Configuration** documents `TAG_CACHE_BLOCK_CACHING_ENABLED`, `TAG_CACHE_BLOCK_SIZE`, and bumps **`TAG_CACHE_MAX_POPULATE_MEMORY`** default from 1 GiB to **2 GiB** (shared populate + block-serve staging).
> 
> **Architecture** reframes range handling: default **block caching** (aligned block GETs, partial serve) vs optional **whole-object** background fetch when block caching is disabled.
> 
> **Deployment guide** adds a **Block-aligned caching** section with `block_size` sizing guidance and Prometheus checks for upstream read amplification, block hit ratio, and latency.
> 
> Example **version pins** move from `v1.14.0` to **`v1.17.0`** (Docker, Kubernetes, TLS, quickstart install URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b31d05410ce26c5ccd1427bae546a9af9b1ccde0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->